### PR TITLE
fix: switch client tests from happy-dom to jsdom

### DIFF
--- a/client/src/components/FixSelectorModal.test.tsx
+++ b/client/src/components/FixSelectorModal.test.tsx
@@ -4,7 +4,7 @@
  * MSW handlers: POST /api/monitors/:id/suggest-selectors, PATCH /api/monitors/:id,
  *               POST /api/monitors/:id/check
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/client/src/hooks/use-api-keys.test.ts
+++ b/client/src/hooks/use-api-keys.test.ts
@@ -3,7 +3,7 @@
  * Coverage: useApiKeys, useCreateApiKey, useRevokeApiKey
  * MSW handlers: GET /api/keys, POST /api/keys, DELETE /api/keys/:id
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-auth.test.ts
+++ b/client/src/hooks/use-auth.test.ts
@@ -2,7 +2,7 @@
  * Tests: use-auth hook
  * Coverage: useAuth — user fetch, authenticated state, null on 401
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-campaigns.test.ts
+++ b/client/src/hooks/use-campaigns.test.ts
@@ -6,7 +6,7 @@
  *           useRecoverCampaigns, useCancelCampaign,
  *           useAutomatedCampaigns, useUpdateAutomatedCampaign, useTriggerAutomatedCampaign
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-conditions.test.ts
+++ b/client/src/hooks/use-conditions.test.ts
@@ -2,7 +2,7 @@
  * Tests: use-conditions hooks
  * Coverage: useMonitorConditions, useAddCondition, useDeleteCondition
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-monitors.test.ts
+++ b/client/src/hooks/use-monitors.test.ts
@@ -7,7 +7,7 @@
  *               POST /api/monitors, PATCH /api/monitors/:id, DELETE /api/monitors/:id,
  *               POST /api/monitors/:id/check, POST /api/monitors/:id/suggest-selectors
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-notification-channels.test.ts
+++ b/client/src/hooks/use-notification-channels.test.ts
@@ -3,7 +3,7 @@
  * Coverage: useNotificationChannels, useUpsertNotificationChannel, useDeleteNotificationChannel,
  *           useRevealWebhookSecret, useDeliveryLog
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-notification-preferences.test.ts
+++ b/client/src/hooks/use-notification-preferences.test.ts
@@ -2,7 +2,7 @@
  * Tests: use-notification-preferences hooks
  * Coverage: useNotificationPreferences, useUpdateNotificationPreferences, useDeleteNotificationPreferences
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-slack.test.ts
+++ b/client/src/hooks/use-slack.test.ts
@@ -2,7 +2,7 @@
  * Tests: use-slack hooks
  * Coverage: useSlackStatus, useSlackChannels, useDisconnectSlack
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-tags.test.ts
+++ b/client/src/hooks/use-tags.test.ts
@@ -2,7 +2,7 @@
  * Tests: use-tags hooks
  * Coverage: useTags, useCreateTag, useUpdateTag, useDeleteTag, useSetMonitorTags
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";

--- a/client/src/hooks/use-toast.test.ts
+++ b/client/src/hooks/use-toast.test.ts
@@ -2,7 +2,7 @@
  * Tests: use-toast reducer and toast function
  * Coverage: reducer (ADD_TOAST, UPDATE_TOAST, DISMISS_TOAST, REMOVE_TOAST)
  *
- * @vitest-environment happy-dom
+ * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { reducer } from "./use-toast";

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "express-rate-limit": "^8.2.1",
         "express-session": "^1.19.0",
         "framer-motion": "^11.13.1",
-        "happy-dom": "^20.8.9",
         "helmet": "^8.1.0",
         "input-otp": "^1.4.2",
         "jsdom": "^28.1.0",
@@ -4833,12 +4832,16 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -7374,7 +7377,10 @@
       "version": "20.8.9",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
       "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -7391,7 +7397,10 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -7403,7 +7412,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "express-rate-limit": "^8.2.1",
     "express-session": "^1.19.0",
     "framer-motion": "^11.13.1",
-    "happy-dom": "^20.8.9",
     "helmet": "^8.1.0",
     "input-otp": "^1.4.2",
     "jsdom": "^28.1.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     exclude: ["node_modules", "dist", ".cache"],
     setupFiles: ["./client/src/test/setup.ts"],
     environmentMatchGlobs: [
-      ["client/**", "happy-dom"],
+      ["client/**", "jsdom"],
     ],
     pool: "forks",
     maxWorkers: 1,


### PR DESCRIPTION
## Summary

All 11 client-side test files fail in Replit's CI runner (`/home/runner/workspace/`) with `ERR_MODULE_NOT_FOUND` for `happy-dom`, even after #312 moved it from `devDependencies` to `dependencies`. This PR eliminates the dependency on `happy-dom` entirely by switching to `jsdom`, which is already in `dependencies` and works identically for these React Testing Library / MSW hook tests.

## Changes

- **vitest.config.ts**: Changed `environmentMatchGlobs` from `happy-dom` to `jsdom` for `client/**` test files
- **11 test files**: Updated `@vitest-environment` docblock directive from `happy-dom` to `jsdom`:
  - `client/src/components/FixSelectorModal.test.tsx`
  - `client/src/hooks/use-api-keys.test.ts`
  - `client/src/hooks/use-auth.test.ts`
  - `client/src/hooks/use-campaigns.test.ts`
  - `client/src/hooks/use-conditions.test.ts`
  - `client/src/hooks/use-monitors.test.ts`
  - `client/src/hooks/use-notification-channels.test.ts`
  - `client/src/hooks/use-notification-preferences.test.ts`
  - `client/src/hooks/use-slack.test.ts`
  - `client/src/hooks/use-tags.test.ts`
  - `client/src/hooks/use-toast.test.ts`
- **package.json**: Removed `happy-dom` from `devDependencies` (no longer needed)
- **package-lock.json**: Updated accordingly

## How to test

1. Run `npm run check` — TypeScript compilation should succeed
2. Run `npm run test` — all 83 test files (2042 tests) should pass with zero unhandled errors
3. Verify no `happy-dom` references remain: `grep -r "happy-dom" --include="*.ts" --include="*.tsx" --include="*.json" . --exclude-dir=node_modules` should return nothing

https://claude.ai/code/session_018WQ3mBAtLFAUBhyPFDry4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure dependencies and configuration to improve testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->