### PR TITLE
Improve monitor error messages with names and fix suggestions

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -226,7 +226,7 @@ export async function registerRoutes(
       let rendered: any = { used: false };
       if (process.env.BROWSERLESS_TOKEN) {
         try {
-          const result = await extractWithBrowserless(monitor.url, monitor.selector, monitor.id);
+          const result = await extractWithBrowserless(monitor.url, monitor.selector, monitor.id, monitor.name);
           rendered = {
             used: true,
             blocked: result.blocked,

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -141,7 +141,7 @@ export async function sendNotificationEmail(monitor: Monitor, oldValue: string |
     console.log(`[Email] Sent to ${recipientEmail} for monitor ${monitor.id}, id: ${response.data?.id}`);
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    await ErrorLogger.error("email", `Failed to send email for monitor ${monitor.id}`, error instanceof Error ? error : null, { monitorId: monitor.id });
+    await ErrorLogger.error("email", `"${monitor.name}" — notification email failed to send. Check that your email address is valid. If this keeps happening, contact support.`, error instanceof Error ? error : null, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url });
     return { success: false, error: error.message };
   }
 }

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -35,8 +35,9 @@ export async function startScheduler() {
 
         if (shouldCheck) {
           checkMonitor(monitor).catch(async (error) => {
-            await ErrorLogger.error("scheduler", `Monitor check failed for monitor ${monitor.id}`, error instanceof Error ? error : null, {
+            await ErrorLogger.error("scheduler", `"${monitor.name}" — scheduled check failed. This is usually a temporary issue. If it persists, verify the URL is still valid and the selector matches the page.`, error instanceof Error ? error : null, {
               monitorId: monitor.id,
+              monitorName: monitor.name,
               url: monitor.url,
               selector: monitor.selector,
             });


### PR DESCRIPTION
## Summary

Error messages in the admin Event Log displayed internal monitor IDs (e.g., `"Monitor check failed for monitor 5"`) which are meaningless to users since the GUI only shows monitor names. This PR replaces all 6 monitor ID references in `ErrorLogger` calls with the monitor's name, adds plain-language explanations of each failure, and suggests actionable fixes the user can try.

## Changes

### Error messages (`server/services/scraper.ts`)
- **Main catch-all** (`checkMonitor`): `"Monitor check failed for monitor 5"` → `"My Price Tracker" failed to check — the page could not be fetched or parsed. Verify the URL is accessible and the CSS selector is correct.`
- **Browserless fallback**: `"Browserless fallback failed"` → `"My Price Tracker" — rendered page extraction failed. The site may block automated browsers or the page took too long to load. Try simplifying the selector or check if the site requires login.`
- **Browserless extraction** (`extractWithBrowserless`): `"Browserless extraction failed"` → `"My Price Tracker" — browser-based extraction failed — the page may be unreachable or blocking automated access.`
- **Curl fetch** (`fetchWithCurl`): `"Fetch fallback failed"` → `"My Price Tracker" — page fetch with curl failed — the site returned an error or is blocking the request.`

### Error messages (`server/services/scheduler.ts`)
- `"Monitor check failed for monitor 5"` → `"My Price Tracker" — scheduled check failed. This is usually a temporary issue. If it persists, verify the URL is still valid and the selector matches the page.`

### Error messages (`server/services/email.ts`)
- `"Failed to send email for monitor 5"` → `"My Price Tracker" — notification email failed to send. Check that your email address is valid. If this keeps happening, contact support.`

### Plumbing
- Added optional `monitorName` parameter to `extractWithBrowserless()` and `fetchWithCurl()` in `server/services/scraper.ts`
- Updated all call sites in `scraper.ts` and `server/routes.ts` to pass `monitor.name`
- Added `monitorName` field to all error context objects so it appears in the expandable log detail

## How to test

1. Create a monitor with a known-bad selector (e.g., URL `https://example.com`, selector `.nonexistent-class`)
2. Click **Check Now** on the monitor detail page
3. Go to the admin **Event Log** page
4. Verify that error messages show the **monitor name** (not a number), include an explanation, and suggest a fix
5. Expand a log entry and confirm the JSON context includes `monitorName` alongside `monitorId`
6. `npm run check` passes (TypeScript), `npm test` passes (all 253 tests)

https://claude.ai/code/session_01S5uDXoYs7ozKQ22XsD2P2S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error logging throughout the monitoring system to include monitor-specific context, providing clearer and more descriptive messages when issues occur for improved troubleshooting and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->