### PR TITLE
Make PublicNav auth-aware to prevent sign-out appearance

### DIFF
--- a/client/src/components/PublicNav.tsx
+++ b/client/src/components/PublicNav.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { Link, useLocation } from "wouter";
+import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import { Zap, Menu, X } from "lucide-react";
+import { Zap, Menu } from "lucide-react";
 
 const navLinks = [
   { label: "How it works", href: "/#how-it-works" },
@@ -15,6 +16,7 @@ const navLinks = [
 export default function PublicNav() {
   const [open, setOpen] = useState(false);
   const [location] = useLocation();
+  const { user } = useAuth();
 
   const handleNavClick = (href: string) => {
     setOpen(false);
@@ -54,9 +56,15 @@ export default function PublicNav() {
               {link.label}
             </a>
           ))}
-          <Button asChild data-testid="button-nav-signin">
-            <a href="/api/login">Sign in</a>
-          </Button>
+          {user ? (
+            <Button asChild data-testid="button-nav-dashboard">
+              <Link href="/dashboard">Dashboard</Link>
+            </Button>
+          ) : (
+            <Button asChild data-testid="button-nav-signin">
+              <a href="/api/login">Sign in</a>
+            </Button>
+          )}
         </div>
 
         <div className="md:hidden">
@@ -98,9 +106,15 @@ export default function PublicNav() {
                   ))}
                 </div>
                 
-                <Button asChild className="mt-4" data-testid="button-nav-signin-mobile">
-                  <a href="/api/login">Sign in</a>
-                </Button>
+                {user ? (
+                  <Button asChild className="mt-4" data-testid="button-nav-dashboard-mobile">
+                    <Link href="/dashboard" onClick={() => setOpen(false)}>Dashboard</Link>
+                  </Button>
+                ) : (
+                  <Button asChild className="mt-4" data-testid="button-nav-signin-mobile">
+                    <a href="/api/login">Sign in</a>
+                  </Button>
+                )}
               </div>
             </SheetContent>
           </Sheet>


### PR DESCRIPTION
## Summary
- PublicNav always showed "Sign in" even for authenticated users, so navigating to /support (or /pricing, /blog) from the dashboard made it look like the user got signed out
- Now checks auth state and shows "Dashboard" button when signed in, "Sign in" when not
- Applies to both desktop and mobile nav

## Test plan
- [x] All 253 tests pass
- [ ] Sign in, click Support in dashboard nav, verify nav shows "Dashboard" button (not "Sign in")
- [ ] Sign out, visit /support, verify nav shows "Sign in" button

https://claude.ai/code/session_018JZC726xcbJfpSbwmPJqnN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication-aware navigation bar. The navigation now intelligently adapts based on user login status. Logged-in users see a Dashboard button linking to their account area, while unauthenticated users see the Sign in button. This responsive behavior is implemented consistently across both desktop and mobile navigation menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->