### PR TITLE
fix: auto-recover on merge-pr pre-flight failures

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -2,7 +2,7 @@ Squash-merge the current branch's PR and delete the remote branch.
 
 ## Instructions
 
-1. Run `gh pr view --repo bd73-com/fetchthechange --json number,url,state,reviewDecision,mergeStateStatus,statusCheckRollup,labels,author` to check the PR's current status.
+1. Run `gh pr view --repo bd73-com/fetchthechange --json number,url,state,reviewDecision,mergeStateStatus,statusCheckRollup,labels,author,reviewRequests` to check the PR's current status.
 2. **Pre-flight checks** — evaluate all of these and report a summary table:
    - PR state must be `OPEN`.
    - `reviewDecision` must be `APPROVED` (no outstanding requesting-changes reviews).


### PR DESCRIPTION
## Summary

The `/merge-pr` command previously stopped cold when a pre-flight check failed, only telling the user what went wrong without taking any action. This made the workflow tedious — you'd have to manually request reviewers, look up the PR URL, or figure out which check failed. This PR makes `/merge-pr` automatically take recovery actions for each failure type.

## Changes

- **Auto-request reviewers**: When `reviewDecision` is empty/not approved, the command now fetches repo collaborators, excludes the PR author, and requests a review from the first available collaborator
- **Status check guidance**: Lists specific failed/pending checks and tells the user whether to wait or investigate
- **Conflict handling**: Directs user to rebase locally when merge state is `CONFLICTING`
- **Missing label recovery**: Offers to add the release label via `gh pr edit` instead of just reporting it missing
- **Bug fixes**: Added `--repo bd73-com/fetchthechange` to all `gh` commands (was missing), added `url` to the JSON query, and accepted `CLEAN` as a valid `mergeStateStatus`

## How to test

1. Open a PR that has no approvals and run `/merge-pr`
2. Verify it reports the failure **and** automatically requests a reviewer
3. Open a PR with all checks passing and approval — verify it still merges normally
4. Open a PR missing a release label — verify it asks which label to add and offers to apply it

https://claude.ai/code/session_01LQjQRCbNWpNwEHxpcQTUYR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated merge workflow documentation to query PR status with additional fields (including PR URL and author).
  * Enhanced pre-flight evaluation to assess all checks and produce a summary table; broadened accepted merge-state logic and explicitly treat draft, unstable, dirty, behind, and blocked as failing conditions.
  * Expanded failure-handling guidance with automatic recovery actions: request missing reviews, report status-check failures/pending, direct conflict resolution, and prompt adding missing release labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->