### PR TITLE
fix: resolve @testing-library/jest-dom/vitest import failure in Replit

### DIFF
--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -1,6 +1,8 @@
-import "@testing-library/jest-dom/vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import { afterEach, expect } from "vitest";
+
+expect.extend(matchers);
 
 afterEach(() => {
   if (typeof document !== "undefined") {


### PR DESCRIPTION
## Summary

The `@testing-library/jest-dom/vitest` auto-setup entry point fails to resolve in the Replit environment, causing all client-side tests to error during import. This PR replaces the broken auto-setup import with an explicit `expect.extend(matchers)` call, which is environment-agnostic and works everywhere.

## Changes

- **`client/src/test/setup.ts`**: Replaced `import "@testing-library/jest-dom/vitest"` (auto-setup entry point) with an explicit import of matchers from `@testing-library/jest-dom/matchers` and manual `expect.extend(matchers)` call. This avoids the module resolution issue while providing the same DOM matchers (e.g., `toBeInTheDocument`, `toHaveTextContent`).

## How to test

1. Run `npm run test` — all 1277 tests across 45 files should pass.
2. Run `npm run check` — TypeScript compilation should succeed with no errors.
3. Verify client tests that use jest-dom matchers (e.g., `toBeInTheDocument`) still work correctly.

https://claude.ai/code/session_0114LVsRNcetSaWDt127Gagi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup configuration to properly register DOM assertion matchers with the test framework while maintaining existing cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->