### PR TITLE
fix(ci): draft release before uploading extension zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.drafter.outputs.tag_name }}
-      release_id: ${{ steps.drafter.outputs.id }}
     steps:
       - uses: release-drafter/release-drafter@v6
         id: drafter


### PR DESCRIPTION
## Summary
- Fixes HTTP 422 "Cannot upload assets to an immutable release" error
- Release-drafter now creates a **draft** release (mutable), the extension zip is built and uploaded, then a final job publishes the release
- sync-changelog still triggers correctly via the `release: [published]` event

## Root cause
`publish: true` on release-drafter makes the release immutable immediately, so `gh release upload` fails.

## Test plan
- [ ] Merge and verify the release workflow completes all 3 jobs
- [ ] Confirm `fetchthechange-extension.zip` appears in release assets
- [ ] Confirm sync-changelog runs after the release is published

https://claude.ai/code/session_01CELwr3Hd9wWHJMpfx8QegH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to require explicit publication step for releases instead of automatic publishing upon draft creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->