### PR TITLE
feat: install skill-creator framework

### DIFF
--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: skill-creator
+description: "Create a new Claude Code skill for this project. Use when asked to 'add a skill', 'create a skill', 'write a skill for X workflow', or 'add /skillname to the project'. Produces a SKILL.md and optional bundled resources under .claude/skills/{name}/. Skills encode FetchTheChange-specific constraints so future agents pass npm run check && npm run test on the first attempt without manual correction."
+---
+
+## Overview
+
+Skills are modular guides that give a future Claude Code session everything it needs to execute a repeatable workflow correctly the first time. Each skill lives at `.claude/skills/{name}/` and consists of a `SKILL.md` plus optional `references/`, `assets/`, and `scripts/` subdirectories. The skill-creator reads the codebase, extracts constraints, and encodes them so that running the skill eliminates first-attempt failures.
+
+## Before Writing Any Skill File
+
+1. Read `CLAUDE.md` — conventions here become hard constraints in the new skill
+2. Read `.claude/skills/skill-creator/references/ftc-patterns.md` — every applicable pattern section must be reflected in the skill's hard constraints
+3. Read the test files that enforce the target workflow — each assertion becomes a hard constraint
+4. Read 2–3 reference implementations of the workflow — these establish the pattern the skill encodes
+5. List existing skills (`ls .claude/skills/`) — do not duplicate coverage
+
+## Deciding What Bundled Resources to Create
+
+| Resource | Include when |
+|----------|-------------|
+| `references/` markdown | Constraints exceed 150 lines in SKILL.md, or a checklist/decision table is needed at runtime |
+| `assets/` template file | Workflow always starts from a predictable file shape; a template eliminates "forgot X" failures |
+| `scripts/` executable | Same shell/Python code would be rewritten each session, or deterministic execution is critical |
+
+Default to the minimum. A SKILL.md-only skill is often sufficient.
+
+## Writing SKILL.md
+
+Frontmatter: `name` and `description` only — no other fields. The description is the only triggering mechanism; include 3–5 natural trigger phrases and name the test file or enforcer the skill encodes.
+
+Body structure (imperative/infinitive form throughout):
+
+1. **Overview** — what the skill does, which files it touches, why they must change together, name the enforcer
+2. **Workflow** — numbered steps from zero to `npm run check && npm run test` passing; each step specific enough that the agent makes no discretionary decisions
+3. **Hard constraints** — minimum 5; each names the test assertion, invariant, or security rule it comes from:
+   ```
+   - NEVER {X} — {why: names the source}
+   ```
+4. **References** (if applicable) — one line per file, what it contains, when to load it
+
+Keep SKILL.md body under 150 lines. Move overflow into a `references/` file.
+
+## Hard Constraints
+
+- NEVER add a skill that duplicates an existing skill's coverage — check `ls .claude/skills/` first
+- NEVER omit frontmatter `name` and `description` fields — they are the only trigger mechanism
+- NEVER hardcode tier limits in a skill's workflow steps — reference `TIER_LIMITS` from `shared/models/auth.ts`
+- NEVER skip the verification gate (`npm run check && npm run test`) at the end of a skill workflow
+- NEVER create a skill that modifies production code without encoding the SSRF, CSRF, and ownership-check constraints from `references/ftc-patterns.md`
+- NEVER use `gh` commands without `--repo bd73-com/fetchthechange` — the git remote uses a local proxy
+
+## After Writing Skill Files
+
+1. Verify with `find .claude/skills/{name} -type f | sort` and `wc -l .claude/skills/{name}/SKILL.md`
+2. Confirm SKILL.md is under 150 lines
+3. Update `CLAUDE.md` — append the new skill to the Skills inventory section
+4. Commit and open a PR:
+
+```bash
+git checkout -b "skill/{name}"
+git add .claude/skills/{name}/ CLAUDE.md
+git commit -m "feat: add .claude/skills/{name}/ skill"
+gh pr create \
+  --repo bd73-com/fetchthechange \
+  --title "feat: add .claude/skills/{name}/ skill" \
+  --body "Adds skill for {workflow}. Encodes constraints from {source files}. No production code changed." \
+  --base main
+```
+
+## References
+
+- `references/ftc-patterns.md` — FetchTheChange-specific patterns (schema, routes, CSRF, tier gating, frontend, security, verification); read before writing any skill's hard constraints section

