### PR TITLE
Fix scraper test suite crash from missing db and email mocks

### DIFF
--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -11,6 +11,7 @@ vi.mock("../storage", () => ({
 
 vi.mock("./email", () => ({
   sendNotificationEmail: vi.fn().mockResolvedValue({ success: true }),
+  sendAutoPauseEmail: vi.fn().mockResolvedValue({ success: true }),
 }));
 
 vi.mock("./logger", () => ({
@@ -25,6 +26,14 @@ vi.mock("./browserlessTracker", () => ({
   BrowserlessUsageTracker: {
     canUseBrowserless: vi.fn().mockResolvedValue({ allowed: false, reason: "free_tier" }),
     recordUsage: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../db", () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue({}),
+    }),
   },
 }));
 


### PR DESCRIPTION
## Summary

The auto-pause feature (#28, commit f0446aa) added `import { db } from "../db"` and `sendAutoPauseEmail` to `server/services/scraper.ts`, but the corresponding test file was not updated with mocks for these new dependencies. Since `server/db.ts` throws immediately when `DATABASE_URL` is not set, the entire test suite (133 tests) fails to load in CI/test environments. Nine tests that exercise the retry and selector-missing paths were reported as timing out at 5s.

## Changes

- **`server/services/scraper.test.ts`**:
  - Added `vi.mock("../db")` with a stub for `db.insert().values()` to prevent the `DATABASE_URL` crash and satisfy `recordMetric()` calls introduced in #28
  - Added `sendAutoPauseEmail` to the existing `./email` mock to cover the new `handleMonitorFailure()` function introduced in #28

## How to test

1. Check out this branch
2. Run `npx vitest run server/services/scraper.test.ts --reporter=verbose`
3. Verify all 133 tests pass, including:
   - "returns selector_missing when selector matches nothing on an unblocked page"
   - "updates monitor with selector_missing when selector not found"
   - "retries static fetch when first attempt finds no value"
   - "retry path: updates block status when retry also detects blocked content"
   - "retry path: continues with original result when retry fetch throws"
   - "retry path: uses fetchWithCurl on UND_ERR_HEADERS_OVERFLOW during retry"
   - "retry path: empty retryHtml is ignored and falls through"
   - "preserves oldValue in return when status is not ok"
   - "retry succeeds on second static attempt when first had no value"

https://claude.ai/code/session_01MZHYeicrbupMDQUs14VtWa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with additional mocks for email and database functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->