### PR TITLE
Fix empty Releases section by labeling PRs and adding workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Retroactively labeled all 65 merged PRs with the correct release category labels (`feature`, `fix`, `security`, `docs`, `breaking`, `chore`) based on the autolabeler rules in `release-drafter.yml`
- Added `workflow_dispatch` trigger to the release drafter workflow so it can be manually re-triggered when needed

## Root cause
PR #65 introduced release-drafter with an autolabeler, but the autolabeler only applies to PRs when they are opened/edited — it doesn't retroactively label previously-merged PRs. Since all 65 existing PRs had no labels, release-drafter couldn't categorize any of them into the defined sections (Features, Bug Fixes, Security, Maintenance), leaving those sections empty.

## What was done
1. Applied labels to all 65 merged PRs matching the autolabeler patterns
2. Deleted the uncategorized v0.1.0 and empty v0.1.1 releases
3. Added `workflow_dispatch` to the release workflow for manual re-triggers

## Test plan
- [ ] Merge this PR to main (triggers release-drafter via push event)
- [ ] Verify the new v0.1.0 release has categorized sections (Features, Bug Fixes, Security, etc.)
- [ ] Verify the `workflow_dispatch` trigger works via Actions > Release Drafter > Run workflow

https://claude.ai/code/session_018nEBSoNxCFfgBAirQiqajo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process configuration to support manual triggering alongside automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->