### PR TITLE
Streamline docs: deduplicate CLAUDE.md, README.md, replit.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,11 @@
 # CLAUDE.md — FetchTheChange
 
-## Project Overview
-FetchTheChange is a website change monitoring SaaS. Users create monitors that track CSS-selected elements on web pages and receive email notifications when values change. Built with React + Express + PostgreSQL (Drizzle ORM).
+See `README.md` for project overview, tech stack, structure, and setup.
 
-## Project Structure
-- `shared/` — Shared types, schemas, and constants used by both client and server
+## Key Files
 - `shared/models/auth.ts` — Tier configuration constants (`TIER_LIMITS`, `BROWSERLESS_CAPS`, `PAUSE_THRESHOLDS`, `RESEND_CAPS`), user table schema
 - `shared/schema.ts` — Database table definitions (monitors, monitorChanges, etc.)
 - `shared/routes.ts` — Zod validation schemas for API routes
-- `server/` — Express backend (routes, services, webhook handlers)
-- `client/src/` — React frontend (pages, components, hooks)
-- `client/src/pages/` — Page components (Dashboard, Pricing, LandingPage, Support, Blog*)
-- `client/src/components/` — Reusable UI components (shadcn/ui based)
 
 ## Conventions
 - **Shared types**: All types shared between client and server live in `shared/`. Import with `@shared/` alias.
@@ -35,6 +29,3 @@ FetchTheChange is a website change monitoring SaaS. Users create monitors that t
 - CodeRabbit auto-reviews all PRs (configured in `.coderabbit.yaml`).
 - PR titles should be concise (<70 chars); use the body for details.
 - Run `npm run check && npm run test` before pushing.
-
-## Specs
-- `update-free-tier-monitors` — Increase free tier from 1 to 3 monitors: `.claude/specs/update-free-tier-monitors.md`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ npm run start
 | JS rendering | No | 200 checks/month | 500 checks/month |
 | Email notifications | 1 per day per monitor | Unlimited | Unlimited |
 
+## Web Scraping
+
+The scraping service uses two methods depending on page complexity:
+
+- **Static HTML** — Cheerio parses server-rendered pages directly (fast, no browser needed)
+- **JS-rendered pages** — Browserless (headless Chrome via Playwright) handles SPAs and dynamic content
+
+Additional capabilities:
+- **Anti-bot bypass** — Detects and handles Cloudflare challenges
+- **Cookie consent** — Dismisses consent dialogs (e.g., OneTrust) before scraping
+- **Change detection statuses** — Each check records a status: `ok`, `blocked`, `selector_missing`, or `error`
+- **Safe value preservation** — Failed checks preserve the existing `currentValue` to prevent false change notifications
+
+## Security
+
+- SSRF protection on user-supplied URLs
+- CORS configuration for API endpoints
+- Session fixation prevention
+- Log sanitization (no PII or secrets in logs)
+
 ## License
 
 This project is licensed under the [GNU Affero General Public License v3.0](LICENSE).

--- a/replit.md
+++ b/replit.md
@@ -1,59 +1,7 @@
-# FetchTheChange - Web Monitor Application
+# FetchTheChange
 
-## Overview
-
-FetchTheChange is a web monitoring application designed to track and notify users about changes on specific elements of any webpage. It enables users to define monitors for CSS selectors, receive email notifications upon content alteration, and access a detailed history of changes. The application incorporates advanced features to bypass anti-bot measures, manage cookie consent banners, and process JavaScript-rendered content using headless browser technology.
+See `README.md` for project overview, tech stack, structure, and setup.
 
 ## User Preferences
 
 Preferred communication style: Simple, everyday language.
-
-## System Architecture
-
-### Frontend
-- **Framework**: React 18 with TypeScript
-- **UI**: shadcn/ui, Tailwind CSS (dark mode default)
-- **State Management**: TanStack React Query
-
-### Backend
-- **Runtime**: Node.js with Express, TypeScript
-- **Authentication**: Replit Auth with OpenID Connect
-- **Scheduling**: `node-cron` for monitor checks
-
-### Web Scraping Service
-- **Core Functionality**: Monitors webpage elements for changes.
-- **Methods**: Cheerio for static HTML, Browserless (headless Chrome) for JavaScript-rendered pages.
-- **Anti-Bot & Consent**: Detects and bypasses anti-bot challenges (e.g., Cloudflare) and cookie consent dialogs (e.g., OneTrust).
-- **Change Detection**: Tracks status (ok, blocked, selector_missing, error) and preserves `currentValue` on failed checks to prevent false notifications.
-
-### Data Storage
-- **Database**: PostgreSQL via Drizzle ORM
-- **Key Tables**: `users`, `sessions`, `monitors`, `monitor_changes`
-
-### Features
-- **Fix Selector Tool**: UI tool assists users in finding and validating CSS selectors.
-- **Tier System**: Limits monitors based on subscription tiers (Free, Pro, Power).
-- **Stripe Integration**: Handles subscription payments and tier management.
-- **Email Notifications**: Utilizes Resend API for sending change notifications, supporting custom notification emails.
-- **Rate Limiting**: Tiered rate limiting on API endpoints to manage resource usage.
-- **Event Log System**: Internal logging for errors and critical events with admin dashboard.
-- **Usage Tracking**: Monitors Browserless and Resend API usage against caps to control costs.
-- **Security Hardening**: Includes SSRF protection, CORS configuration, session fixation prevention, and log sanitization.
-
-## External Dependencies
-
-- **Required Environment Variables**: `DATABASE_URL`, `SESSION_SECRET`, `ISSUER_URL`, `REPL_ID`
-- **Optional Environment Variables**: `RESEND_API_KEY`, `RESEND_FROM`, `BROWSERLESS_TOKEN`
-
-### Third-Party Services
-- **Replit Auth**: User authentication
-- **Resend**: Transactional email delivery
-- **Browserless.io**: Headless Chrome as a service
-
-### Key NPM Dependencies
-- `drizzle-orm`: Database ORM
-- `cheerio`: HTML parsing
-- `playwright-core`: Browser automation
-- `resend`: Email API client
-- `node-cron`: Scheduler
-- `passport`, `openid-client`: Authentication


### PR DESCRIPTION
## Summary
- **README.md**: Added Web Scraping and Security sections (promoted from replit.md)
- **CLAUDE.md**: Removed duplicated overview/structure, trimmed to key files + conventions only, removed stale Specs section
- **replit.md**: Replaced with lean pointer to README.md + User Preferences (59 → 7 lines)

No code changes — documentation only. All 472 tests pass.

https://claude.ai/code/session_013AgN5mVgVBFseFbEvrmrG4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured development documentation for improved clarity and organization
  * Added Web Scraping guidance with methods for static HTML and JavaScript-rendered pages
  * Added Security documentation covering protection mechanisms and best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->