### PR TITLE
feat: add git-based insights dashboard report

### DIFF
--- a/insights-report.html
+++ b/insights-report.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FetchTheChange — Git Insights</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #0f172a; color: #e2e8f0; line-height: 1.65; padding: 48px 24px; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0f172a; color: #e2e8f0; line-height: 1.65; padding: 48px 24px; }
     .container { max-width: 860px; margin: 0 auto; }
     h1 { font-size: 32px; font-weight: 700; color: #f1f5f9; margin-bottom: 4px; }
     h2 { font-size: 20px; font-weight: 600; color: #f1f5f9; margin-top: 48px; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #1e293b; }


### PR DESCRIPTION
## Summary

Adds a standalone HTML insights report (`insights-report.html`) generated from the repository's actual git history. This replaces the broken Claude Code `/insights` report which showed zero sessions despite extensive project activity. The report uses a dark theme matching the app's design system.

## Changes

- **`insights-report.html`** — New standalone HTML dashboard with:
  - Top-level stats: 50 commits, +86K lines added, 51 PRs merged, ~25 commits/week
  - "At a Glance" summary with velocity, focus area, hotspot, and work rhythm insights
  - Bar charts: commit types (84% fixes), day-of-week activity, hour-of-day (CET), language breakdown
  - Hotspot files table showing the 10 most frequently changed files
  - Biggest commits section (top 5 by lines changed)
  - Key insights cards: shipping velocity, production hardening phase, test-driven workflow, route hotspot warning, Monday load spike, add/remove ratio

## How to test

1. Check out the branch: `git checkout claude/build-insights-dashboard-V3vmx`
2. Open `insights-report.html` in a browser
3. Verify all charts render correctly with the dark theme
4. Verify stats match git history (`git log --oneline | wc -l` should show 50+ commits)
5. Check responsive layout by resizing the browser window

https://claude.ai/code/session_01LQtS6mgGPiYt1BTugXsbAH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone Git Insights report page: a dark-themed dashboard showing overall commit/line/PR counts, commits-per-week, commit-type and language distributions, day/hour activity patterns, most-changed (hotspot) files, largest commits summary, and colored "Key Insights" cards. Footer shows report source/date and commits analyzed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->