### PR TITLE
Extract determineTierFromProduct and require merge confirmation in review-pr

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -16,7 +16,8 @@ Review the Pull Request on the current branch, fix any issues found, merge it, a
    - Commit the fixes with a clear message describing what was fixed and why.
    - Push the fixes with `git push -u origin HEAD`.
 6. Output a summary of findings: what was found, what was fixed, and what was left as-is.
-7. Merge the PR with `gh pr merge --squash --delete-branch`.
-8. Confirm the merge succeeded and the remote branch was deleted.
+7. **Ask the user for confirmation before merging.** Present the summary and wait for explicit approval.
+8. If approved, merge the PR with `gh pr merge --squash --delete-branch`.
+9. Confirm the merge succeeded and the remote branch was deleted.
 
 Fix real problems, not style preferences. When in doubt, leave it alone and mention it in the summary.

--- a/server/webhookHandlers.test.ts
+++ b/server/webhookHandlers.test.ts
@@ -24,10 +24,49 @@ vi.mock("./services/logger", () => ({
   },
 }));
 
-import { WebhookHandlers } from "./webhookHandlers";
+import { WebhookHandlers, determineTierFromProduct } from "./webhookHandlers";
 import { authStorage } from "./replit_integrations/auth/storage";
 
 const mockAuthStorage = vi.mocked(authStorage);
+
+describe("determineTierFromProduct", () => {
+  it("returns tier from explicit metadata.tier", () => {
+    expect(determineTierFromProduct({ metadata: { tier: "pro" }, name: "Anything" })).toBe("pro");
+  });
+
+  it("returns tier from metadata even if name suggests a different tier", () => {
+    expect(determineTierFromProduct({ metadata: { tier: "pro" }, name: "Power Plan" })).toBe("pro");
+  });
+
+  it("returns 'power' when name contains 'power' (no metadata)", () => {
+    expect(determineTierFromProduct({ metadata: {}, name: "Power User Subscription" })).toBe("power");
+  });
+
+  it("returns 'pro' when name contains 'pro' (no metadata)", () => {
+    expect(determineTierFromProduct({ metadata: {}, name: "Pro Plan Monthly" })).toBe("pro");
+  });
+
+  it("returns 'power' over 'pro' when name contains both", () => {
+    expect(determineTierFromProduct({ metadata: {}, name: "Professional Power Bundle" })).toBe("power");
+  });
+
+  it("returns 'free' when name matches nothing", () => {
+    expect(determineTierFromProduct({ metadata: {}, name: "Basic Plan" })).toBe("free");
+  });
+
+  it("returns 'free' when name is undefined", () => {
+    expect(determineTierFromProduct({ metadata: {} })).toBe("free");
+  });
+
+  it("returns 'free' when metadata is undefined and name matches nothing", () => {
+    expect(determineTierFromProduct({ name: "Starter" })).toBe("free");
+  });
+
+  it("is case-insensitive for name matching", () => {
+    expect(determineTierFromProduct({ metadata: {}, name: "PRO PLAN" })).toBe("pro");
+    expect(determineTierFromProduct({ metadata: {}, name: "POWER PLAN" })).toBe("power");
+  });
+});
 
 describe("WebhookHandlers.processWebhook", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Extracts the Stripe product-to-tier determination logic from `handleSubscriptionChange` into a standalone, exported `determineTierFromProduct()` function so it can be unit tested independently. Also updates the `/review-pr` Claude command to require explicit user confirmation before merging.

## Changes

**Webhook handlers (`server/webhookHandlers.ts`)**
- Extract `determineTierFromProduct(product)` as a named export
- Priority: `metadata.tier` > name containing "power" > name containing "pro" > default "free"
- Replace inline tier logic in `handleSubscriptionChange` with a call to the new function
- No behavioral change — same logic, just independently testable

**Tests (`server/webhookHandlers.test.ts`)**
- Add 9 unit tests for `determineTierFromProduct` covering metadata override, name matching priority, case insensitivity, and fallback to "free"

**Review-PR command (`.claude/commands/review-pr.md`)**
- Add confirmation step before merging — merge now requires explicit user approval

## How to test

1. Run `npx vitest run` — all tests should pass (9 new + existing)
2. Verify `determineTierFromProduct` tests cover the priority chain
3. Read `.claude/commands/review-pr.md` and confirm merge requires user confirmation

https://claude.ai/code/session_01EpEAoqbbJejHTqtmm88qcf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for subscription tier detection across various product configurations.

* **Refactor**
  * Extracted and centralized subscription tier determination logic for improved maintainability.

* **Chores**
  * Updated development workflow to require explicit user confirmation before finalizing merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->