### PR TITLE
fix: harden scraper anti-bot evasion for retail sites

### DIFF
--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -4660,7 +4660,9 @@ describe("stealth evasion", () => {
     expect(gotoIdx).toBeGreaterThan(initIdx);
   });
 
-  it("includes modern User-Agent and anti-detection headers in static fetch", async () => {
+  it("includes Chrome UA with Client Hints headers in static fetch", async () => {
+    // Force Chrome profile selection (index 0 = Chrome 133 Windows)
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
     const html = `<html><body><span class="price">$10</span></body></html>`;
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(html, { status: 200 }));
@@ -4670,20 +4672,34 @@ describe("stealth evasion", () => {
 
     const fetchCall = fetchSpy.mock.calls[0];
     const headers = (fetchCall[1] as RequestInit)?.headers as Record<string, string>;
-    // UA is randomly selected from a pool — verify it's present and modern
-    expect(headers['User-Agent']).toBeDefined();
-    expect(headers['User-Agent']).toMatch(/Chrome\/13[234]|Firefox\/13[45]/);
-    // Sec-CH-UA-Mobile is only sent for Chrome profiles, not Firefox
-    if (headers['User-Agent'].includes('Chrome')) {
-      expect(headers['Sec-CH-UA-Mobile']).toBe('?0');
-    } else {
-      expect(headers['Sec-CH-UA-Mobile']).toBeUndefined();
-    }
-    // Direct navigation — no Referer, Sec-Fetch-Site: none
+    expect(headers['User-Agent']).toMatch(/Chrome\/13[234]/);
+    expect(headers['Sec-CH-UA-Mobile']).toBe('?0');
+    expect(headers['Sec-CH-UA']).toBeDefined();
     expect(headers['Referer']).toBeUndefined();
     expect(headers['Sec-Fetch-Site']).toBe('none');
-    // Accept-Encoding should be present
     expect(headers['Accept-Encoding']).toContain('gzip');
+    randomSpy.mockRestore();
+  });
+
+  it("includes Firefox UA without Client Hints headers in static fetch", async () => {
+    // Force Firefox profile selection (index 7 = Firefox 134 macOS, last entry)
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.99);
+    const html = `<html><body><span class="price">$10</span></body></html>`;
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(html, { status: 200 }));
+
+    const monitor = makeMonitor({ selector: ".price" });
+    await runWithTimers(monitor);
+
+    const fetchCall = fetchSpy.mock.calls[0];
+    const headers = (fetchCall[1] as RequestInit)?.headers as Record<string, string>;
+    expect(headers['User-Agent']).toMatch(/Firefox\/13[45]/);
+    expect(headers['Sec-CH-UA-Mobile']).toBeUndefined();
+    expect(headers['Sec-CH-UA']).toBeUndefined();
+    expect(headers['Referer']).toBeUndefined();
+    expect(headers['Sec-Fetch-Site']).toBe('none');
+    expect(headers['Accept-Encoding']).toContain('gzip');
+    randomSpy.mockRestore();
   });
 
   it("calls addInitScript with stealth function in discoverSelectors", async () => {

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -70,6 +70,15 @@ function pickUaProfile() {
   return UA_PROFILES[Math.floor(Math.random() * UA_PROFILES.length)];
 }
 
+/** Chrome-only profiles for Browserless contexts where stealthInitScript injects Chrome-specific
+ *  JS stubs (window.chrome, navigator.plugins, mimeTypes). Using a Firefox UA in Chromium
+ *  creates a contradictory fingerprint that is a stronger bot signal than no stealth at all. */
+const CHROME_PROFILES = UA_PROFILES.filter(p => p.secChUa != null);
+
+function pickChromeProfile() {
+  return CHROME_PROFILES[Math.floor(Math.random() * CHROME_PROFILES.length)];
+}
+
 /** Returns browser-like headers with a randomly selected UA profile. */
 function browserLikeHeaders(url: string) {
   const profile = pickUaProfile();
@@ -95,18 +104,17 @@ function browserLikeHeaders(url: string) {
   return headers;
 }
 
-/** Returns Browserless stealth context options with a randomly selected UA profile. */
+/** Returns Browserless stealth context options with a Chrome-only UA profile.
+ *  Browserless runs Chromium — Firefox UAs would contradict the Chrome-specific
+ *  JS stubs injected by stealthInitScript(). */
 function stealthContextOptions() {
-  const profile = pickUaProfile();
+  const profile = pickChromeProfile();
   const extraHTTPHeaders: Record<string, string> = {
     'Accept-Language': 'en-US,en;q=0.9',
+    'Sec-CH-UA': profile.secChUa!,
+    'Sec-CH-UA-Mobile': '?0',
   };
-  // Only send Client Hints headers for Chrome profiles — Firefox never sends them
-  if (profile.secChUa) {
-    extraHTTPHeaders['Sec-CH-UA'] = profile.secChUa;
-    extraHTTPHeaders['Sec-CH-UA-Mobile'] = '?0';
-    if (profile.secChUaPlatform) extraHTTPHeaders['Sec-CH-UA-Platform'] = profile.secChUaPlatform;
-  }
+  if (profile.secChUaPlatform) extraHTTPHeaders['Sec-CH-UA-Platform'] = profile.secChUaPlatform;
   return {
     userAgent: profile.userAgent,
     locale: "en-US",
@@ -122,7 +130,10 @@ const VALUE_ATTRIBUTES = ['content', 'data-price', 'value', 'data-value'] as con
 /** Pattern matching known tracking/analytics domains to block in Browserless sessions. */
 const BLOCKED_TRACKING_PATTERN = /google-analytics|googletagmanager|facebook\.net|doubleclick|hotjar|segment\.io|newrelic|datadoghq/i;
 
-/** Resource types to block in Browserless sessions to speed up page load. */
+/** Resource types to block in Browserless sessions to speed up page load.
+ *  Images and fonts are intentionally allowed — anti-bot systems (DataDome, Akamai)
+ *  fingerprint pages that load zero images/fonts as headless. This increases bandwidth
+ *  but is necessary for evasion on retail sites. Only media (video/audio) is blocked. */
 const BLOCKED_RESOURCE_TYPES = ['media'];
 
 /** Base delay for exponential backoff on Browserless retry. */
@@ -252,7 +263,14 @@ function stealthInitScript() {
   if (!(window as any).chrome) {
     (window as any).chrome = {
       runtime: {
-        connect: function() { return {}; },
+        connect: function() {
+          return {
+            onMessage: { addListener: function() {}, removeListener: function() {} },
+            onDisconnect: { addListener: function() {}, removeListener: function() {} },
+            postMessage: function() {},
+            name: '',
+          };
+        },
         sendMessage: function() {},
         id: undefined,
         onMessage: { addListener: function() {}, removeListener: function() {} },
@@ -261,13 +279,14 @@ function stealthInitScript() {
       },
       csi: function() { return {}; },
       loadTimes: function() {
+        const t = Date.now() / 1000;
         return {
-          requestTime: Date.now() / 1000,
-          startLoadTime: Date.now() / 1000,
-          commitLoadTime: Date.now() / 1000,
-          finishDocumentLoadTime: Date.now() / 1000,
-          finishLoadTime: Date.now() / 1000,
-          firstPaintTime: Date.now() / 1000,
+          requestTime: t,
+          startLoadTime: t + 0.01,
+          commitLoadTime: t + 0.05,
+          finishDocumentLoadTime: t + 0.15,
+          finishLoadTime: t + 0.2,
+          firstPaintTime: t + 0.18,
           firstPaintAfterLoadTime: 0,
           navigationType: 'Other',
           wasFetchedViaSpdy: false,
@@ -281,12 +300,14 @@ function stealthInitScript() {
   }
 
   // 5. WebGL — spoof renderer/vendor away from SwiftShader
-  const getParameter = WebGLRenderingContext.prototype.getParameter;
-  WebGLRenderingContext.prototype.getParameter = function(parameter: number) {
-    if (parameter === 37445) return 'Intel Inc.';   // UNMASKED_VENDOR_WEBGL
-    if (parameter === 37446) return 'Intel Iris OpenGL Engine'; // UNMASKED_RENDERER_WEBGL
-    return getParameter.call(this, parameter);
-  };
+  try {
+    const getParameter = WebGLRenderingContext.prototype.getParameter;
+    WebGLRenderingContext.prototype.getParameter = function(parameter: number) {
+      if (parameter === 37445) return 'Intel Inc.';   // UNMASKED_VENDOR_WEBGL
+      if (parameter === 37446) return 'Intel Iris OpenGL Engine'; // UNMASKED_RENDERER_WEBGL
+      return getParameter.call(this, parameter);
+    };
+  } catch (_) { /* WebGL may be unavailable */ }
 
   // 6. Permissions API — spoof notifications as 'prompt'
   try {
@@ -894,9 +915,11 @@ export async function extractWithBrowserless(url: string, selector: string, moni
       const isClassName = !trimmedSelector.startsWith('.') && !trimmedSelector.startsWith('#') && !trimmedSelector.includes(' ');
       const effectiveSelector = isClassName ? `.${trimmedSelector}` : trimmedSelector;
 
-      // Small random delay before selector access to mimic human reading behavior
-      await page.waitForTimeout(800 + Math.floor(Math.random() * 1200));
-      await page.waitForSelector(effectiveSelector, { timeout: 10000 }).catch(() => {});
+      // Small random delay before selector access to mimic human reading behavior.
+      // Deduct from waitForSelector timeout to avoid pushing total beyond page budget.
+      const humanDelay = 800 + Math.floor(Math.random() * 1200);
+      await page.waitForTimeout(humanDelay);
+      await page.waitForSelector(effectiveSelector, { timeout: Math.max(10000 - humanDelay, 3000) }).catch(() => {});
       const count = await page.locator(effectiveSelector).count();
 
       let value: string | null = null;


### PR DESCRIPTION
## Summary

Hardens the scraper's anti-bot evasion in `server/services/scraper.ts` to fix persistent extraction failures on retail sites using commercial anti-bot services (DataDome, Cloudflare, Akamai). Updates stealth fingerprints, fixes header inconsistencies, and improves browser environment spoofing.

## Changes

**UA & Header Hardening**
- Replace stale Chrome 120–124 UA profiles with Chrome 132–134 and Firefox 134–135
- Fix `Sec-Fetch-Site` from `cross-site` to `none` for direct navigation (removes Referer)
- Send Client Hints headers (`Sec-CH-UA-Mobile`, `Sec-CH-UA`) only for Chrome profiles — Firefox never sends them
- Use Chrome-only profiles in Browserless contexts (Firefox UA would contradict Chrome JS stubs)

**Stealth Script Improvements**
- Expand `chrome.runtime` stub with `connect()` (Port-like return), `sendMessage`, `getManifest`, `loadTimes()` with staggered timestamps
- Add `navigator.mimeTypes` spoof (2 PDF MIME types matching real Chrome)
- Add `WebGL2RenderingContext` renderer/vendor spoof (matches existing WebGL1 spoof)
- Wrap WebGL1 spoof in try/catch for resilience (matches sections 6–11 pattern)

**Resource & Timing**
- Only block `media` resources (allow images/fonts — anti-bot systems fingerprint pages with zero images)
- Add random 800–2000ms human-like delay before DOM extraction, deducted from `waitForSelector` timeout to avoid budget overrun

**Tests**
- Split UA header test into deterministic Chrome and Firefox variants (mocked `Math.random`)
- Add test for image/font passthrough via route handler
- Add test verifying human-like delay ordering and range
- Update all existing assertions for new UA versions, header semantics, and resource types

## How to test

```bash
npm run check       # TypeScript passes
npm run test        # All 354 scraper tests pass (1624 total, 2 pre-existing scheduler failures)
npm run build       # Production build succeeds

# Verify old UA versions removed
grep -n "Chrome/120\|Chrome/121\|Chrome/122\|Chrome/123\|Chrome/124" server/services/scraper.ts
# Should return zero results

# Verify cross-site header removed
grep -n "cross-site" server/services/scraper.ts
# Should return zero results
```

https://claude.ai/code/session_01VSP76XVotVh9Nom5mAr9gM