### PR TITLE
Add automated release tracking

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,79 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - feature
+  patch:
+    labels:
+      - fix
+      - chore
+      - docs
+      - security
+  default: patch
+
+categories:
+  - title: "Breaking Changes"
+    labels:
+      - breaking
+  - title: "Features"
+    labels:
+      - feature
+  - title: "Bug Fixes"
+    labels:
+      - fix
+  - title: "Security"
+    labels:
+      - security
+  - title: "Maintenance"
+    labels:
+      - chore
+      - docs
+
+autolabeler:
+  - label: feature
+    title:
+      - '/^Add\b/i'
+      - '/^Implement\b/i'
+      - '/^Create\b/i'
+      - '/^Introduce\b/i'
+      - '/\bfeat\b/i'
+  - label: fix
+    title:
+      - '/^Fix\b/i'
+      - '/^Resolve\b/i'
+      - '/^Patch\b/i'
+      - '/\bbug\b/i'
+  - label: breaking
+    title:
+      - '/\bbreaking\b/i'
+      - '/^Remove\b/i'
+  - label: chore
+    title:
+      - '/^Refactor\b/i'
+      - '/^Update\b/i'
+      - '/^Upgrade\b/i'
+      - '/^Clean\b/i'
+      - '/^Bump\b/i'
+      - '/\bchore\b/i'
+  - label: docs
+    title:
+      - '/\bdocs\b/i'
+      - '/\breadme\b/i'
+      - '/\bdocumentation\b/i'
+  - label: security
+    title:
+      - '/\bsecurity\b/i'
+      - '/\bvuln\b/i'
+      - '/\bCVE\b/i'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/bd73-com/fetchthechange/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,19 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          publish: true
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ See `README.md` for project overview, tech stack, structure, and setup.
 - **API patterns**: Express routes in `server/routes.ts`. JSON responses with `{ message, code }` for errors.
 - **Authentication**: Replit Auth with OpenID Connect via Passport.
 - **Database**: PostgreSQL with Drizzle ORM. Schema in `shared/schema.ts` and `shared/models/auth.ts`.
+- **Release labels**: PRs should carry one of: `feature`, `fix`, `breaking`, `chore`, `docs`, `security`. Auto-applied from PR title by release-drafter, but verify before merging.
 
 ## Verification
 - `npm run check` — TypeScript type checking (tsc)


### PR DESCRIPTION
## Summary
- Add release-drafter config (`.github/release-drafter.yml`) with version resolver (major/minor/patch by label), categorized release notes, and autolabeler rules based on PR title patterns
- Add workflow (`.github/workflows/release.yml`) to publish a release on every push to `main`
- Add workflow (`.github/workflows/label-prs.yml`) to auto-label PRs when opened/edited
- Update `CLAUDE.md` with release labels convention

## Test plan
- [ ] Verify label-prs workflow triggers on PR open and applies correct labels based on title
- [ ] Verify release workflow triggers on push to main and creates a draft/published release
- [ ] Confirm version resolver increments correctly for major/minor/patch labels
- [ ] Check autolabeler matches expected PR title patterns (e.g. "Add ...", "Fix ...", "Refactor ...")

https://claude.ai/code/session_01LMavBCnF5MqHwnLvKMQNiA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated pull request labeling system that categorizes contributions by type, including features, bug fixes, breaking changes, security updates, and maintenance work.
  * Added GitHub Actions workflows to automatically generate and update release drafts based on pull request activity.
  * Updated documentation to describe the new release labeling conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->