### PR TITLE
fix: resolve TOCTOU race in Resend webhook handler

### DIFF
--- a/server/services/resendWebhook.test.ts
+++ b/server/services/resendWebhook.test.ts
@@ -519,8 +519,9 @@ describe("handleResendWebhookEvent", () => {
       const whereArg = mockTxWhere.mock.calls[0][0];
       expect(whereArg.op).toBe("and");
       const nullConditions = whereArg.conditions.filter((c: any) => c.op === "isNull");
-      expect(nullConditions).toHaveLength(1);
-      expect(nullConditions[0].field).toBe("openedAt");
+      expect(nullConditions).toHaveLength(2);
+      expect(nullConditions.some((c: any) => c.field === "openedAt")).toBe(true);
+      expect(nullConditions.some((c: any) => c.field === "failedAt")).toBe(true);
     });
 
     it("clicked: uses isNull(clickedAt) in WHERE clause", async () => {
@@ -536,8 +537,9 @@ describe("handleResendWebhookEvent", () => {
       const whereArg = mockTxWhere.mock.calls[0][0];
       expect(whereArg.op).toBe("and");
       const nullConditions = whereArg.conditions.filter((c: any) => c.op === "isNull");
-      expect(nullConditions).toHaveLength(1);
-      expect(nullConditions[0].field).toBe("clickedAt");
+      expect(nullConditions).toHaveLength(2);
+      expect(nullConditions.some((c: any) => c.field === "clickedAt")).toBe(true);
+      expect(nullConditions.some((c: any) => c.field === "failedAt")).toBe(true);
     });
 
     it("bounced: uses isNull(failedAt) in WHERE clause", async () => {
@@ -602,6 +604,8 @@ describe("handleResendWebhookEvent", () => {
         const forUpdateEvents = ["email.opened", "email.clicked"];
         const expectedCalls = forUpdateEvents.includes(eventType) ? 2 : 0;
         expect(mockTxExecute).toHaveBeenCalledTimes(expectedCalls);
+        // Every event type must call .returning() exactly once for the atomic guard
+        expect(mockTxReturning).toHaveBeenCalledTimes(1);
       }
     });
   });

--- a/server/services/resendWebhook.ts
+++ b/server/services/resendWebhook.ts
@@ -110,7 +110,7 @@ export async function handleResendWebhookEvent(event: ResendWebhookEvent): Promi
         const [updated] = await tx
           .update(campaignRecipients)
           .set({ status: "opened", openedAt: now, deliveredAt: fresh?.delivered_at ?? now })
-          .where(and(eq(campaignRecipients.id, recipient.id), isNull(campaignRecipients.openedAt)))
+          .where(and(eq(campaignRecipients.id, recipient.id), isNull(campaignRecipients.openedAt), isNull(campaignRecipients.failedAt)))
           .returning({ id: campaignRecipients.id });
 
         if (updated) {
@@ -145,7 +145,7 @@ export async function handleResendWebhookEvent(event: ResendWebhookEvent): Promi
             openedAt: fresh?.opened_at ?? now,
             deliveredAt: fresh?.delivered_at ?? now,
           })
-          .where(and(eq(campaignRecipients.id, recipient.id), isNull(campaignRecipients.clickedAt)))
+          .where(and(eq(campaignRecipients.id, recipient.id), isNull(campaignRecipients.clickedAt), isNull(campaignRecipients.failedAt)))
           .returning({ id: campaignRecipients.id });
 
         if (updated) {


### PR DESCRIPTION
## Summary

Fixes a Time-of-Check-Time-of-Use (TOCTOU) race condition in the Resend webhook handler (`server/services/resendWebhook.ts`) where concurrent duplicate webhooks for the same `email_id` could double-increment campaign denormalized counters (`delivered_count`, `opened_count`, `clicked_count`, `failed_count`). This was reported in #220.

The fix replaces pre-transaction JavaScript guard checks with atomic `UPDATE ... WHERE ... RETURNING` clauses inside transactions. For `email.opened` and `email.clicked` handlers that need fresh state for conditional counter logic, `SELECT ... FOR UPDATE` is used inside the transaction with a 5-second lock timeout.

## Changes

### Core fix (`server/services/resendWebhook.ts`)
- **Atomic guards**: Moved guard conditions (`status = 'sent'`, `openedAt IS NULL`, etc.) from JavaScript `if` statements into the `UPDATE`'s `WHERE` clause using `and()`, `eq()`, `isNull()` from drizzle-orm
- **Row-level locking**: Added `SELECT ... FOR UPDATE` inside transactions for `email.opened` and `email.clicked` to read fresh `deliveredAt`/`openedAt` state, preventing stale-read counter inflation
- **Lock timeout**: Added `SET LOCAL lock_timeout = '5s'` to prevent indefinite blocking if another transaction holds the row lock
- **Observability**: Added `console.debug` logging when the atomic guard rejects a duplicate webhook, making it possible to detect excessive Resend retries
- **Documentation**: Added comments explaining the bounce-before-delivery guard behavior and raw SQL column name coupling to physical schema

### Tests (`server/services/resendWebhook.test.ts`)
- Updated all tests for the new `.returning()` mock chain pattern
- Added tests verifying atomic `WHERE` conditions (eq for status, isNull for timestamps)
- Added test for concurrent webhook scenario (fresh read detects deliveredAt set by another handler)
- Added comprehensive test that all event types gate counter updates on `.returning()` results
- 32 tests covering all event types, guard conditions, transaction atomicity, and error propagation

## How to test

1. `npm run check` — TypeScript type checking passes
2. `npm run test` — All 1680 tests pass (60 test files)
3. `npm run build` — Production build succeeds
4. Review the atomic UPDATE WHERE pattern in each switch case of `handleResendWebhookEvent`
5. Verify that `SELECT ... FOR UPDATE` is used only in `email.opened` and `email.clicked` (the cases that need fresh state for conditional counter logic)

Closes #220

https://claude.ai/code/session_015S8WuBz6thFfbTJgXvVQJJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved email event webhook handling to prevent duplicate counting of delivered, opened, clicked, bounced, and complained events.
  * Enhanced data consistency by validating event preconditions before updating counters.
  * Better handling of out-of-order and duplicate webhook deliveries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->