### PR TITLE
Fix SSL security warnings by normalizing sslmode in DATABASE_URL

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -31,7 +31,7 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
 
   // Initialize Stripe schema and sync
   async function initStripe() {
-    const databaseUrl = process.env.DATABASE_URL;
+    const { databaseUrl } = await import("./db");
     if (!databaseUrl) {
       console.log('DATABASE_URL not set, skipping Stripe initialization');
       return;

--- a/server/replit_integrations/auth/replitAuth.ts
+++ b/server/replit_integrations/auth/replitAuth.ts
@@ -6,6 +6,7 @@ import session from "express-session";
 import type { Express, RequestHandler } from "express";
 import memoize from "memoizee";
 import connectPg from "connect-pg-simple";
+import { databaseUrl } from "../../db";
 import { authStorage } from "./storage";
 
 const getOidcConfig = memoize(
@@ -22,7 +23,7 @@ export function getSession() {
   const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 1 week
   const pgStore = connectPg(session);
   const sessionStore = new pgStore({
-    conString: process.env.DATABASE_URL,
+    conString: databaseUrl,
     createTableIfMissing: false,
     ttl: sessionTtl,
     tableName: "sessions",

--- a/server/stripeClient.ts
+++ b/server/stripeClient.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { databaseUrl } from './db';
 
 // Uses environment variables for Stripe API keys
 // Set STRIPE_SECRET_KEY and STRIPE_PUBLISHABLE_KEY in your secrets
@@ -71,7 +72,7 @@ export async function getStripeSync() {
 
     stripeSync = new StripeSync({
       poolConfig: {
-        connectionString: process.env.DATABASE_URL!,
+        connectionString: databaseUrl,
         max: 2,
       },
       stripeSecretKey: secretKey,


### PR DESCRIPTION
pg v8.16+ treats sslmode values 'prefer', 'require', and 'verify-ca' as aliases for 'verify-full' and emits security warnings on every connection. Normalize the DATABASE_URL to explicitly use sslmode=verify-full in all four connection sites (main pool, session store, Stripe migrations, and StripeSync pool) to silence the warnings while preserving identical security behaviour.

https://claude.ai/code/session_019RvCfN3P5ZUXcGokCJrG8L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database connection security with improved SSL verification configuration, addressing security warnings across all database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->