### PR TITLE
Fix Resend webhook counter drift with atomic transactions

### DIFF
--- a/server/services/resendWebhook.test.ts
+++ b/server/services/resendWebhook.test.ts
@@ -32,10 +32,14 @@ vi.mock("@shared/schema", () => ({
   campaigns: {},
 }));
 
-vi.mock("drizzle-orm", () => ({
-  eq: (a: any, b: any) => ({ field: a, value: b }),
-  sql: (strings: TemplateStringsArray, ...values: any[]) => ({ strings, values }),
-}));
+vi.mock("drizzle-orm", () => {
+  const sqlTag = (strings: TemplateStringsArray, ...values: any[]) => ({ strings, values });
+  sqlTag.empty = () => ({ strings: [], values: [] });
+  return {
+    eq: (a: any, b: any) => ({ field: a, value: b }),
+    sql: sqlTag,
+  };
+});
 
 vi.mock("./logger", () => ({
   ErrorLogger: {

--- a/server/services/resendWebhook.ts
+++ b/server/services/resendWebhook.ts
@@ -100,7 +100,7 @@ export async function handleResendWebhookEvent(event: ResendWebhookEvent): Promi
 
           await tx.execute(sql`
             UPDATE campaigns SET opened_count = opened_count + 1
-            ${recipient.deliveredAt ? sql`` : sql`, delivered_count = delivered_count + 1`}
+            ${recipient.deliveredAt ? sql.empty() : sql`, delivered_count = delivered_count + 1`}
             WHERE id = ${recipient.campaignId}
           `);
         });


### PR DESCRIPTION
## Summary
- Wraps all five Resend webhook event handlers in `db.transaction()` so recipient status updates and campaign counter increments succeed or roll back together
- Prevents permanent counter drift when a transient DB error occurs between the two writes
- Uses `sql.empty()` (Drizzle best practice) for conditional SQL fragments
- Adds test verifying transaction errors propagate for webhook retry

Supersedes #218 and #219. Fixes #216.

## Test plan
- [x] `npm run check` passes
- [x] `npm run test` passes (all 1668 tests)
- [ ] Verify in staging that webhook events correctly update both recipient status and campaign counters

https://claude.ai/code/session_0167g7m6rjn81gg81pMTRfNP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook event processing reliability by implementing transactional database operations for delivered, opened, clicked, bounced, and complained event types, ensuring atomic updates.

* **Tests**
  * Added comprehensive test coverage verifying error propagation and retry behavior in webhook transaction handling.

* **Refactor**
  * Updated internal database and mock handling to support enhanced transactional test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->