### PR TITLE
fix: externalize msw in vitest for Replit compatibility

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,6 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "client", "src"),
       "@shared": path.resolve(__dirname, "shared"),
-      "msw/node": path.resolve(__dirname, "node_modules/msw/lib/node/index.mjs"),
-      "msw": path.resolve(__dirname, "node_modules/msw/lib/core/index.mjs"),
     },
   },
   test: {
@@ -25,7 +23,8 @@ export default defineConfig({
     maxWorkers: 1,
     server: {
       deps: {
-        inline: ["@testing-library/jest-dom", "msw"],
+        inline: ["@testing-library/jest-dom"],
+        external: [/^msw/],
       },
     },
   },


### PR DESCRIPTION
## Summary

Fixes the 10 client-side test suites that fail with `Failed to resolve import "msw"` in the Replit runner environment. The previous fix (#316) used hardcoded resolve aliases pointing into `node_modules/msw/lib/`, but Replit's runner has a different `node_modules` layout so those paths don't exist there. This PR takes a fundamentally different approach: externalize `msw` so Vitest uses Node's native module resolution (which works everywhere) instead of Vite's import resolver (which fails in Replit).

## Changes

- **vitest.config.ts**: Removed hardcoded `msw` and `msw/node` resolve aliases. Removed `msw` from `server.deps.inline`. Added `server.deps.external: [/^msw/]` to force Node-native resolution for all msw imports.

## How to test

1. `npm run check` — TypeScript compiles cleanly
2. `npm run test` — all 83 suites (2042 tests) pass
3. Deploy to Replit and run `npm run test` — the 10 previously failing client hook/component suites should now pass

https://claude.ai/code/session_01HUbXU7vukoBqwMHvDVJD12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration to optimize dependency handling for improved test environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->