### PR TITLE
fix: harden deleteMonitor, error detection, and history query

### DIFF
--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { monitors, monitorChanges, monitorConditions, monitorTags, monitorMetrics, browserlessUsage, resendUsage } from "@shared/schema";
 
 // ── Drizzle mocks ─────────────────────────────────────────────────────────────
 // vi.hoisted ensures these are available when the vi.mock factories run.
@@ -97,6 +98,9 @@ describe("DatabaseStorage", () => {
       // monitorConditions, monitorTags, monitorChanges, monitorMetrics,
       // browserlessUsage, resendUsage, monitors
       expect(deletedTables.length).toBeGreaterThanOrEqual(11);
+      expect(deletedTables).toEqual(
+        expect.arrayContaining([monitorConditions, monitorTags, monitorChanges, monitorMetrics, browserlessUsage, resendUsage, monitors]),
+      );
     });
 
     it("catches 42P01 (undefined_table) errors for optional tables", async () => {
@@ -195,6 +199,21 @@ describe("DatabaseStorage", () => {
     it("clamps limit to 1 when a negative value is passed", async () => {
       await storage.getMonitorChanges(1, -5);
       expect(mockChain.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("falls back to 200 when NaN is passed", async () => {
+      await storage.getMonitorChanges(1, NaN);
+      expect(mockChain.limit).toHaveBeenCalledWith(200);
+    });
+
+    it("falls back to 200 when Infinity is passed", async () => {
+      await storage.getMonitorChanges(1, Infinity);
+      expect(mockChain.limit).toHaveBeenCalledWith(200);
+    });
+
+    it("truncates float values", async () => {
+      await storage.getMonitorChanges(1, 50.9);
+      expect(mockChain.limit).toHaveBeenCalledWith(50);
     });
 
     it("orders results by detectedAt descending", async () => {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -129,11 +129,12 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getMonitorChanges(monitorId: number, limit = 200): Promise<MonitorChange[]> {
+    const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(Math.trunc(limit), 200)) : 200;
     return await db.select()
       .from(monitorChanges)
       .where(eq(monitorChanges.monitorId, monitorId))
       .orderBy(desc(monitorChanges.detectedAt))
-      .limit(Math.max(1, Math.min(limit, 200)));
+      .limit(safeLimit);
   }
 
   async getMonitorChangeById(changeId: number): Promise<MonitorChange | undefined> {


### PR DESCRIPTION
## Summary

Fixes three bugs in `server/storage.ts`: non-atomic multi-table deletion in `deleteMonitor` (#173), fragile string-based error detection for missing PostgreSQL tables (#172), and unbounded query in `getMonitorChanges` that could exhaust server memory (#171).

## Changes

**Transaction wrapping (Closes #173)**
- Wrap all DELETE statements in `deleteMonitor` inside `db.transaction()` for atomic deletion
- Use `tx.delete()` instead of `db.delete()` throughout the transaction
- Add explicit cleanup of `monitorConditions` and `monitorTags` tables (previously not cleaned up)

**PostgreSQL error code detection (Closes #172)**
- Replace `err?.message?.includes("relation")` with `err?.code !== "42P01"` in `deleteMonitor` and `cleanupPollutedValues`
- Uses locale-independent SQLSTATE code instead of fragile English string matching
- Prevents silently swallowing unrelated errors (e.g., FK violations) whose message happened to contain "relation"

**Bounded history query (Closes #171)**
- Add optional `limit` parameter to `getMonitorChanges` (default 200)
- Clamp with `Math.max(1, Math.min(limit, 200))` to prevent zero, negative, or excessively large values
- Update `IStorage` interface to match

**Tests**
- Add `server/storage.test.ts` with 14 unit tests covering:
  - Transaction wrapping (verifies `tx.delete` used, not `db.delete`)
  - Error code filtering (42P01 caught, other codes rethrown)
  - Limit clamping (default 200, custom values, upper/lower bounds)
  - `cleanupPollutedValues` error handling

## How to test

1. `npm run check` — TypeScript passes
2. `npm run test` — All 1572 tests pass (14 new)
3. `npm run build` — Production build succeeds
4. Verify `deleteMonitor` atomicity: if any child-table delete fails, the entire operation rolls back
5. Verify `getMonitorChanges` returns at most 200 rows by default

Closes #171, Closes #172, Closes #173

https://claude.ai/code/session_0113gYtTzefDXwrMQifsPXdR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional limit parameter to monitor change retrieval, allowing customizable result set sizes (default: 200 entries).

* **Bug Fixes**
  * Improved database error handling for partially migrated schemas with transaction-based delete operations for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->