### PR TITLE
fix: resolve Chrome extension "Failed to generate token" error

### DIFF
--- a/client/src/pages/ExtensionAuth.test.tsx
+++ b/client/src/pages/ExtensionAuth.test.tsx
@@ -89,6 +89,31 @@ describe("ExtensionAuth", () => {
     consoleSpy.mockRestore();
   });
 
+  it("shows error when 200 response has malformed token payload", async () => {
+    const postMessageSpy = vi.spyOn(window, "postMessage");
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    server.use(
+      http.post("/api/extension/token", () =>
+        HttpResponse.json({ unexpected: "shape" }),
+      ),
+    );
+
+    renderWithProviders(<ExtensionAuth />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong. Please try again.")).toBeDefined();
+    });
+
+    // postMessage should NOT have been called with a token
+    expect(postMessageSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "FTC_EXTENSION_TOKEN" }),
+      expect.anything(),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
   it("posts token via postMessage and shows success on valid response", async () => {
     const postMessageSpy = vi.spyOn(window, "postMessage");
 

--- a/client/src/pages/ExtensionAuth.tsx
+++ b/client/src/pages/ExtensionAuth.tsx
@@ -24,6 +24,9 @@ export default function ExtensionAuth() {
         const data = await res.json().catch(() => {
           throw new Error("Unexpected response format from server");
         });
+        if (typeof data?.token !== "string" || typeof data?.expiresAt !== "string") {
+          throw new Error("Invalid token payload from server");
+        }
         window.postMessage(
           { type: "FTC_EXTENSION_TOKEN", token: data.token, expiresAt: data.expiresAt },
           window.location.origin,


### PR DESCRIPTION
## Summary

The Chrome extension auth flow was broken — users saw "Failed to generate token. Please try again." when connecting the extension. The root cause was a `Content-Type: application/json` header on a bodyless POST to `/api/extension/token`. Express's JSON body parser attempted to parse the empty body, failed with a SyntaxError, and returned 400 before the route handler ever ran.

## Changes

### Bug fix
- **`client/src/pages/ExtensionAuth.tsx`** — Removed the unnecessary `Content-Type: application/json` header from the POST fetch. The endpoint reads no request body; only the session cookie is needed for authentication.
- **`client/src/pages/ExtensionAuth.tsx`** — Added `error` to the useEffect dependency array for exhaustive-deps compliance. Currently safe (retry uses `window.location.reload()`), but prevents a silent break if retry logic changes to state-based clearing.

### Tests
- **`client/src/pages/ExtensionAuth.test.tsx`** (new) — 6 tests covering:
  - Sign-in link shown when unauthenticated
  - POST sent without Content-Type header (regression test for the fix)
  - Error message on non-OK server response
  - Error message on non-JSON response
  - postMessage token relay and success state
  - `credentials: "include"` verified via window.fetch spy

## How to test

1. Build and run the app locally
2. Install the Chrome extension (or use an existing install)
3. Click the extension popup → "Connect" to open `/extension-auth`
4. Verify the token exchange succeeds and shows "Connected!" instead of the error
5. Run `npm run check && npm run test` — all 2146 tests pass

## Related

- Filed #348 (pre-existing: extension JWT logged in plaintext by logging middleware)

https://claude.ai/code/session_01XFF8kVwbRCMfMXzCfvELur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for extension authentication covering authentication flows, error scenarios, token generation, and message-posting behavior with proper mock server handling.

* **Bug Fixes**
  * Improved error state handling in the token request process for better error recovery and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->