### PR TITLE
fix: auto-delete branches after PR merge

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -1,0 +1,33 @@
+name: Delete merged branches
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete merged branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            if (branch === 'main') return;
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              console.log(`Deleted branch: ${branch}`);
+            } catch (error) {
+              if (error.status === 422) {
+                console.log(`Branch already deleted: ${branch}`);
+              } else {
+                throw error;
+              }
+            }


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that automatically deletes the head branch when a PR is merged, preventing stale feature branches from accumulating.

## Changes
- Add `.github/workflows/delete-merged-branches.yml` — triggered on PR close, deletes the head branch if the PR was merged (skips `main`, handles already-deleted gracefully)
- Narrowed the "Copilot review for default branch" ruleset scope from `~ALL` to `refs/heads/main` so deletion protection only applies to main
- Deleted 3 stale remote branches that had already been merged/closed

## How to test
1. Merge this PR and verify the `claude/fix-branch-cleanup-02cO8` branch is automatically deleted
2. Create and merge a test PR to confirm the workflow triggers correctly

https://claude.ai/code/session_011Endh7o7X6NAvFhfP575kB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to clean up merged feature branches from the repository, excluding the main branch. This helps maintain a tidy codebase and reduces clutter from old branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->