### PR TITLE
fix: make helmet non-fatal in dev mode to prevent Replit crash

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -29,16 +29,20 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
   const app = express();
   const httpServer = createServer(app);
 
-  // Security headers — helmet is mandatory; refuse to start without it
+  // Security headers — helmet is bundled in production builds;
+  // in dev mode it may fail to resolve, so degrade gracefully.
   try {
     const helmet = (await import("helmet")).default;
     app.use(helmet({
       contentSecurityPolicy: false,  // CSP handled by Vite / static serving
       crossOriginEmbedderPolicy: false,  // Allow embedded resources
     }));
-  } catch (err) {
-    console.error("FATAL: helmet failed to load — refusing to start without security headers", err);
-    process.exit(1);
+  } catch {
+    if (process.env.NODE_ENV === "production") {
+      console.error("FATAL: helmet failed to load in production — refusing to start without security headers");
+      process.exit(1);
+    }
+    console.warn("WARNING: helmet not available — security headers disabled (dev mode)");
   }
 
   // Initialize Stripe schema and sync


### PR DESCRIPTION
## Summary
- The previous PR (#139) made helmet import failure call `process.exit(1)` unconditionally, crashing the app on Replit where the dev server (tsx/esbuild-kit) can't resolve helmet via ESM loader (`ERR_MODULE_NOT_FOUND`)
- Production builds bundle helmet into `dist/index.cjs` via the esbuild allowlist, so it's always available there
- Now only `process.exit(1)` in production (`NODE_ENV=production`); in dev mode, logs a warning and continues without security headers

## Test plan
- [x] `npm run check` passes
- [x] `npm run test` passes (1484 tests)
- [ ] Verify app starts on Replit with `npm run dev` (no crash)
- [ ] Verify production deployment still has security headers

https://claude.ai/code/session_01KYfvQLGhYRoCwm21nrqenz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to provide graceful degradation in development environments, allowing the application to continue running with a warning when initialization fails, while maintaining strict error handling and termination in production for security compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->