### PR TITLE
Add Dashboard button to nav bar for non-dashboard pages

### DIFF
--- a/client/src/components/DashboardNav.tsx
+++ b/client/src/components/DashboardNav.tsx
@@ -44,7 +44,7 @@ export default function DashboardNav() {
             <Button variant="ghost" size="sm" asChild className="text-muted-foreground">
               <Link href="/dashboard">
                 <LayoutDashboard className="h-4 w-4 mr-2" />
-                <span className="hidden sm:inline">Dashboard</span>
+                <span className="sr-only sm:not-sr-only">Dashboard</span>
               </Link>
             </Button>
           )}


### PR DESCRIPTION
## Summary

When logged-in users navigate away from the dashboard to pages like Campaigns, Event Log, API Docs, or Support, there is no obvious way to return to the monitors/dashboard page — the only options are clicking the FetchTheChange logo (not discoverable) or using the browser back button. This PR adds an explicit "Dashboard" navigation button that appears whenever the user is on a non-dashboard page.

## Changes

- **`client/src/components/DashboardNav.tsx`**:
  - Import `useLocation` from `wouter` to detect the current route
  - Add `isOnDashboard` check (`/` or `/dashboard`)
  - Render a "Dashboard" button (with `LayoutDashboard` icon) in the nav bar when the user is **not** on the dashboard, positioned before the existing Campaigns/Event Log links
  - Button is hidden when already on the dashboard to avoid redundancy
  - Styled consistently with existing nav buttons (`variant="ghost"`, `size="sm"`)
  - Label hidden on small screens (`hidden sm:inline`), icon always visible

## How to test

1. Log in and navigate to the Dashboard — verify no "Dashboard" button appears in the nav bar (it would be redundant)
2. Click "Campaigns", "Event Log", "API Docs", or "Support" in the nav bar
3. Verify a "Dashboard" button with a grid icon now appears in the nav bar
4. Click the "Dashboard" button — verify it navigates back to `/dashboard`
5. On a narrow viewport, verify only the icon shows (label is hidden on small screens)

https://claude.ai/code/session_01NLGx4unmTxHGSjoukR1WeE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Dashboard button now displays contextually based on your current page location. It appears when navigating away from the dashboard, providing quick access to return to it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->