### PR TITLE
fix: skip notification cron when tables are not migrated

### DIFF
--- a/server/services/notification.ts
+++ b/server/services/notification.ts
@@ -150,7 +150,12 @@ export async function processChangeNotification(
     return null;
   }
 
-  const prefs = await storage.getNotificationPreferences(monitor.id);
+  let prefs: NotificationPreference | undefined;
+  try {
+    prefs = await storage.getNotificationPreferences(monitor.id);
+  } catch {
+    // Notification tables may not be migrated yet — fall through to send immediate email
+  }
 
   if (!prefs) {
     return await sendNotificationEmail(monitor, change.oldValue, change.newValue);

--- a/server/services/scheduler.test.ts
+++ b/server/services/scheduler.test.ts
@@ -454,10 +454,10 @@ describe("daily metrics cleanup", () => {
   });
 
   it("executes DELETE for old metrics and logs when rows are deleted", async () => {
-    mockDbExecute.mockResolvedValueOnce({ rowCount: 42 });
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await startScheduler();
+    mockDbExecute.mockResolvedValueOnce({ rowCount: 42 });
     await cronCallbacks["0 3 * * *"]();
 
     expect(mockDbExecute).toHaveBeenCalled();
@@ -468,10 +468,10 @@ describe("daily metrics cleanup", () => {
   });
 
   it("does not log when no rows are deleted", async () => {
-    mockDbExecute.mockResolvedValueOnce({ rowCount: 0 });
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await startScheduler();
+    mockDbExecute.mockResolvedValueOnce({ rowCount: 0 });
     await cronCallbacks["0 3 * * *"]();
 
     expect(consoleSpy).not.toHaveBeenCalledWith(
@@ -481,9 +481,8 @@ describe("daily metrics cleanup", () => {
   });
 
   it("logs error when cleanup query fails", async () => {
-    mockDbExecute.mockRejectedValueOnce(new Error("DB timeout"));
-
     await startScheduler();
+    mockDbExecute.mockRejectedValueOnce(new Error("DB timeout"));
     await cronCallbacks["0 3 * * *"]();
 
     expect(ErrorLogger.error).toHaveBeenCalledWith(
@@ -499,9 +498,8 @@ describe("daily metrics cleanup", () => {
   });
 
   it("handles non-Error thrown in cleanup (uses String coercion)", async () => {
-    mockDbExecute.mockRejectedValueOnce("disk full");
-
     await startScheduler();
+    mockDbExecute.mockRejectedValueOnce("disk full");
     await cronCallbacks["0 3 * * *"]();
 
     expect(ErrorLogger.error).toHaveBeenCalledWith(

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -10,6 +10,16 @@ const MAX_CONCURRENT_CHECKS = 10;
 const ACCELERATED_RETRY_MS = 5 * 60 * 1000; // 5 minutes
 let activeChecks = 0;
 
+async function notificationTablesExist(): Promise<boolean> {
+  try {
+    await db.execute(sql`SELECT 1 FROM notification_preferences LIMIT 0`);
+    await db.execute(sql`SELECT 1 FROM notification_queue LIMIT 0`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function runCheckWithLimit(monitor: Parameters<typeof checkMonitor>[0]) {
   if (activeChecks >= MAX_CONCURRENT_CHECKS) {
     console.debug(`[Scheduler] Concurrency limit reached, deferring monitor ${monitor.id}`);
@@ -80,23 +90,29 @@ export async function startScheduler() {
     }
   });
 
-  // Process queued notifications (quiet hours + digest delivery) every minute
-  cron.schedule("*/1 * * * *", async () => {
-    try {
-      await processQueuedNotifications();
-    } catch (error) {
-      await ErrorLogger.error("scheduler", "Queued notification processing failed", error instanceof Error ? error : null, {
-        errorMessage: error instanceof Error ? error.message : String(error),
-      });
-    }
-    try {
-      await processDigestCron();
-    } catch (error) {
-      await ErrorLogger.error("scheduler", "Digest processing failed", error instanceof Error ? error : null, {
-        errorMessage: error instanceof Error ? error.message : String(error),
-      });
-    }
-  });
+  // Process queued notifications (quiet hours + digest delivery) every minute,
+  // but only if the notification tables have been migrated
+  const hasNotificationTables = await notificationTablesExist();
+  if (!hasNotificationTables) {
+    console.warn("[Scheduler] Notification tables (notification_preferences, notification_queue) do not exist yet — skipping notification cron. Run `npm run schema:push` to create them.");
+  } else {
+    cron.schedule("*/1 * * * *", async () => {
+      try {
+        await processQueuedNotifications();
+      } catch (error) {
+        await ErrorLogger.error("scheduler", "Queued notification processing failed", error instanceof Error ? error : null, {
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      }
+      try {
+        await processDigestCron();
+      } catch (error) {
+        await ErrorLogger.error("scheduler", "Digest processing failed", error instanceof Error ? error : null, {
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+  }
 
   // Daily cleanup: prune monitor_metrics older than 90 days to prevent unbounded growth
   cron.schedule("0 3 * * *", async () => {


### PR DESCRIPTION
## Summary
- The `notification_preferences` and `notification_queue` tables were defined in the Drizzle schema but never pushed to the database, causing `processDigestCron()` and `processQueuedNotifications()` to fail every minute with `relation "notification_preferences" does not exist`
- Added a one-time table existence check at scheduler startup — if the tables are missing, the notification cron is skipped with a single warning instead of spamming errors every minute
- Also guarded `processChangeNotification()` to fall back to immediate email delivery if the preferences table lookup fails, so change notifications still work

## Test plan
- [x] All 703 existing tests pass (including updated scheduler tests)
- [ ] Deploy and verify scheduler no longer logs repeated "Digest processing failed" errors
- [ ] Run `npm run schema:push` to create the notification tables, then restart and verify notification cron activates normally

https://claude.ai/code/session_01Gs6ptSQZRaN9QCiPj84uue