### PR TITLE
Fix: persist refreshed OAuth tokens to session store

### DIFF
--- a/server/replit_integrations/auth/replitAuth.test.ts
+++ b/server/replit_integrations/auth/replitAuth.test.ts
@@ -278,7 +278,7 @@ describe("isAuthenticated", () => {
     expect(res.json).toHaveBeenCalledWith({ message: "Internal Server Error" });
     expect(consoleSpy).toHaveBeenCalledWith(
       "[auth] Failed to save refreshed session:",
-      "store write failed"
+      expect.stringContaining("store write failed")
     );
     consoleSpy.mockRestore();
   });

--- a/server/replit_integrations/auth/replitAuth.ts
+++ b/server/replit_integrations/auth/replitAuth.ts
@@ -225,10 +225,14 @@ export const isAuthenticated: RequestHandler = async (req, res, next) => {
 
     // Persist refreshed tokens to the session store.
     // resave is false, so we must explicitly re-serialize and save.
-    (req.session as any).passport.user = serializeUserPayload(user);
+    const passport = (req.session as any).passport;
+    if (passport) {
+      passport.user = serializeUserPayload(user);
+    }
     req.session.save((err) => {
       if (err) {
-        console.error("[auth] Failed to save refreshed session:", err.message);
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error("[auth] Failed to save refreshed session:", msg);
         return res.status(500).json({ message: "Internal Server Error" });
       }
       return next();


### PR DESCRIPTION
## Summary

When the OIDC access token expires, the `isAuthenticated` middleware refreshes it via `refreshTokenGrant` but previously only updated tokens in memory. With `resave: false`, express-session never persisted the refreshed tokens to the PostgreSQL session store, causing redundant refresh calls on every subsequent request (~100-500ms extra latency each) and potential unexpected logouts if the provider issues one-time-use refresh tokens.

This PR persists refreshed tokens to the session store and hardens the refresh path against several edge cases discovered during review.

## Changes

**Core fix** (`server/replit_integrations/auth/replitAuth.ts`):
- After token refresh, re-serialize updated tokens into `req.session.passport.user` and call `req.session.save()`
- Move `next()` inside the `session.save()` callback to prevent race condition where the response dispatches before persistence completes
- Return 500 on session save failure instead of silently proceeding

**Hardening**:
- Extract `serializeUserPayload()` helper to eliminate shape duplication between `serializeUser` (login) and the refresh path
- Add null check on `req.session.passport` before assignment to handle corrupted session rows gracefully
- Use safe error message extraction (`err instanceof Error ? err.message : String(err)`) to prevent logging undefined and avoid leaking full error objects

**Tests** (`server/replit_integrations/auth/replitAuth.test.ts`):
- 7 new tests for `isAuthenticated` middleware covering: unauthenticated, missing expiry, valid token, missing refresh token, successful refresh with session persistence verification, failed refresh grant, and session save failure (500 response)

## How to test

1. `npm run check` — TypeScript passes
2. `npm run test` — All 1764 tests pass (7 new)
3. `npm run build` — Production build succeeds
4. Manual: Log in, wait for token expiry, confirm session store row updates with new tokens
5. Manual: Confirm subsequent requests after refresh do not trigger additional `refreshTokenGrant` calls

## Related issues

- Fixes #265
- Filed #268 (pre-existing: refresh token overwritten with undefined when provider omits it)
- Filed #269 (pre-existing: concurrent refresh race condition)

https://claude.ai/code/session_01JUweaU4PunmvR2R3oD9SKD