### PR TITLE
Remove refunds FAQ and add Support link to dashboard nav

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -123,7 +123,7 @@ export default function Dashboard() {
             <Button variant="ghost" size="sm" asChild className="text-muted-foreground" data-testid="link-support">
               <Link href="/support">
                 <HelpCircle className="h-4 w-4 mr-2" />
-                <span className="hidden sm:inline">Support</span>
+                <span className="sr-only sm:not-sr-only">Support</span>
               </Link>
             </Button>
             <NotificationEmailDialog

--- a/client/src/pages/Support.tsx
+++ b/client/src/pages/Support.tsx
@@ -111,7 +111,7 @@ const faqSections: FAQSection[] = [
         answer:
           "Yes. You can manage your subscription through the Stripe billing portal, accessible from your dashboard. Changes and cancellations take effect at the end of the current billing period.",
       },
-{
+      {
         question: "What happens to my monitors if I downgrade?",
         answer:
           "Your existing monitors will continue to work, but you won't be able to create new ones if you exceed the lower plan's limit. You'll need to delete monitors to get below the new limit before creating new ones.",


### PR DESCRIPTION
## Summary
- Removed the "Do you offer refunds?" FAQ entry from the support page
- Added a Support link (with HelpCircle icon) to the authenticated dashboard header so logged-in users can navigate to /support

## Test plan
- [x] All 253 existing tests pass
- [ ] Verify support page no longer shows refunds FAQ
- [ ] Verify dashboard nav shows Support link when logged in

https://claude.ai/code/session_018JZC726xcbJfpSbwmPJqnN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Support button to the dashboard header for quick access to support resources and assistance.

* **Documentation**
  * Updated the Support page FAQ by removing the refund policy and the 14-day money-back guarantee entry under Account & Billing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->