### PR TITLE
Fix deployment crash: add db:push to build step

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -39,8 +39,16 @@ async function buildAll() {
   // Apply database schema changes before building
   if (process.env.DATABASE_URL) {
     console.log("pushing database schema...");
-    execSync("npx drizzle-kit push", { stdio: "inherit" });
-    console.log("database schema up to date");
+    try {
+      execSync("npx drizzle-kit push", {
+        stdio: "inherit",
+        timeout: 300_000,
+      });
+      console.log("database schema up to date");
+    } catch (err) {
+      console.error("database schema push failed");
+      throw err;
+    }
   }
 
   console.log("building client...");


### PR DESCRIPTION
## Summary
- The deployment was crash-looping because `consecutive_failures` and `pause_reason` columns exist in the Drizzle schema but were never applied to the actual database
- Added `drizzle-kit push` to `script/build.ts` so schema changes are applied during the Replit deployment build step, before the app starts
- Only runs when `DATABASE_URL` is set (i.e., in deployed environments)

## Root cause
PR #31 added new columns to `shared/schema.ts` but the build pipeline never ran `drizzle-kit push` to sync those columns to PostgreSQL. The app then crashed on startup trying to SELECT non-existent columns.

## Test plan
- [ ] Redeploy — the build step should now print "pushing database schema..." and apply the missing columns
- [ ] Verify the app starts without crash-looping
- [ ] Verify monitors page loads and auto-pause feature works

https://claude.ai/code/session_014b6KWcMRQgcnejbFNo4gru

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now performs an automatic database schema synchronization (when database is configured) before client packaging; includes status logging and failure handling—no change for setups without a database.
* **Tests**
  * Added comprehensive tests covering the conditional schema sync, task ordering, cleanup behavior, status logging, and failure handling to improve build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->