### PR TITLE
fix: stop CodeRabbit and missing reviews from blocking merges

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -5,10 +5,10 @@ Squash-merge the current branch's PR and delete the remote branch.
 1. Run `gh pr view --repo bd73-com/fetchthechange --json number,url,state,reviewDecision,mergeStateStatus,statusCheckRollup,labels,author,reviewRequests` to check the PR's current status.
 2. **Pre-flight checks** — evaluate all of these and report a summary table:
    - PR state must be `OPEN`.
-   - `reviewDecision` must be `APPROVED` (no outstanding requesting-changes reviews).
-   - `mergeStateStatus` must be `CLEAN` or `HAS_HOOKS` (not `DIRTY`, `BEHIND`, `BLOCKED`, `DRAFT`, or `UNSTABLE`).
+   - `reviewDecision`: if `APPROVED`, pass. If empty/missing (no reviewers), pass with a note. Only fail if `reviewDecision` equals `CHANGES_REQUESTED`.
+   - `mergeStateStatus` must be `CLEAN`, `HAS_HOOKS`, or `UNSTABLE` (not `DIRTY`, `BEHIND`, `BLOCKED`, or `DRAFT`). `UNSTABLE` is accepted because known third-party bot checks may still be running — see the status check rule below for how to verify this is safe.
    - PR must have exactly one release label from: `feature`, `fix`, `breaking`, `chore`, `docs`, `security`.
-   - All required status checks must pass: every entry in `statusCheckRollup` must have a conclusion of `SUCCESS`, `NEUTRAL`, or `SKIPPED` — fail if any entry is `FAILURE`, `PENDING`, or missing.
+   - All status checks must pass, **except** known third-party bot checks. When evaluating `statusCheckRollup`, ignore entries whose name or context contains `CodeRabbit`, `coderabbitai`, or `coderabbit`. For all remaining entries: `SUCCESS`, `NEUTRAL`, or `SKIPPED` pass; `FAILURE` or `PENDING` fail. If `mergeStateStatus` is `UNSTABLE`, verify that the only non-passing checks are from the ignored bot list above — if any non-bot check is failing or pending, treat it as a failure.
 3. **Auto-resolve stale bot reviews** — before reporting failures for `reviewDecision` or `mergeStateStatus`, run the stale-bot-review check described below. If it resolves the blocker, re-fetch PR status and continue.
 4. If all checks pass, merge with: `gh pr merge --repo bd73-com/fetchthechange --squash --delete-branch`.
 5. Confirm the merge succeeded and the remote branch was deleted.
@@ -24,7 +24,7 @@ When `reviewDecision` is `CHANGES_REQUESTED` or `mergeStateStatus` is `BLOCKED`,
    - Get the latest commit date: `gh api --paginate repos/bd73-com/fetchthechange/pulls/<number>/commits --jq '.[].commit.committer.date' | tail -n1`
    - Compare timestamps: convert both to epoch seconds (`date -d "$COMMIT_DATE" +%s` vs `date -d "$REVIEW_DATE" +%s`) and only proceed if the commit timestamp is strictly greater than the review timestamp.
 5. If the last commit is newer than the bot's review, the review is stale. **Dismiss it automatically**: `gh api --method PUT repos/bd73-com/fetchthechange/pulls/<number>/reviews/<review_id>/dismissals -f message="Dismissing stale bot review — fixes were pushed in subsequent commits." -f event="DISMISS"`. If the dismissal API call fails (e.g., insufficient permissions, rate limit), log the error and skip to reporting the original failure — do not attempt to re-fetch or merge.
-6. After a successful dismissal, re-fetch PR status from step 1 and continue the pre-flight checks. If the PR is now `APPROVED` (or `reviewDecision` is empty/null and `mergeStateStatus` is not `BLOCKED`) and `mergeStateStatus` is `CLEAN`/`HAS_HOOKS`, proceed to merge.
+6. After a successful dismissal, re-fetch PR status from step 1 and continue the pre-flight checks. If the PR is now `APPROVED` (or `reviewDecision` is empty/null and `mergeStateStatus` is not `BLOCKED`) and `mergeStateStatus` is `CLEAN`/`HAS_HOOKS`/`UNSTABLE`, proceed to merge.
 
 **Important**: Only dismiss bot reviews automatically. Never dismiss reviews from human collaborators — those always require manual resolution.
 