--- a/.claude/skills/skill-creator/references/ftc-patterns.md
+++ b/.claude/skills/skill-creator/references/ftc-patterns.md
@@ -1,0 +1,65 @@
+# FetchTheChange Patterns Reference
+
+Constraints every skill must encode when its workflow touches the corresponding area.
+
+## Schema & Storage
+
+- New tables: define in `shared/schema.ts` using `pgTable()` from `drizzle-orm/pg-core`
+- New types: export insert/select types from `shared/schema.ts` via `createInsertSchema`
+- Storage methods: add to the `IStorage` interface and `DatabaseStorage` class in `server/storage.ts` — no raw DB queries in route handlers
+- Relations: declare in `shared/schema.ts` using `relations()` from `drizzle-orm`
+
+## Routes & Validation
+
+- Route path constants: define in `shared/routes.ts` in the `api` object — no hardcoded path strings in handlers
+- Request validation: Zod schemas for all request bodies and query params in `shared/routes.ts`
+- Route registration: new routes go in `server/routes.ts`
+- Ownership checks: every protected route must verify `monitor.userId === req.user.id` (or equivalent), not just `isAuthenticated`
+- SSRF protection: every route accepting a user-supplied URL must call `isPrivateUrl()` from `server/utils/ssrf.ts` — missing check is **Critical** severity
+
+## CSRF
+
+- CSRF middleware in `server/middleware/csrf.ts` blocks state-changing requests without a valid Origin header
+- Exempt paths listed in `EXEMPT_PATHS` (exact) and `EXEMPT_PREFIXES` (prefix match)
+- New endpoints that receive requests without a session cookie (webhooks, external callbacks, API key auth) must be added to the exempt list
+- Exemptions must be called out explicitly in the skill — never added silently
+
+## Tier Gating
+
+- Tier limits: `TIER_LIMITS` in `shared/models/auth.ts` — type is `UserTier`
+- Server-side enforcement: `TIER_LIMITS[tier] ?? TIER_LIMITS.free` pattern in route handlers
+- UI-only gating is never sufficient — server must enforce
+- Unknown Stripe products: default to `free`, never to a paid tier
+
+## Frontend
+
+- React Query hooks: `client/src/hooks/use-*.ts` following `use-monitors.ts` pattern (queryKey from `api.*`, response parsed with Zod schema)
+- New pages: register route in `client/src/App.tsx`
+- SEO: `SEOHead` component + `getCanonicalUrl()` on every public page
+- Blog posts: entry in `blogPosts` array in `Blog.tsx` AND route in `App.tsx` AND page file — all three required, enforced by `blog-integrity.test.ts`
+- UI primitives: shadcn/ui from `@/components/ui/` — no raw HTML form elements
+- Colors: Tailwind semantic tokens (`text-primary`, `bg-secondary`, `text-muted-foreground`) — no hardcoded hex/rgb
+
+## Security
+
+- API keys: SHA-256 hash stored at rest, plaintext never persisted, log only safe prefix
+- Slack tokens: AES-256-GCM encrypted via `server/utils/encryption.ts`
+- New env vars: add to `.env.example` with placeholder and explanatory comment
+
+## Verification Gate
+
+Every skill workflow must end with:
+
+```bash
+npm run check && npm run test
+```
+
+Fix all failures before committing. Run `npm run build` before creating a PR.
+
+## PR Convention
+
+```bash
+gh pr create --repo bd73-com/fetchthechange --title "..." --body "..."
+```
+
+Always pass `--repo` — the git remote uses a local proxy and `gh` cannot infer it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,3 +37,7 @@ See `README.md` for project overview, tech stack, structure, and setup.
   gh pr create --repo bd73-com/fetchthechange --title "..." --body "..."
   gh pr list --repo bd73-com/fetchthechange
 ```
+
+## Skills
+
+- `.claude/skills/skill-creator/` — guide for creating new skills that encode FetchTheChange conventions


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/skill-creator/SKILL.md` — trigger, workflow, and hard constraints for authoring new skills
- Adds `.claude/skills/skill-creator/references/ftc-patterns.md` — FetchTheChange-specific patterns a skill author must encode (schema, routes, CSRF, tier gating, frontend, security, verification gate)
- Updates `CLAUDE.md` with a Skills inventory section

## Why

Without a skill-creator skill, each new skill would be written from scratch with no shared understanding of FetchTheChange conventions (tier gating, SSRF protection, CSRF exemptions, blog integrity, PR workflow, etc.). This skill encodes those patterns once so every subsequent skill inherits them automatically.

## Test plan

- [x] `npm run check` passes — no TypeScript errors
- [x] `npm run test` passes — all 1373 tests green (46 files)
- [ ] No production code changed — skill files are consumed by Claude Code agents only

https://claude.ai/code/session_01Pfj9nWKzBnJj4wkLqBxAgS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation establishing standardized patterns, guidelines, and constraints for implementing new features in the codebase.
  * Included detailed workflow procedures, verification requirements, and best practice references to ensure consistency and quality across development efforts.
  * Expanded project documentation guide with new resource paths for developers to reference during feature development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->