### PR TITLE
fix: harden conditions routes and resolve flaky scraper tests

### DIFF
--- a/server/routes.conditions.test.ts
+++ b/server/routes.conditions.test.ts
@@ -470,9 +470,10 @@ describe("conditions routes", () => {
       // Our insert got id=10 (earliest), the concurrent one got id=20
       const created = { id: 10, monitorId: 1, type: "numeric_lt", value: "100", groupIndex: 0, createdAt: new Date() };
       mockAddMonitorCondition.mockResolvedValue(created);
+      // Return higher-ID row first to prove implementation picks Math.min, not first element
       mockGetMonitorConditions.mockResolvedValue([
-        created,
         { id: 20, monitorId: 1, type: "numeric_gt", value: "50", groupIndex: 0, createdAt: new Date() },
+        created,
       ]);
 
       const req = makeReq("user1", {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -72,8 +72,19 @@ export async function registerRoutes(
   // because condition routes are inline — 503 gives clients a clear retry signal.
   // Lazy retry: if startup fails (transient DB error), first request retries once.
   let conditionsReady = await ensureMonitorConditionsTable();
+  let conditionsReadyProbe: Promise<boolean> | null = null;
   async function requireConditionsReady(res: any): Promise<boolean> {
-    if (!conditionsReady) conditionsReady = await ensureMonitorConditionsTable();
+    if (!conditionsReady) {
+      conditionsReadyProbe ??= ensureMonitorConditionsTable()
+        .then((ready) => {
+          if (ready) conditionsReady = true;
+          return conditionsReady;
+        })
+        .finally(() => {
+          conditionsReadyProbe = null;
+        });
+      await conditionsReadyProbe;
+    }
     if (!conditionsReady) {
       res.status(503).json({ message: "Conditions not available", code: "SERVICE_UNAVAILABLE" });
       return false;
@@ -723,8 +734,8 @@ export async function registerRoutes(
     if (!(await requireConditionsReady(res))) return;
     const id = Number(req.params.id);
     const monitor = await storage.getMonitor(id);
-    if (!monitor) return res.status(404).json({ message: "Not found" });
-    if (String(monitor.userId) !== String(req.user.claims.sub)) return res.status(404).json({ message: "Not found" });
+    if (!monitor) return res.status(404).json({ message: "Not found", code: "NOT_FOUND" });
+    if (String(monitor.userId) !== String(req.user.claims.sub)) return res.status(404).json({ message: "Not found", code: "NOT_FOUND" });
 
     const conditions = await storage.getMonitorConditions(id);
     res.json(conditions);
@@ -736,8 +747,8 @@ export async function registerRoutes(
     try {
       const id = Number(req.params.id);
       const monitor = await storage.getMonitor(id);
-      if (!monitor) return res.status(404).json({ message: "Not found" });
-      if (String(monitor.userId) !== String(req.user.claims.sub)) return res.status(404).json({ message: "Not found" });
+      if (!monitor) return res.status(404).json({ message: "Not found", code: "NOT_FOUND" });
+      if (String(monitor.userId) !== String(req.user.claims.sub)) return res.status(404).json({ message: "Not found", code: "NOT_FOUND" });
 
       // Tier check: Free users capped at 1 condition per monitor
       const user = await authStorage.getUser(req.user.claims.sub);
@@ -790,15 +801,19 @@ export async function registerRoutes(
         const postInsertCount = await storage.countMonitorConditions(id);
         if (postInsertCount > 1) {
           const existing = await storage.getMonitorConditions(id);
-          if (existing.length > 0) {
-            const minId = Math.min(...existing.map((c) => c.id));
-            if (condition.id !== minId) {
-              await storage.deleteMonitorCondition(condition.id, id);
-              return res.status(403).json({
-                message: "Free plan supports 1 condition per monitor. Upgrade to Pro or Power for unlimited conditions.",
-                code: "TIER_LIMIT_REACHED",
-              });
-            }
+          if (!existing.some((c) => c.id === condition.id)) {
+            return res.status(409).json({
+              message: "Condition state changed during creation. Please retry.",
+              code: "CONDITION_RACE",
+            });
+          }
+          const minId = Math.min(...existing.map((c) => c.id));
+          if (condition.id !== minId) {
+            await storage.deleteMonitorCondition(condition.id, id);
+            return res.status(403).json({
+              message: "Free plan supports 1 condition per monitor. Upgrade to Pro or Power for unlimited conditions.",
+              code: "TIER_LIMIT_REACHED",
+            });
           }
         }
       }
@@ -818,8 +833,8 @@ export async function registerRoutes(
     const id = Number(req.params.id);
     const conditionId = Number(req.params.conditionId);
     const monitor = await storage.getMonitor(id);
-    if (!monitor) return res.status(404).json({ message: "Not found" });
-    if (String(monitor.userId) !== String(req.user.claims.sub)) return res.status(404).json({ message: "Not found" });
+    if (!monitor) return res.status(404).json({ message: "Not found", code: "NOT_FOUND" });
+    if (String(monitor.userId) !== String(req.user.claims.sub)) return res.status(404).json({ message: "Not found", code: "NOT_FOUND" });
 
     await storage.deleteMonitorCondition(conditionId, id);
     res.status(204).send();

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -56,19 +56,23 @@ vi.mock("../utils/ssrf", () => ({
     // Race the real fetch against a short timer so that unmocked retry calls
     // (where mockRejectedValueOnce has been exhausted) fail fast under fake
     // timers instead of hanging on real network I/O + AbortSignal.timeout.
+    // AbortController ensures the dangling fetch is cleaned up when the timeout wins.
+    const controller = new AbortController();
+    const mergedInit = { ...init, signal: controller.signal };
     let timeoutId: ReturnType<typeof setTimeout>;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => reject(new Error("Test: unmocked fetch call")), 50);
     });
     try {
       const result = await Promise.race([
-        globalThis.fetch(url, init),
+        globalThis.fetch(url, mergedInit),
         timeoutPromise,
       ]);
       clearTimeout(timeoutId!);
       return result;
     } catch (err) {
       clearTimeout(timeoutId!);
+      controller.abort();
       throw err;
     }
   }),


### PR DESCRIPTION
## Summary

Fixes issues caught in previous PR review: 36 flaky scraper test timeouts, missing `monitor_conditions` table startup migration, and TOCTOU race condition hardening in condition routes.

## Changes

**Startup reliability**
- Add `ensureMonitorConditionsTable()` to create the table at startup if `schema:push` hasn't run
- Add `requireConditionsReady()` helper with lazy retry — transient DB failures at startup self-heal on first request
- Guard all condition routes (GET/POST/DELETE) with 503 when table is unavailable

**TOCTOU race condition hardening**
- Keep the lowest-ID insert (deterministic winner) instead of arbitrary rollback
- Guard `Math.min()` against empty array edge case (concurrent DELETE between count and list)
- Add test for the winner path (lowest-ID insert survives the race)

**Scraper test flakiness (36 timeouts → 0)**
- Add 50ms safety race in `ssrfSafeFetch` mock so unmocked retry fetch calls fail fast under fake timers instead of hanging on real network I/O

**Other**
- Recategorize internal tooling releases in release-drafter
- Add schema sync comment between `shared/schema.ts` and `ensureTables.ts`

## How to test

1. `npm run check && npm run test` — all 1452 tests pass
2. `npm run build` — production build succeeds
3. Scraper tests complete in ~2s (previously 185s due to timeouts)

https://claude.ai/code/session_01ANkmmaafCMkdg9CYnQeYTg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for concurrent monitor condition creation and a guarded fetch behavior to fail fast on unmocked requests  
* **Bug Fixes**
  * Standardized readiness checks for monitor condition endpoints, returning 503 when not ready  
  * Improved concurrent-insert (TOCTOU) handling to enforce earliest-entry rules and surface race conflicts as 409 errors  
  * Made not-found error responses more explicit and consistent
<!-- end of auto-generated comment: release notes by coderabbit.ai -->