### PR TITLE
fix: eliminate rebase conflicts in sync-changelog CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,16 +85,21 @@ jobs:
 
       - run: npm install --no-save tsx@4.21.0
 
-      - run: npx tsx script/sync-changelog.ts
+      - name: Generate and push changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add client/src/data/changelog.ts
-          git diff --cached --quiet && exit 0
-          git commit -m "chore: sync changelog from GitHub releases"
-          git pull --rebase origin main
-          git push origin HEAD:main || (sleep 2 && git pull --rebase origin main && git push origin HEAD:main)
+          for attempt in 1 2 3; do
+            git fetch origin main
+            git reset --hard origin/main
+            npx tsx script/sync-changelog.ts
+            git add client/src/data/changelog.ts
+            git diff --cached --quiet && echo "No changes" && exit 0
+            git commit -m "chore: sync changelog from GitHub releases"
+            git push origin HEAD:main && exit 0
+            echo "Push failed (attempt $attempt), retrying..."
+            sleep $((attempt * 2))
+          done
+          echo "Failed after 3 attempts" && exit 1

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -26,16 +26,21 @@ jobs:
 
       - run: npm install --no-save tsx@4.21.0
 
-      - run: npx tsx script/sync-changelog.ts
+      - name: Generate and push changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add client/src/data/changelog.ts
-          git diff --cached --quiet && exit 0
-          git commit -m "chore: sync changelog from GitHub releases"
-          git pull --rebase origin main
-          git push origin HEAD:main || (sleep 2 && git pull --rebase origin main && git push origin HEAD:main)
+          for attempt in 1 2 3; do
+            git fetch origin main
+            git reset --hard origin/main
+            npx tsx script/sync-changelog.ts
+            git add client/src/data/changelog.ts
+            git diff --cached --quiet && echo "No changes" && exit 0
+            git commit -m "chore: sync changelog from GitHub releases"
+            git push origin HEAD:main && exit 0
+            echo "Push failed (attempt $attempt), retrying..."
+            sleep $((attempt * 2))
+          done
+          echo "Failed after 3 attempts" && exit 1


### PR DESCRIPTION
## Summary

- Fixes the recurring sync-changelog CI failure caused by `git pull --rebase origin main` conflicting on `changelog.ts` when main has moved since checkout
- Replaces the rebase-after-commit approach with fetch-reset-generate-push: always starts from latest `origin/main` before running the script, eliminating rebase conflicts entirely
- Adds a 3-attempt retry loop for push race conditions (without rebase)

## Why this works

The sync-changelog script is **idempotent** — it regenerates `changelog.ts` from scratch via the GitHub API every time. There is no local state to preserve via rebase. By fetching the latest main before each attempt, we guarantee a clean base and avoid conflicts.

## Test plan

- [x] `npm run check` passes
- [x] `npm run test` passes (87 files, 2140 tests)
- [ ] Verify next Release Drafter run completes sync-changelog successfully

https://claude.ai/code/session_01KWBDFTs4ZzJo5N1w3cKcyT