### PR TITLE
Show dashboard nav on Support page for authenticated users

### DIFF
--- a/client/src/components/DashboardNav.tsx
+++ b/client/src/components/DashboardNav.tsx
@@ -1,0 +1,53 @@
+import { useAuth } from "@/hooks/use-auth";
+import { NotificationEmailDialog } from "@/components/NotificationEmailDialog";
+import { Button } from "@/components/ui/button";
+import { LogOut, LayoutDashboard, FileWarning, HelpCircle } from "lucide-react";
+import { Link } from "wouter";
+
+export default function DashboardNav() {
+  const { user, logout } = useAuth();
+
+  if (!user) return null;
+
+  return (
+    <header className="border-b bg-card/50 backdrop-blur-md sticky top-0 z-10">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Link href="/dashboard" className="flex items-center gap-2">
+            <LayoutDashboard className="h-6 w-6 text-primary" />
+            <h1 className="text-xl font-display font-bold">FetchTheChange</h1>
+          </Link>
+          <span className="hidden md:inline text-sm text-muted-foreground">- Reliable change monitoring for the modern web</span>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <div className="hidden sm:block text-sm text-muted-foreground">
+            Welcome, <span className="font-medium text-foreground">{user?.firstName || user?.email}</span>
+          </div>
+          {((user as any)?.tier === "power") && (
+            <Button variant="ghost" size="sm" asChild className="text-muted-foreground" data-testid="link-error-logs">
+              <Link href="/admin/errors">
+                <FileWarning className="h-4 w-4 mr-2" />
+                <span className="hidden sm:inline">Event Log</span>
+              </Link>
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" asChild className="text-muted-foreground" data-testid="link-support">
+            <Link href="/support">
+              <HelpCircle className="h-4 w-4 mr-2" />
+              <span className="sr-only sm:not-sr-only">Support</span>
+            </Link>
+          </Button>
+          <NotificationEmailDialog
+            currentNotificationEmail={(user as any)?.notificationEmail}
+            accountEmail={user?.email}
+          />
+          <Button variant="ghost" size="sm" onClick={() => logout()} className="text-muted-foreground hover:text-destructive">
+            <LogOut className="h-4 w-4 mr-2" />
+            Sign Out
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -3,12 +3,11 @@ import { useMonitors, useCheckMonitor } from "@/hooks/use-monitors";
 import { CreateMonitorDialog } from "@/components/CreateMonitorDialog";
 import { MonitorCard } from "@/components/MonitorCard";
 import { UpgradeDialog } from "@/components/UpgradeDialog";
-import { NotificationEmailDialog } from "@/components/NotificationEmailDialog";
+import DashboardNav from "@/components/DashboardNav";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { LogOut, LayoutDashboard, RefreshCw, Loader2, Sparkles, FileWarning, HelpCircle } from "lucide-react";
-import { Link } from "wouter";
+import { LayoutDashboard, RefreshCw, Loader2, Sparkles } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { TIER_LIMITS, type UserTier } from "@shared/models/auth";
 import { useEffect } from "react";
@@ -99,44 +98,7 @@ export default function Dashboard() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-card/50 backdrop-blur-md sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <LayoutDashboard className="h-6 w-6 text-primary" />
-            <h1 className="text-xl font-display font-bold">FetchTheChange</h1>
-            <span className="hidden md:inline text-sm text-muted-foreground">- Reliable change monitoring for the modern web</span>
-          </div>
-          
-          <div className="flex items-center gap-4">
-            <div className="hidden sm:block text-sm text-muted-foreground">
-              Welcome, <span className="font-medium text-foreground">{user?.firstName || user?.email}</span>
-            </div>
-            {((user as any)?.tier === "power") && (
-              <Button variant="ghost" size="sm" asChild className="text-muted-foreground" data-testid="link-error-logs">
-                <Link href="/admin/errors">
-                  <FileWarning className="h-4 w-4 mr-2" />
-                  <span className="hidden sm:inline">Event Log</span>
-                </Link>
-              </Button>
-            )}
-            <Button variant="ghost" size="sm" asChild className="text-muted-foreground" data-testid="link-support">
-              <Link href="/support">
-                <HelpCircle className="h-4 w-4 mr-2" />
-                <span className="sr-only sm:not-sr-only">Support</span>
-              </Link>
-            </Button>
-            <NotificationEmailDialog
-              currentNotificationEmail={(user as any)?.notificationEmail}
-              accountEmail={user?.email}
-            />
-            <Button variant="ghost" size="sm" onClick={() => logout()} className="text-muted-foreground hover:text-destructive">
-              <LogOut className="h-4 w-4 mr-2" />
-              Sign Out
-            </Button>
-          </div>
-        </div>
-      </header>
+      <DashboardNav />
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">

--- a/client/src/pages/Support.tsx
+++ b/client/src/pages/Support.tsx
@@ -7,6 +7,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { useAuth } from "@/hooks/use-auth";
 import { useToast } from "@/hooks/use-toast";
 import PublicNav from "@/components/PublicNav";
+import DashboardNav from "@/components/DashboardNav";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -377,7 +378,7 @@ export default function Support() {
   return (
     <div className="min-h-screen bg-background">
       <SEOHead />
-      <PublicNav />
+      {user ? <DashboardNav /> : <PublicNav />}
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 md:py-20">
         {/* Header */}


### PR DESCRIPTION
## Summary
- Extracted the dashboard header into a reusable `DashboardNav` component
- Support page now renders `DashboardNav` when logged in, `PublicNav` when not
- Dashboard page uses the same shared `DashboardNav` component (no duplication)

## Test plan
- [x] All 253 tests pass
- [ ] Sign in, click Support → see dashboard header (Welcome, Settings, Sign Out)
- [ ] Sign out, visit /support → see public nav (Sign in button)
- [ ] Dashboard still renders correctly with the extracted nav

https://claude.ai/code/session_018JZC726xcbJfpSbwmPJqnN