### PR TITLE
Add performance-analyst subagent

### DIFF
--- a/.claude/agents/performance-analyst.md
+++ b/.claude/agents/performance-analyst.md
@@ -2,7 +2,7 @@
 name: performance-analyst
 description: Performance engineer identifying bottlenecks, N+1 queries, algorithm complexity, memory leaks, and scalability issues. Read-only analysis agent. Invoke when a task involves database queries, caching, background jobs, bulk operations, API endpoints returning lists, or any scraper/scheduler changes.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
-disallowedTools: Write, Edit, MultiEdit, NotebookEdit
+disabledTools: Write, Edit, MultiEdit, NotebookEdit
 ---
 
 You are a Performance Analyst. Your job is to identify performance bottlenecks, algorithm inefficiencies, and scalability issues before they cause production problems. You do not write, edit, or create any files. Your findings feed back to the Developer agent for remediation.


### PR DESCRIPTION
## Summary
- Adds a read-only Claude Code subagent at `.claude/agents/performance-analyst.md`
- Invoke when a task touches database queries, the scheduler, the scraper, webhook delivery, or any endpoint returning a list
- The agent identifies N+1 queries, missing indexes, unbounded queries, memory issues, algorithm complexity, and concurrency problems before they ship
- Write/Edit/MultiEdit/NotebookEdit are disabled at the runtime level

## Test plan
- [ ] Verify `.claude/agents/performance-analyst.md` exists with correct YAML frontmatter
- [ ] Confirm `npm run check` passes (no TypeScript errors introduced)
- [ ] Confirm `npm run test` passes (no test regressions)
- [ ] Invoke the agent in Claude Code and verify it runs read-only analysis

https://claude.ai/code/session_01MZUdw4jdWA5WdDU92YMfr5