### PR TITLE
fix: add helmet to esbuild bundle allowlist

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -15,6 +15,7 @@ const allowlist = [
   "express",
   "express-rate-limit",
   "express-session",
+  "helmet",
   "jsonwebtoken",
   "memorystore",
   "multer",


### PR DESCRIPTION
## Summary
- The previous commit (#136) added `helmet` as a dependency and imported it in `server/index.ts`, but did not add it to the esbuild bundle allowlist in `script/build.ts`
- This caused `helmet` to be treated as an external dependency, resulting in `ERR_MODULE_NOT_FOUND` at runtime and a full app crash
- Adding `helmet` to the allowlist ensures it gets bundled into `dist/index.cjs`

## Test plan
- [x] `npm run check` passes
- [x] `npm run test` passes (all 1484 tests)
- [x] `npm run build` succeeds

https://claude.ai/code/session_012QiEvYCnucMdrVEC3647hB