### PR TITLE
fix: CSRF-safe test-email endpoint and bounded error log batch delete

### DIFF
--- a/client/src/pages/AdminErrors.tsx
+++ b/client/src/pages/AdminErrors.tsx
@@ -155,7 +155,7 @@ export default function AdminErrors() {
   }, []);
 
   const finalizeMutation = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (): Promise<{ count: number; hasMore?: boolean }> => {
       const res = await fetch("/api/admin/error-logs/finalize", {
         method: "POST",
         credentials: "include",
@@ -163,9 +163,12 @@ export default function AdminErrors() {
       if (!res.ok) throw new Error("Failed to finalize deletion");
       return res.json();
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       invalidateAll();
       clearSelection();
+      if (data.hasMore) {
+        toast({ title: "More entries remain", description: "Some soft-deleted entries were not finalized. Repeat to finalize more." });
+      }
     },
     onError: () => {
       toast({ title: "Error", description: "Failed to permanently delete entries", variant: "destructive" });
@@ -173,7 +176,7 @@ export default function AdminErrors() {
   });
 
   const restoreMutation = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (): Promise<{ count: number; hasMore?: boolean }> => {
       const res = await fetch("/api/admin/error-logs/restore", {
         method: "POST",
         credentials: "include",
@@ -181,8 +184,11 @@ export default function AdminErrors() {
       if (!res.ok) throw new Error("Failed to restore entries");
       return res.json();
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       invalidateAll();
+      if (data.hasMore) {
+        toast({ title: "More entries remain", description: "Some soft-deleted entries were not restored. Repeat to restore more." });
+      }
     },
     onError: () => {
       toast({ title: "Error", description: "Failed to restore entries", variant: "destructive" });

--- a/server/routes.deleteErrorLog.test.ts
+++ b/server/routes.deleteErrorLog.test.ts
@@ -776,9 +776,10 @@ describe("POST /api/admin/error-logs/restore", () => {
     await ensureRoutes();
     vi.clearAllMocks();
 
-    // restore uses .where(...).limit(500), so chain through mockLimitFn
+    // restore uses .where(...).orderBy(...).limit(500), so chain through mockOrderByFn/mockLimitFn
     mockLimitFn.mockResolvedValue([]);
-    mockSelectWhereFn.mockReturnValue({ limit: mockLimitFn });
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ orderBy: mockOrderByFn, limit: mockLimitFn });
     mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn });
     mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
 
@@ -869,9 +870,10 @@ describe("POST /api/admin/error-logs/finalize", () => {
     await ensureRoutes();
     vi.clearAllMocks();
 
-    // finalize uses .where(...).limit(500), so chain through mockLimitFn
+    // finalize uses .where(...).orderBy(...).limit(500), so chain through mockOrderByFn/mockLimitFn
     mockLimitFn.mockResolvedValue([]);
-    mockSelectWhereFn.mockReturnValue({ limit: mockLimitFn });
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ orderBy: mockOrderByFn, limit: mockLimitFn });
     mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn });
     mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1653,7 +1653,7 @@ export async function registerRoutes(
         (await storage.getMonitors(userId)).map((m: any) => m.id)
       );
 
-      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).limit(500);
+      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).orderBy(asc(errorLogs.id)).limit(500);
 
       const authorized = softDeleted.filter((log: any) => {
         const ctx = log.context as Record<string, unknown> | null;
@@ -1691,7 +1691,7 @@ export async function registerRoutes(
         (await storage.getMonitors(userId)).map((m: any) => m.id)
       );
 
-      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).limit(500);
+      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).orderBy(asc(errorLogs.id)).limit(500);
 
       const authorized = softDeleted.filter((log: any) => {
         const ctx = log.context as Record<string, unknown> | null;


### PR DESCRIPTION
## Summary

Fixes two reported bugs: the `/api/test-email` endpoint used HTTP GET for a state-changing operation (sending email), making it vulnerable to CSRF via image tags and browser prefetching (#284). The filter-based batch delete on `/api/admin/error-logs/batch-delete` loaded all matching rows into memory with no upper bound, risking OOM on large tables (#283).

## Changes

**Security — test-email endpoint (fixes #284)**
- Changed `app.get("/api/test-email", ...)` to `app.post(...)` in `server/routes.ts`
- POST requests are automatically protected by the existing CSRF middleware (Origin header validation)
- No frontend caller exists for this endpoint; it is a debug/admin endpoint

**Performance — bounded batch delete (fixes #283)**
- Added `.orderBy(asc(errorLogs.id)).limit(500)` to the filter-based query in the batch-delete endpoint
- Added `hasMore` boolean to the response so the client knows if additional requests are needed
- Applied the same `hasMore` pattern to the restore and finalize endpoints for API consistency
- Updated the client (`AdminErrors.tsx`) to read `hasMore` and show a toast when more entries remain

**Tests**
- Updated mock chain in `routes.deleteErrorLog.test.ts` to match the new `.where().orderBy().limit()` query shape
- Added test for `hasMore: true` when exactly 500 entries are returned
- Added test verifying `/api/test-email` is registered as POST, not GET
- Updated restore/finalize test expectations to include `hasMore`

## How to test

1. **Test-email CSRF fix**: Verify that `GET /api/test-email` returns 404 (or method not allowed) and `POST /api/test-email` works with a valid session
2. **Batch delete limit**: Create >500 error log entries matching a filter, trigger filter-based delete, verify response includes `{ hasMore: true }` and only 500 are processed
3. **Client toast**: After a filter-based delete that hits the 500-row limit, verify a "More entries remain" toast appears
4. **Run tests**: `npm run check && npm run test` — all 1834 tests pass

Closes #284
Closes #283

https://claude.ai/code/session_01P8grWDU2NXyfvqY3cxj18b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch operations (delete, restore, finalize) now indicate when additional matching entries remain (hasMore), so admins know when to repeat the action.
  * Batch operations use deterministic ordering and bounded fetches to ensure consistent results.

* **Bug Fixes**
  * Test Email endpoint now uses POST instead of GET.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->