### PR TITLE
fix: auto-dismiss stale bot reviews in /merge-pr

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -19,10 +19,12 @@ When `reviewDecision` is `CHANGES_REQUESTED` or `mergeStateStatus` is `BLOCKED`,
 
 1. Fetch all reviews on the PR: `gh api repos/bd73-com/fetchthechange/pulls/<number>/reviews --jq '[.[] | {id: .id, user: .user.login, user_type: .user.type, state: .state, submitted_at: .submitted_at}]'`
 2. Identify reviews with `state: "CHANGES_REQUESTED"`.
-3. For each such review, check if the reviewer is a bot (`user_type == "Bot"` — e.g., `coderabbitai[bot]`, `github-actions[bot]`).
-4. If the reviewer is a bot, check whether new commits were pushed **after** the review's `submitted_at` timestamp: `gh api --paginate repos/bd73-com/fetchthechange/pulls/<number>/commits --jq '.[].commit.committer.date' | tail -n1` — compare that latest commit date to the review date.
-5. If the last commit is newer than the bot's review, the review is stale. **Dismiss it automatically**: `gh api repos/bd73-com/fetchthechange/pulls/<number>/reviews/<review_id>/dismissals -f message="Dismissing stale bot review — fixes were pushed in subsequent commits." -f event="DISMISS"`
-6. After dismissing, re-fetch PR status from step 1 and continue the pre-flight checks. If the PR is now `APPROVED` (or `reviewDecision` is empty with no blocking reviews) and `mergeStateStatus` is `CLEAN`/`HAS_HOOKS`, proceed to merge.
+3. For each such review, check if the reviewer is a **trusted bot** by matching the login against this allowlist: `coderabbitai[bot]`, `github-actions[bot]`, `dependabot[bot]`. Do not rely solely on `user_type == "Bot"` — only dismiss reviews from bots on this list.
+4. If the reviewer is a trusted bot, check whether new commits were pushed **after** the review's `submitted_at` timestamp:
+   - Get the latest commit date: `gh api --paginate repos/bd73-com/fetchthechange/pulls/<number>/commits --jq '.[].commit.committer.date' | tail -n1`
+   - Compare timestamps: convert both to epoch seconds (`date -d "$COMMIT_DATE" +%s` vs `date -d "$REVIEW_DATE" +%s`) and only proceed if the commit timestamp is strictly greater than the review timestamp.
+5. If the last commit is newer than the bot's review, the review is stale. **Dismiss it automatically**: `gh api --method PUT repos/bd73-com/fetchthechange/pulls/<number>/reviews/<review_id>/dismissals -f message="Dismissing stale bot review — fixes were pushed in subsequent commits." -f event="DISMISS"`. If the dismissal API call fails (e.g., insufficient permissions, rate limit), log the error and skip to reporting the original failure — do not attempt to re-fetch or merge.
+6. After a successful dismissal, re-fetch PR status from step 1 and continue the pre-flight checks. If the PR is now `APPROVED` (or `reviewDecision` is empty/null and `mergeStateStatus` is not `BLOCKED`) and `mergeStateStatus` is `CLEAN`/`HAS_HOOKS`, proceed to merge.
 
 **Important**: Only dismiss bot reviews automatically. Never dismiss reviews from human collaborators — those always require manual resolution.
 


### PR DESCRIPTION
## Summary
- `/merge-pr` now autonomously detects and dismisses stale bot reviews (e.g., CodeRabbit) when fixes have been pushed after the review
- Adds a new "Auto-resolving stale bot reviews" phase that runs before reporting failures — fetches reviews, checks if the reviewer is a bot, compares timestamps, and dismisses if stale
- Adds explicit handling for `BLOCKED` mergeStateStatus
- Only bot reviews are auto-dismissed; human reviews always require manual resolution

## Test plan
- [ ] Run `/merge-pr` on a PR where CodeRabbit requested changes and fixes were pushed — should auto-dismiss and merge
- [ ] Run `/merge-pr` on a PR where a human requested changes — should NOT auto-dismiss, should follow existing reviewer-request flow
- [ ] Run `/merge-pr` on a PR with no review issues — should merge normally (no regression)
- [ ] Run `/merge-pr` on a PR where bot review is newer than last commit — should NOT dismiss (review is not stale)

https://claude.ai/code/session_0153tqfefRKFSwEKmNUNZn7x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-resolves stale bot-generated review requests before reporting merge failures, reducing false blockers.

* **Improvements**
  * Merge flow now continues only when PR is approved (or has no blocking reviews) and merge status is clean.
  * Failure messages clarify that "no retry/bypass" applies only when a blocker wasn’t auto-resolved.
  * Better distinction between human review blockers and other branch-protection/required-approval blockers; human reviews must be resolved manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->