### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-
+node_modules/


### PR DESCRIPTION
Adds node_modules/ to .gitignore — it was missing, causing untracked file warnings.