### PR TITLE
Update /review-pr to include CodeRabbit feedback step

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,4 +1,4 @@
-Review the Pull Request on the current branch, fix any issues found, merge it, and clean up the branch.
+Reviews the PR for bugs/security/architecture, fixes issues found, reads feedback from CodeRabbit and fix the issues, runs tests, merges via squash, and deletes the merged branch.
 
 ## Instructions
 
@@ -9,15 +9,20 @@ Review the Pull Request on the current branch, fix any issues found, merge it, a
    - **Security**: Injection, auth issues, data exposure, input validation gaps
    - **Architecture**: Separation of concerns, coupling, consistency with existing patterns
 4. Rate each finding as **critical**, **warning**, or **nit**.
-5. If any **critical** or **warning** issues are found:
+5. Read CodeRabbit feedback on the PR:
+   - Run `gh pr view --comments --json comments` to get all PR comments.
+   - Run `gh api repos/{owner}/{repo}/pulls/{number}/reviews` to get review comments.
+   - Run `gh api repos/{owner}/{repo}/pulls/{number}/comments` to get inline review comments.
+   - Evaluate each CodeRabbit suggestion and fix any that are valid.
+6. If any **critical** or **warning** issues are found (from your review or CodeRabbit):
    - Fix each issue directly in the source code.
    - Run `npx vitest run` to verify nothing is broken.
    - If tests fail, fix them and re-run until all tests pass.
    - Commit the fixes with a clear message describing what was fixed and why.
    - Push the fixes with `git push -u origin HEAD`.
-6. Output a summary of findings: what was found, what was fixed, and what was left as-is.
-7. **Ask the user for confirmation before merging.** Present the summary and wait for explicit approval.
-8. If approved, merge the PR with `gh pr merge --squash --delete-branch`.
-9. Confirm the merge succeeded and the remote branch was deleted.
+7. Output a summary of findings: what was found, what was fixed, and what was left as-is.
+8. **Ask the user for confirmation before merging.** Present the summary and wait for explicit approval.
+9. If approved, merge the PR with `gh pr merge --squash --delete-branch`.
+10. Confirm the merge succeeded and the remote branch was deleted.
 
 Fix real problems, not style preferences. When in doubt, leave it alone and mention it in the summary.


### PR DESCRIPTION
## Summary

Updates the `/review-pr` slash command to include a dedicated step for reading and addressing CodeRabbit feedback from PR comments and inline reviews before proceeding to fixes and merge.

## Changes

- Added step 5: Read CodeRabbit feedback via `gh pr view --comments`, `gh api` for reviews and inline comments
- Evaluate each CodeRabbit suggestion and fix valid ones
- Updated description to reflect full workflow

https://claude.ai/code/session_01Sr1yC9rDSSb8c2vWnSudNw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR review workflow documentation to include enhanced feedback collection and evaluation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->