### PR TITLE
fix: resolve 4 TypeScript errors in scraper.ts

### DIFF
--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -335,7 +335,7 @@ async function handleMonitorFailure(
   // Truncate error message to prevent unbounded storage in pause_reason.
   // Use spread to operate on Unicode code points, not UTF-16 code units,
   // so surrogate pairs (e.g. emoji) are never split.
-  const truncatedError = [...errorMsg].slice(0, 200).join('');
+  const truncatedError = Array.from(errorMsg).slice(0, 200).join('');
 
   // Look up the user's tier to determine the pause threshold BEFORE the atomic update,
   // so we can include the pause decision in the same UPDATE statement.

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -71,7 +71,7 @@ export class DatabaseStorage implements IStorage {
     return monitor;
   }
 
-  async updateMonitor(id: number, updates: Partial<InsertMonitor>): Promise<Monitor> {
+  async updateMonitor(id: number, updates: Partial<typeof monitors.$inferInsert>): Promise<Monitor> {
     const [updated] = await db.update(monitors).set(updates).where(eq(monitors.id, id)).returning();
     return updated;
   }


### PR DESCRIPTION
## Summary

`npm run check` (tsc) fails with 4 errors in `server/services/scraper.ts`. This PR fixes all 4 type errors with minimal, behavior-preserving changes across two files.

## Changes

**`server/services/scraper.ts`**
- Replace `[...errorMsg]` with `Array.from(errorMsg)` on line 338 to fix TS2802 — string spread requires `target >= es2015` but the project's tsconfig has no explicit target (defaults to `es3`)

**`server/storage.ts`**
- Widen `DatabaseStorage.updateMonitor()` parameter type from `Partial<InsertMonitor>` to `Partial<typeof monitors.$inferInsert>` on line 74 — fixes TS2353 on three call sites (lines 955, 1055, 1064 in scraper.ts) where server-managed fields (`lastChecked`, `lastChanged`, `currentValue`, etc.) are passed but `InsertMonitor` explicitly omits them

## How to test

1. `npm run check` — should pass with zero errors (was failing with 4 errors before)
2. `npm run test` — all 1165 tests pass, no regressions
3. `npm run build` — production build succeeds

https://claude.ai/code/session_012U3bQJDFMuPs1gGUiagSUA