### PR TITLE
fix: add stealth evasion to bypass bot detection

### DIFF
--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -4424,7 +4424,7 @@ describe("stealth evasion", () => {
     await runWithTimers(monitor);
 
     expect(mockConnectOverCDP).toHaveBeenCalledWith(
-      expect.stringContaining("&stealth"),
+      expect.stringContaining("/stealth?token="),
       expect.any(Object)
     );
   });
@@ -4543,7 +4543,7 @@ describe("stealth evasion", () => {
 
     // Verify &stealth in connection URL
     expect(mockConnectOverCDP).toHaveBeenCalledWith(
-      expect.stringContaining("&stealth"),
+      expect.stringContaining("/stealth?token="),
       expect.any(Object)
     );
 

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -51,13 +51,12 @@ const STEALTH_CONTEXT_OPTIONS = {
 function stealthInitScript() {
   Object.defineProperty(navigator, 'webdriver', { get: () => false });
   if (!(window as any).chrome) {
-    (window as any).chrome = { runtime: {}, loadTimes: () => ({}), csi: () => ({}) };
+    (window as any).chrome = { runtime: {}, csi: () => ({}) };
   }
   Object.defineProperty(navigator, 'plugins', {
     get: () => [
       { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
       { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai', description: '' },
-      { name: 'Native Client', filename: 'internal-nacl-plugin', description: '' },
     ],
   });
   Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
@@ -536,7 +535,7 @@ export async function extractWithBrowserless(url: string, selector: string, moni
     if (!chromium || typeof chromium.connectOverCDP !== 'function') {
       throw new Error("Playwright browser automation is not available");
     }
-    browser = await chromium.connectOverCDP(`wss://production-sfo.browserless.io?token=${token}&stealth`, {
+    browser = await chromium.connectOverCDP(`wss://production-sfo.browserless.io/stealth?token=${encodeURIComponent(token)}`, {
       timeout: 30000
     });
 
@@ -1129,7 +1128,7 @@ export async function discoverSelectors(
     if (!chromium || typeof chromium.connectOverCDP !== 'function') {
       throw new Error("Playwright browser automation is not available. Please try again later.");
     }
-    browser = await chromium.connectOverCDP(`wss://production-sfo.browserless.io?token=${token}&stealth`, {
+    browser = await chromium.connectOverCDP(`wss://production-sfo.browserless.io/stealth?token=${encodeURIComponent(token)}`, {
       timeout: 30000
     });
 


### PR DESCRIPTION
## Summary
- Add `Sec-CH-UA` client hints to static fetch headers (missing hints are a strong bot signal)
- Add stealth init script to Browserless/Playwright: hides `navigator.webdriver`, spoofs `window.chrome` runtime, `navigator.plugins`, and `navigator.languages`
- Set realistic viewport (1920x1080) and `Sec-CH-UA` headers on browser context
- Enable Browserless `&stealth` mode on the CDP connection URL
- Applied to both `extractWithBrowserless()` and `discoverSelectors()`

## Test plan
- [x] All 996 tests pass (added `addInitScript` mock to all Browserless test fixtures)
- [x] TypeScript check passes (pre-existing errors only, unrelated to this change)
- [ ] Manual: verify jaztime.com monitor (`#maincontent span.special-price`) extracts price successfully

https://claude.ai/code/session_01Bn8ZCVV9Rf3XpsZXuQvd3X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved scraper reliability with stronger anti-detection/stealth measures, consistent browser-like headers, viewport/screen handling, and guaranteed stealth initialization during rendering and navigation.
* **Tests**
  * Added a comprehensive stealth evasion test suite to validate stealth behavior, header/configuration application, navigation order, recovery paths, and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->