@@ -32,13 +32,10 @@ When `reviewDecision` is `CHANGES_REQUESTED` or `mergeStateStatus` is `BLOCKED`,
 
 If a pre-flight check fails (and was not auto-resolved above), report exactly which check failed. Do NOT retry or attempt to bypass branch protection. Then take **automatic recovery actions** based on the failure type:
 
-### reviewDecision is empty or not APPROVED (human reviewers)
+### reviewDecision is CHANGES_REQUESTED
 
-1. Get the PR author from the JSON retrieved in step 1 (the `author` or `user` field).
-2. Fetch repo collaborators, excluding the PR author and any already-requested reviewers: `gh api repos/bd73-com/fetchthechange/collaborators --jq '[.[].login] | map(select(. != "AUTHOR_LOGIN"))' | jq -r 'first'` (replace `AUTHOR_LOGIN` with the actual author login; also exclude logins already in the PR's `reviewRequests` list from step 1).
-3. If no eligible collaborators remain, tell the user no reviewers are available and they must manually request one.
-4. Otherwise, request a review: `gh pr edit <number> --repo bd73-com/fetchthechange --add-reviewer <login>` (replace `<number>` with the PR number from step 1).
-5. Tell the user: who was requested, the PR URL, and that they can run `/merge-pr` again once approved.
+- List the reviewers who requested changes and their comments.
+- Tell the user to address the feedback, push updates, then re-run `/merge-pr`.
 
 ### Status checks FAILURE or PENDING
 
@@ -48,7 +45,7 @@ If a pre-flight check fails (and was not auto-resolved above), report exactly wh
 
 ### mergeStateStatus is BLOCKED
 
-- If blocked due to outstanding reviews that were not auto-resolved (i.e., human `CHANGES_REQUESTED` reviews), follow the "reviewDecision is empty or not APPROVED" steps above.
+- If blocked due to outstanding reviews that were not auto-resolved (i.e., human `CHANGES_REQUESTED` reviews), follow the "reviewDecision is CHANGES_REQUESTED" steps above.
 - If blocked for other reasons (branch protection rules, required approvals), tell the user what is blocking and suggest next steps.
 
 ### mergeStateStatus is DIRTY (merge conflicts)

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,7 +28,7 @@ reviews:
   sequence_diagrams: true
   review_status: true
   poem: false
-  commit_status: true
+  commit_status: false
   assess_linked_issues: true
   related_issues: true
   related_prs: true


### PR DESCRIPTION
## Summary

The `/merge-pr` command was blocking merges for two reasons that don't apply to a solo-dev workflow: (1) CodeRabbit's `commit_status` setting created a GitHub commit status that stayed PENDING while it reviewed, causing `mergeStateStatus = UNSTABLE` and failing the status-checks gate, and (2) the command required `reviewDecision = APPROVED`, which is impossible when there are no human reviewers. This PR fixes both issues.

## Changes

**`.coderabbit.yaml`**
- Set `commit_status: false` so CodeRabbit no longer creates a GitHub commit status that blocks merges while it's reviewing

**`.claude/commands/merge-pr.md`**
- `reviewDecision`: empty/missing (no reviewers) now passes instead of failing — only blocks when a reviewer has explicitly requested changes
- `mergeStateStatus`: `UNSTABLE` is now accepted alongside `CLEAN`/`HAS_HOOKS`, since non-required bot checks can lag behind
- `statusCheckRollup`: CodeRabbit/bot status checks are now excluded from evaluation — only required branch-protection checks are enforced
- Simplified the `reviewDecision` failure-handling section (removed the collaborator-lookup/reviewer-request flow, replaced with guidance to address requested changes)

## How to test

1. Open a PR on a branch with no human reviewers requested
2. Run `/merge-pr` — it should no longer fail on `reviewDecision` being empty
3. If CodeRabbit is still reviewing (PENDING), `/merge-pr` should still proceed since `commit_status` is now disabled and CodeRabbit checks are excluded from `statusCheckRollup`
4. Verify that PRs with actual `CHANGES_REQUESTED` reviews still correctly block merging

https://claude.ai/code/session_01L933ExMQzMorgxWrGyVo7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened merge validation to allow an additional unstable merge state in safe cases, ignore known bot checks when evaluating statuses, and require remaining checks to pass; empty/no-reviewer is allowed but explicit "changes requested" now blocks merge and prompts users to address feedback and re-run the merge command.

* **Chores**
  * Disabled automated commit status updates in the review workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->