### PR TITLE
Remove Edit/Write permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "permissions": {
+    "allow": [
+      "Edit",
+      "Write"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Adds `Edit` and `Write` to the project-level Claude Code permissions allow list in `.claude/settings.json`. This removes the interactive confirmation prompt that appears every time Claude attempts to edit or create a file, streamlining the development workflow.

## Changes

- **`.claude/settings.json`**: Added `permissions.allow` array with `Edit` and `Write` entries, preserving the existing `hooks` configuration

## How to test

1. Open a new Claude Code session in this repo
2. Ask Claude to edit any file (e.g., "add a comment to README.md")
3. Verify that no "Allow Claude to Edit?" permission prompt appears
4. Ask Claude to create a new file
5. Verify that no "Allow Claude to Write?" permission prompt appears

https://claude.ai/code/session_01G8R5ayrkzQRk53TAzUhohs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Introduced permissions configuration settings with support for edit and write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->