### PR TITLE
fix: resolve msw import failures in Replit runner

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "client", "src"),
       "@shared": path.resolve(__dirname, "shared"),
+      "msw/node": path.resolve(__dirname, "node_modules/msw/lib/node/index.mjs"),
+      "msw": path.resolve(__dirname, "node_modules/msw/lib/core/index.mjs"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Client-side test suites (10 files) fail with `Failed to resolve import "msw"` in the Replit runner environment. Vite's `vite:import-analysis` plugin cannot locate the `msw` package during SSR-mode module resolution, even though it is installed in `node_modules`. This PR fixes the issue through a series of changes across 5 commits: switching from `happy-dom` to `jsdom`, moving `msw` to production dependencies (Replit installs only production deps in some contexts), adding `msw` to Vitest's `server.deps.inline`, and finally adding explicit resolve aliases that bypass Vite's environment-specific module resolution entirely.

## Changes

- **vitest.config.ts**: Added explicit `resolve.alias` entries for `msw` and `msw/node` pointing directly to their `.mjs` entry files, ensuring resolution works regardless of environment. Added `msw` to `server.deps.inline`. Switched `environmentMatchGlobs` from `happy-dom` to `jsdom`.
- **package.json / package-lock.json**: Moved `msw` from `devDependencies` to `dependencies`. Removed `happy-dom` (no longer used).
- **11 test files** (`client/src/components/FixSelectorModal.test.tsx`, `client/src/hooks/use-*.test.ts`): Changed `@vitest-environment` docblock from `happy-dom` to `jsdom`.

## How to test

1. Run `npm run test` — all 83 suites (2042 tests) should pass
2. Run `npm run check` — TypeScript should compile cleanly
3. Deploy to Replit and run tests there — the 10 previously failing suites should now pass

https://claude.ai/code/session_01HUbXU7vukoBqwMHvDVJD12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration for improved mocking framework compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->