### PR TITLE
Fix review-pr and create-pr agent command implementations

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -13,7 +13,7 @@ Create a GitHub Pull Request for the current branch with a generated title and d
    - **Changes**: Bulleted list of the key changes, grouped by area
    - **How to test**: Step-by-step instructions for verifying the changes
 6. Push the current branch with `git push -u origin HEAD`.
-7. Create the PR with `gh pr create --title "<title>" --body "<description>"` targeting `main`.
+7. Create the PR with `gh pr create --title "<title>" --body "<description>" --base main`.
 8. Output the PR URL and the generated title and description for review.
 
 Write the PR description for a reviewer who has no context. Be specific, not vague.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,4 +1,4 @@
-Reviews the PR for bugs/security/architecture, fixes issues found, reads feedback from CodeRabbit and fix the issues, runs tests, merges via squash, and deletes the merged branch.
+Review the PR for bugs/security/architecture, fix issues found, read feedback from CodeRabbit and fix the issues, run tests, merge via squash, and delete the merged branch.
 
 ## Instructions
 
@@ -10,9 +10,11 @@ Reviews the PR for bugs/security/architecture, fixes issues found, reads feedbac
    - **Architecture**: Separation of concerns, coupling, consistency with existing patterns
 4. Rate each finding as **critical**, **warning**, or **nit**.
 5. Read CodeRabbit feedback on the PR:
-   - Run `gh pr view --comments --json comments` to get all PR comments.
-   - Run `gh api repos/{owner}/{repo}/pulls/{number}/reviews` to get review comments.
-   - Run `gh api repos/{owner}/{repo}/pulls/{number}/comments` to get inline review comments.
+   - Run `gh pr view --json number -q .number` to get the current PR number.
+   - Run `gh repo view --json nameWithOwner -q .nameWithOwner` to get the repo identifier (e.g., `owner/repo`).
+   - Run `gh pr view --json comments` to get all PR comments.
+   - Run `gh api repos/{owner}/{repo}/pulls/{number}/reviews` to get review comments (substitute the actual owner/repo and number from above).
+   - Run `gh api repos/{owner}/{repo}/pulls/{number}/comments` to get inline review comments (substitute the actual values).
    - Evaluate each CodeRabbit suggestion and fix any that are valid.
 6. If any **critical** or **warning** issues are found (from your review or CodeRabbit):
    - Fix each issue directly in the source code.


### PR DESCRIPTION
## Summary

The `/review-pr` and `/create-pr` slash commands had implementation gaps that would cause them to fail or behave incorrectly when invoked. This PR fixes unresolved placeholders in `gh api` calls, a redundant CLI flag, an inconsistent description voice, and a missing `--base` flag.

## Changes

**`.claude/commands/review-pr.md`**
- Add explicit steps to resolve `{owner}/{repo}` and `{number}` placeholders before they are used in `gh api` calls (`gh pr view --json number` and `gh repo view --json nameWithOwner`)
- Remove redundant `--comments` flag from `gh pr view --json comments` (the `--json` flag already controls output format)
- Fix first line from descriptive voice ("Reviews the PR...") to imperative voice ("Review the PR...") for consistency with all other commands

**`.claude/commands/create-pr.md`**
- Add `--base main` flag to the `gh pr create` command, which the prose already described as "targeting `main`" but the command itself was missing

## How to test

1. Open `.claude/commands/review-pr.md` and verify:
   - Step 5 now includes sub-steps to get the PR number and repo name before the `gh api` calls
   - The `gh pr view` call uses `--json comments` without the redundant `--comments` flag
   - The first line uses imperative voice ("Review the PR...")
2. Open `.claude/commands/create-pr.md` and verify:
   - Step 7 includes `--base main` in the `gh pr create` command
3. Invoke `/review-pr` or `/create-pr` on a test branch to confirm the commands execute correctly

https://claude.ai/code/session_01XUp7qExPtqDkD8H3wBjZC8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * PR creation commands now explicitly target the main branch by default.
  * PR review instructions refined with improved guidance for retrieving and processing feedback, including explicit substitution steps for repository details.
  * Added post-review testing and validation steps to streamline the merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->