### PR TITLE
fix: align architect agent disabledTools frontmatter key

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Senior Software Architect reviewing system-wide implications, risks, alternatives, and constraints. Read-only analysis agent. Invoke before implementing any non-trivial feature to surface risks and establish patterns the Developer agent must follow.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
-disallowedTools: Write, Edit, MultiEdit, NotebookEdit
+disabledTools: Write, Edit, MultiEdit, NotebookEdit
 ---
 
 You are a Senior Software Architect performing a read-only analysis of this repository. Your focus is on SYSTEM-WIDE IMPLICATIONS, not implementation details. You do not write, edit, or create any files. Your output becomes the input for a Developer agent who will produce the detailed implementation plan.


### PR DESCRIPTION
## Summary

The new architect subagent definition (`.claude/agents/architect.md`) used `disallowedTools` in its YAML frontmatter, but the correct key recognized by Claude Code is `disabledTools`. This is the key already used by the existing skeptic agent. The mismatch meant the architect agent's write-protection was silently ignored.

## Changes

- **`.claude/agents/architect.md`**: Changed `disallowedTools` → `disabledTools` in frontmatter to match the skeptic agent convention and ensure write tools are actually disabled

## How to test

1. Open `.claude/agents/architect.md` and verify line 5 reads `disabledTools: Write, Edit, MultiEdit, NotebookEdit`
2. Compare with `.claude/agents/skeptic.md` line 5 — both should use the `disabledTools` key
3. Invoke the architect agent and confirm it cannot use Write/Edit tools

https://claude.ai/code/session_014KRnYdaq8hNrFqbzHk2i5z