### PR TITLE
docs: add extension README with build instructions

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -11,7 +11,7 @@ npm run build
 ```
 
 Then in Chrome/Brave:
-1. Navigate to `chrome://extensions`
+1. Navigate to `chrome://extensions` (or `brave://extensions` in Brave)
 2. Enable **Developer mode**
 3. Click **Load unpacked**
 4. Select the `extension/build/` directory (not `extension/` itself)


### PR DESCRIPTION
## Summary

The Chrome extension shows a blank/black popup when loaded from the source directory instead of the `build/` directory. This is because the source files are TypeScript and don't execute in the browser. Added a README to the extension directory documenting the build step, correct load path, available scripts, and troubleshooting for this exact issue.

## Changes

- **extension/README.md** — New file documenting:
  - Quick start (install, build, load unpacked from `build/`)
  - Development workflow (`npm run watch:dev`)
  - Available npm scripts table
  - Troubleshooting section for the blank popup issue

## How to test

1. Verify the README renders correctly on GitHub
2. Follow the Quick Start instructions in a fresh checkout:
   - `cd extension && npm install && npm run build`
   - Load `extension/build/` as unpacked extension in Chrome/Brave
   - Click toolbar icon — should show "Connect your account" screen

https://claude.ai/code/session_01CELwr3Hd9wWHJMpfx8QegH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Browser Extension documentation including quick start instructions, development workflow guidelines, available npm scripts reference, and troubleshooting guidance for proper extension installation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->