### PR TITLE
Fix Resend webhook counter drift with atomic transactions

### DIFF
--- a/server/services/resendWebhook.test.ts
+++ b/server/services/resendWebhook.test.ts
@@ -14,6 +14,13 @@ vi.mock("../db", () => ({
     select: () => ({ from: mockFrom }),
     update: () => ({ set: mockSet }),
     execute: mockExecute,
+    transaction: async (fn: (tx: any) => Promise<void>) => {
+      const tx = {
+        update: () => ({ set: mockSet }),
+        execute: mockExecute,
+      };
+      await fn(tx);
+    },
   },
 }));
 

--- a/server/services/resendWebhook.ts
+++ b/server/services/resendWebhook.ts
@@ -75,98 +75,108 @@ export async function handleResendWebhookEvent(event: ResendWebhookEvent): Promi
     case "email.delivered":
       // Only upgrade status if not already opened/clicked
       if (recipient.status === "sent") {
-        await db
-          .update(campaignRecipients)
-          .set({ status: "delivered", deliveredAt: now })
-          .where(eq(campaignRecipients.id, recipient.id));
+        await db.transaction(async (tx) => {
+          await tx
+            .update(campaignRecipients)
+            .set({ status: "delivered", deliveredAt: now })
+            .where(eq(campaignRecipients.id, recipient.id));
 
-        await db.execute(sql`
-          UPDATE campaigns SET delivered_count = delivered_count + 1
-          WHERE id = ${recipient.campaignId}
-        `);
+          await tx.execute(sql`
+            UPDATE campaigns SET delivered_count = delivered_count + 1
+            WHERE id = ${recipient.campaignId}
+          `);
+        });
       }
       break;
 
     case "email.opened":
       // Only count first open
       if (!recipient.openedAt) {
-        await db
-          .update(campaignRecipients)
-          .set({ status: "opened", openedAt: now, deliveredAt: recipient.deliveredAt ?? now })
-          .where(eq(campaignRecipients.id, recipient.id));
+        await db.transaction(async (tx) => {
+          await tx
+            .update(campaignRecipients)
+            .set({ status: "opened", openedAt: now, deliveredAt: recipient.deliveredAt ?? now })
+            .where(eq(campaignRecipients.id, recipient.id));
 
-        await db.execute(sql`
-          UPDATE campaigns SET opened_count = opened_count + 1
-          ${recipient.deliveredAt ? sql`` : sql`, delivered_count = delivered_count + 1`}
-          WHERE id = ${recipient.campaignId}
-        `);
+          await tx.execute(sql`
+            UPDATE campaigns SET opened_count = opened_count + 1
+            ${recipient.deliveredAt ? sql`` : sql`, delivered_count = delivered_count + 1`}
+            WHERE id = ${recipient.campaignId}
+          `);
+        });
       }
       break;
 
     case "email.clicked":
       // Only count first click
       if (!recipient.clickedAt) {
-        await db
-          .update(campaignRecipients)
-          .set({
-            status: "clicked",
-            clickedAt: now,
-            openedAt: recipient.openedAt ?? now,
-            deliveredAt: recipient.deliveredAt ?? now,
-          })
-          .where(eq(campaignRecipients.id, recipient.id));
+        await db.transaction(async (tx) => {
+          await tx
+            .update(campaignRecipients)
+            .set({
+              status: "clicked",
+              clickedAt: now,
+              openedAt: recipient.openedAt ?? now,
+              deliveredAt: recipient.deliveredAt ?? now,
+            })
+            .where(eq(campaignRecipients.id, recipient.id));
 
-        // Build counter updates
-        let counterUpdates = sql`clicked_count = clicked_count + 1`;
-        if (!recipient.openedAt) {
-          counterUpdates = sql`${counterUpdates}, opened_count = opened_count + 1`;
-        }
-        if (!recipient.deliveredAt) {
-          counterUpdates = sql`${counterUpdates}, delivered_count = delivered_count + 1`;
-        }
+          // Build counter updates
+          let counterUpdates = sql`clicked_count = clicked_count + 1`;
+          if (!recipient.openedAt) {
+            counterUpdates = sql`${counterUpdates}, opened_count = opened_count + 1`;
+          }
+          if (!recipient.deliveredAt) {
+            counterUpdates = sql`${counterUpdates}, delivered_count = delivered_count + 1`;
+          }
 
-        await db.execute(sql`
-          UPDATE campaigns SET ${counterUpdates}
-          WHERE id = ${recipient.campaignId}
-        `);
+          await tx.execute(sql`
+            UPDATE campaigns SET ${counterUpdates}
+            WHERE id = ${recipient.campaignId}
+          `);
+        });
       }
       break;
 
     case "email.bounced":
       // Guard against duplicate webhook retries
       if (!recipient.failedAt) {
-        await db
-          .update(campaignRecipients)
-          .set({
-            status: "bounced",
-            failedAt: now,
-            failureReason: "bounced",
-          })
-          .where(eq(campaignRecipients.id, recipient.id));
+        await db.transaction(async (tx) => {
+          await tx
+            .update(campaignRecipients)
+            .set({
+              status: "bounced",
+              failedAt: now,
+              failureReason: "bounced",
+            })
+            .where(eq(campaignRecipients.id, recipient.id));
 
-        await db.execute(sql`
-          UPDATE campaigns SET failed_count = failed_count + 1
-          WHERE id = ${recipient.campaignId}
-        `);
+          await tx.execute(sql`
+            UPDATE campaigns SET failed_count = failed_count + 1
+            WHERE id = ${recipient.campaignId}
+          `);
+        });
       }
       break;
 
     case "email.complained":
       // Guard against duplicate webhook retries
       if (!recipient.failedAt) {
-        await db
-          .update(campaignRecipients)
-          .set({
-            status: "complained",
-            failedAt: now,
-            failureReason: "spam complaint",
-          })
-          .where(eq(campaignRecipients.id, recipient.id));
+        await db.transaction(async (tx) => {
+          await tx
+            .update(campaignRecipients)
+            .set({
+              status: "complained",
+              failedAt: now,
+              failureReason: "spam complaint",
+            })
+            .where(eq(campaignRecipients.id, recipient.id));
 
-        await db.execute(sql`
-          UPDATE campaigns SET failed_count = failed_count + 1
-          WHERE id = ${recipient.campaignId}
-        `);
+          await tx.execute(sql`
+            UPDATE campaigns SET failed_count = failed_count + 1
+            WHERE id = ${recipient.campaignId}
+          `);
+        });
       }
       break;
 


### PR DESCRIPTION
## Summary
- Wraps each webhook event case's recipient status update and campaign counter increment in a `db.transaction()` so they succeed or fail atomically
- Prevents permanent counter drift when a transient DB error occurs between the two separate queries
- Updates test mock to include `transaction` method on the db mock

## Details
When a transient DB error occurred after the recipient row was updated but before the campaign counter was incremented, the guard conditions (`if (!recipient.openedAt)`, etc.) would cause webhook retries to skip processing entirely — leaving counters permanently out of sync. Wrapping both queries in a transaction ensures the recipient update is rolled back if the counter update fails, allowing retries to correctly process both.

Fixes #216

## Test plan
- [x] All 1667 existing tests pass
- [x] TypeScript type check passes
- [ ] Verify webhook processing in staging with simulated transient failures

https://claude.ai/code/session_01QtxZpnQHxGPogv5oiqvTTS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency for email event handling (delivered, opened, clicked, bounced, complained) by ensuring database updates execute within atomic transactions, preventing inconsistencies during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->