### PR TITLE
fix: serialize Stripe init after route registration

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -240,9 +240,19 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
   if (!process.env.STRIPE_WEBHOOK_SECRET) {
     console.warn("STRIPE_WEBHOOK_SECRET not set — webhooks will fail until managed webhook setup completes");
   }
-  initStripe().catch((err) => {
-    console.error("Stripe background init failed:", err);
-  });
+  const MAX_STRIPE_INIT_ATTEMPTS = 5;
+  const BASE_STRIPE_INIT_RETRY_MS = 5_000;
+
+  const startStripeInitWithRetry = (attempt = 1): void => {
+    initStripe().catch((err) => {
+      console.error(`Stripe background init failed (attempt ${attempt}/${MAX_STRIPE_INIT_ATTEMPTS}):`, err);
+      if (attempt >= MAX_STRIPE_INIT_ATTEMPTS) return;
+      const delay = BASE_STRIPE_INIT_RETRY_MS * 2 ** (attempt - 1);
+      setTimeout(() => startStripeInitWithRetry(attempt + 1), delay).unref();
+    });
+  };
+
+  startStripeInitWithRetry();
 
   // Error Handler
   app.use((err: any, _req: any, res: any, next: any) => {


### PR DESCRIPTION
## Summary

- Move `initStripe()` from before webhook route registration to after `registerRoutes()` completes, fixing DB connection pool exhaustion during server startup
- `registerRoutes()` runs 7+ sequential `ensure*` migration calls through the main pool (max 3). Previously, `initStripe()` ran concurrently, adding `runMigrations` + StripeSync pool connections, exceeding the database connection limit and causing "timeout exceeded when trying to connect" errors
- Add timing instrumentation to `initStripe()` for cold-start observability (logs elapsed time on success and failure)

## Test plan

- [x] `npm run check` passes (TypeScript)
- [x] `npm run test` passes (1680 tests, 60 files)
- [x] `npm run build` passes (production build)
- [x] Security review: no vulnerabilities — webhook route ordering preserved, fail-closed behavior unchanged
- [x] Architecture review: correct fix for pool exhaustion; alternatives (increase pool size, await initStripe) have worse tradeoffs
- [x] Skeptic review: PROCEED verdict — added timing instrumentation to address wider webhook rejection window during cold start

https://claude.ai/code/session_01CqkEqweeNRBmC6aZHxydka

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delayed background payment service setup until after routes register to prevent startup DB connection issues.
  * Made payment data backfill non-blocking so startup isn't blocked; added start/completion timing and clearer failure logs.
  * Added guarded check for missing webhook configuration to avoid silent failures and introduced retry with exponential backoff for initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->