### PR TITLE
fix: harden sync-changelog and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           publish: false
           config-name: release-drafter.yml
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -37,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci
@@ -82,7 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install tsx
         run: |
@@ -200,13 +201,23 @@ jobs:
             -X PUT --input "$PAYLOAD_FILE" > /dev/null || {
             echo "::error::Failed to commit changelog to branch $BRANCH"; exit 1; }
 
-          PR_URL=$(gh pr create \
-            --repo "$REPO" \
-            --head "$BRANCH" \
-            --base main \
-            --title "chore: sync changelog from GitHub releases" \
-            --body "Auto-generated changelog update after release publication.") || {
-            echo "::error::Failed to create PR"; exit 1; }
+          # Wait for GitHub to propagate the branch and commit before creating PR
+          PR_URL=""
+          for pr_attempt in 1 2 3; do
+            PR_URL=$(gh pr create \
+              --repo "$REPO" \
+              --head "$BRANCH" \
+              --base main \
+              --title "chore: sync changelog from GitHub releases" \
+              --body "Auto-generated changelog update after release publication." 2>/dev/null) && break
+            echo "PR creation attempt $pr_attempt failed, retrying in $((pr_attempt * 3))s..."
+            PR_URL=""
+            sleep $((pr_attempt * 3))
+          done
+          if [ -z "$PR_URL" ]; then
+            echo "::error::Failed to create PR after 3 attempts"
+            exit 1
+          fi
           echo "Created changelog PR: $PR_URL"
           BRANCH_CREATED=false  # PR owns the branch now; don't delete on exit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,23 +201,26 @@ jobs:
             -X PUT --input "$PAYLOAD_FILE" > /dev/null || {
             echo "::error::Failed to commit changelog to branch $BRANCH"; exit 1; }
 
-          # Wait for GitHub to propagate the branch and commit before creating PR
+          # Retry PR creation — GitHub may need time to propagate the branch/commit
           PR_URL=""
+          PR_ERR=$(mktemp)
           for pr_attempt in 1 2 3; do
             PR_URL=$(gh pr create \
               --repo "$REPO" \
               --head "$BRANCH" \
               --base main \
               --title "chore: sync changelog from GitHub releases" \
-              --body "Auto-generated changelog update after release publication." 2>/dev/null) && break
-            echo "PR creation attempt $pr_attempt failed, retrying in $((pr_attempt * 3))s..."
+              --body "Auto-generated changelog update after release publication." 2>"$PR_ERR") && break
+            echo "PR creation attempt $pr_attempt failed: $(cat "$PR_ERR")"
             PR_URL=""
             sleep $((pr_attempt * 3))
           done
           if [ -z "$PR_URL" ]; then
-            echo "::error::Failed to create PR after 3 attempts"
+            echo "::error::Failed to create PR after 3 attempts: $(cat "$PR_ERR")"
+            rm -f "$PR_ERR"
             exit 1
           fi
+          rm -f "$PR_ERR"
           echo "Created changelog PR: $PR_URL"
           BRANCH_CREATED=false  # PR owns the branch now; don't delete on exit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
   update-release-draft:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.merged == true
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.user.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.drafter.outputs.tag_name }}
@@ -25,6 +26,8 @@ jobs:
         with:
           publish: false
           config-name: release-drafter.yml
+          # Autolabeling is handled by label-prs.yml on PR open/edit;
+          # disable here to avoid pull_request_target warnings during draft updates
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: sync-changelog
-      cancel-in-progress: true
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -109,7 +112,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        # Auto-merge requires "Allow auto-merge" enabled in repo settings.
+        # If branch protection requires reviews, GITHUB_TOKEN cannot self-approve;
+        # add github-actions[bot] to the bypass list or merge changelog PRs manually.
         run: |
-          gh pr merge "$PR_NUMBER" \
-            --repo ${{ github.repository }} --squash --auto 2>/dev/null \
-            || echo "::warning::Auto-merge not available; PR requires manual merge"
+          if ! merge_output=$(gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto 2>&1); then
+            echo "::warning::Auto-merge failed: $merge_output"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,8 @@ jobs:
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} \
+          gh pr merge "$PR_NUMBER" \
             --repo ${{ github.repository }} --squash --auto 2>/dev/null \
             || echo "::warning::Auto-merge not available; PR requires manual merge"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
         # Auto-merge requires "Allow auto-merge" enabled in repo settings.
         # If branch protection requires reviews, GITHUB_TOKEN cannot self-approve;
         # add github-actions[bot] to the bypass list or merge changelog PRs manually.
         run: |
-          if ! merge_output=$(gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto 2>&1); then
+          if ! merge_output=$(gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --auto 2>&1); then
             echo "::warning::Auto-merge failed: $merge_output"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,146 +86,29 @@ jobs:
           node-version: 22
 
       - name: Install tsx
-        run: |
-          npm install --no-save tsx@4.21.0
-          echo "tsx version: $(npx tsx --version)"
-          echo "node version: $(node --version)"
+        run: npm install --no-save tsx@4.21.0
 
       - name: Generate changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "::group::Running sync-changelog.ts"
-          npx tsx script/sync-changelog.ts
-          echo "::endgroup::"
-          echo "Generated file size: $(wc -c < client/src/data/changelog.ts) bytes"
-          echo "Generated file lines: $(wc -l < client/src/data/changelog.ts)"
-          echo "Local blob SHA: $(git hash-object client/src/data/changelog.ts)"
+        run: npx tsx script/sync-changelog.ts
 
-      - name: Commit changelog update
+      - name: Create changelog PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: sync changelog from GitHub releases"
+          title: "chore: sync changelog from GitHub releases"
+          body: "Auto-generated changelog update after release publication."
+          branch: chore/sync-changelog
+          delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          REPO="${{ github.repository }}"
-          LOCAL_SHA=$(git hash-object client/src/data/changelog.ts)
-          BODY_FILE=$(mktemp)
-          PAYLOAD_FILE=$(mktemp)
-          base64 -w0 client/src/data/changelog.ts > "$BODY_FILE"
-          echo "Content base64 length: $(wc -c < "$BODY_FILE") chars"
-
-          cleanup() {
-            rm -f "$BODY_FILE" "$PAYLOAD_FILE" "${DIRECT_ERR:-}"
-            if [ "${BRANCH_CREATED:-false}" = "true" ]; then
-              echo "Cleaning up branch $BRANCH"
-              timeout 5 gh api "repos/$REPO/git/refs/heads/$BRANCH" -X DELETE 2>/dev/null || true
-            fi
-          }
-          trap cleanup EXIT
-
-          # Helper: build Contents API JSON payload without shell-expanding the base64
-          build_payload() {
-            jq -n \
-              --arg msg "chore: sync changelog from GitHub releases" \
-              --rawfile content "$BODY_FILE" \
-              --arg sha "$1" \
-              --arg branch "$2" \
-              '{message: $msg, content: $content, sha: $sha, branch: $branch}' \
-              > "$PAYLOAD_FILE"
-          }
-
-          # Fetch current file SHA from GitHub (pinned to main)
-          FILE_SHA=""
-          for attempt in 1 2 3; do
-            FILE_SHA=$(gh api "repos/$REPO/contents/client/src/data/changelog.ts?ref=main" \
-              --jq '.sha' 2>/dev/null) && [ -n "$FILE_SHA" ] && [ "$FILE_SHA" != "null" ] && break
-            echo "Failed to fetch file SHA (attempt $attempt)"
-            FILE_SHA=""
-            sleep $((attempt * 2))
-          done
-          if [ -z "$FILE_SHA" ]; then
-            echo "::error::Could not fetch file SHA after 3 attempts"
-            exit 1
-          fi
-
-          # Skip if content is unchanged
-          if [ "$LOCAL_SHA" = "$FILE_SHA" ]; then
-            echo "No changelog changes needed"
-            exit 0
-          fi
-
-          echo "Changelog changed (local=$LOCAL_SHA remote=$FILE_SHA)"
-
-          # Try direct commit to main first
-          build_payload "$FILE_SHA" "main"
-          echo "Payload size: $(wc -c < "$PAYLOAD_FILE") bytes"
-          DIRECT_ERR=$(mktemp)
-          if gh api "repos/$REPO/contents/client/src/data/changelog.ts" \
-            -X PUT --input "$PAYLOAD_FILE" > /dev/null 2>"$DIRECT_ERR"; then
-            echo "Changelog committed directly to main"
-            rm -f "$DIRECT_ERR"
-            exit 0
-          fi
-          echo "::warning::Direct commit to main failed:"
-          cat "$DIRECT_ERR"
-          rm -f "$DIRECT_ERR"
-          echo "Falling back to PR..."
-
-          # Fallback: create a PR when direct push is blocked
-          BRANCH="chore/sync-changelog-$(date +%s)"
-          BRANCH_CREATED=false
-
-          # Close any existing open changelog PRs to avoid accumulation
-          EXISTING_PRS=$(gh pr list --repo "$REPO" --author "app/github-actions" --search "chore: sync changelog from GitHub releases in:title" --state open --json number --jq '.[].number' 2>/dev/null || true)
-          for pr_num in $EXISTING_PRS; do
-            echo "Closing stale changelog PR #$pr_num"
-            gh pr close "$pr_num" --repo "$REPO" --delete-branch 2>/dev/null || true
-          done
-
-          echo "Creating branch: $BRANCH"
-          MAIN_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha') || {
-            echo "::error::Failed to fetch main HEAD SHA"; exit 1; }
-          echo "main HEAD: $MAIN_SHA"
-
-          gh api "repos/$REPO/git/refs" \
-            -f ref="refs/heads/$BRANCH" \
-            -f sha="$MAIN_SHA" > /dev/null || {
-            echo "::error::Failed to create branch $BRANCH"; exit 1; }
-          BRANCH_CREATED=true
-
-          # Re-fetch file SHA pinned to the exact commit the branch was created from
-          BRANCH_FILE_SHA=$(gh api "repos/$REPO/contents/client/src/data/changelog.ts?ref=$MAIN_SHA" \
-            --jq '.sha' 2>/dev/null) || BRANCH_FILE_SHA="$FILE_SHA"
-
-          build_payload "$BRANCH_FILE_SHA" "$BRANCH"
-          gh api "repos/$REPO/contents/client/src/data/changelog.ts" \
-            -X PUT --input "$PAYLOAD_FILE" > /dev/null || {
-            echo "::error::Failed to commit changelog to branch $BRANCH"; exit 1; }
-
-          # Retry PR creation — GitHub may need time to propagate the branch/commit
-          PR_URL=""
-          PR_ERR=$(mktemp)
-          for pr_attempt in 1 2 3; do
-            PR_URL=$(gh pr create \
-              --repo "$REPO" \
-              --head "$BRANCH" \
-              --base main \
-              --title "chore: sync changelog from GitHub releases" \
-              --body "Auto-generated changelog update after release publication." 2>"$PR_ERR") && break
-            echo "PR creation attempt $pr_attempt failed: $(cat "$PR_ERR")"
-            PR_URL=""
-            sleep $((pr_attempt * 3))
-          done
-          if [ -z "$PR_URL" ]; then
-            echo "::error::Failed to create PR after 3 attempts: $(cat "$PR_ERR")"
-            rm -f "$PR_ERR"
-            exit 1
-          fi
-          rm -f "$PR_ERR"
-          echo "Created changelog PR: $PR_URL"
-          BRANCH_CREATED=false  # PR owns the branch now; don't delete on exit
-
-          # Enable auto-merge so the PR lands without manual intervention
-          PR_NUM=$(echo "$PR_URL" | grep -oP '\d+$' || true)
-          if [ -n "$PR_NUM" ]; then
-            gh pr merge "$PR_NUM" --repo "$REPO" --squash --auto 2>/dev/null || echo "::warning::Auto-merge not available; PR requires manual merge"
-          fi
+          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} \
+            --repo ${{ github.repository }} --squash --auto 2>/dev/null \
+            || echo "::warning::Auto-merge not available; PR requires manual merge"

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: sync-changelog
-      cancel-in-progress: true
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,7 +46,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        # Auto-merge requires "Allow auto-merge" enabled in repo settings.
+        # If branch protection requires reviews, GITHUB_TOKEN cannot self-approve;
+        # add github-actions[bot] to the bypass list or merge changelog PRs manually.
         run: |
-          gh pr merge "$PR_NUMBER" \
-            --repo ${{ github.repository }} --squash --auto 2>/dev/null \
-            || echo "::warning::Auto-merge not available; PR requires manual merge"
+          if ! merge_output=$(gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto 2>&1); then
+            echo "::warning::Auto-merge failed: $merge_output"
+          fi

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -23,146 +23,29 @@ jobs:
           node-version: 22
 
       - name: Install tsx
-        run: |
-          npm install --no-save tsx@4.21.0
-          echo "tsx version: $(npx tsx --version)"
-          echo "node version: $(node --version)"
+        run: npm install --no-save tsx@4.21.0
 
       - name: Generate changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "::group::Running sync-changelog.ts"
-          npx tsx script/sync-changelog.ts
-          echo "::endgroup::"
-          echo "Generated file size: $(wc -c < client/src/data/changelog.ts) bytes"
-          echo "Generated file lines: $(wc -l < client/src/data/changelog.ts)"
-          echo "Local blob SHA: $(git hash-object client/src/data/changelog.ts)"
+        run: npx tsx script/sync-changelog.ts
 
-      - name: Commit changelog update
+      - name: Create changelog PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: sync changelog from GitHub releases"
+          title: "chore: sync changelog from GitHub releases"
+          body: "Auto-generated changelog update after release publication."
+          branch: chore/sync-changelog
+          delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          REPO="${{ github.repository }}"
-          LOCAL_SHA=$(git hash-object client/src/data/changelog.ts)
-          BODY_FILE=$(mktemp)
-          PAYLOAD_FILE=$(mktemp)
-          base64 -w0 client/src/data/changelog.ts > "$BODY_FILE"
-          echo "Content base64 length: $(wc -c < "$BODY_FILE") chars"
-
-          cleanup() {
-            rm -f "$BODY_FILE" "$PAYLOAD_FILE" "${DIRECT_ERR:-}"
-            if [ "${BRANCH_CREATED:-false}" = "true" ]; then
-              echo "Cleaning up branch $BRANCH"
-              timeout 5 gh api "repos/$REPO/git/refs/heads/$BRANCH" -X DELETE 2>/dev/null || true
-            fi
-          }
-          trap cleanup EXIT
-
-          # Helper: build Contents API JSON payload without shell-expanding the base64
-          build_payload() {
-            jq -n \
-              --arg msg "chore: sync changelog from GitHub releases" \
-              --rawfile content "$BODY_FILE" \
-              --arg sha "$1" \
-              --arg branch "$2" \
-              '{message: $msg, content: $content, sha: $sha, branch: $branch}' \
-              > "$PAYLOAD_FILE"
-          }
-
-          # Fetch current file SHA from GitHub (pinned to main)
-          FILE_SHA=""
-          for attempt in 1 2 3; do
-            FILE_SHA=$(gh api "repos/$REPO/contents/client/src/data/changelog.ts?ref=main" \
-              --jq '.sha' 2>/dev/null) && [ -n "$FILE_SHA" ] && [ "$FILE_SHA" != "null" ] && break
-            echo "Failed to fetch file SHA (attempt $attempt)"
-            FILE_SHA=""
-            sleep $((attempt * 2))
-          done
-          if [ -z "$FILE_SHA" ]; then
-            echo "::error::Could not fetch file SHA after 3 attempts"
-            exit 1
-          fi
-
-          # Skip if content is unchanged
-          if [ "$LOCAL_SHA" = "$FILE_SHA" ]; then
-            echo "No changelog changes needed"
-            exit 0
-          fi
-
-          echo "Changelog changed (local=$LOCAL_SHA remote=$FILE_SHA)"
-
-          # Try direct commit to main first
-          build_payload "$FILE_SHA" "main"
-          echo "Payload size: $(wc -c < "$PAYLOAD_FILE") bytes"
-          DIRECT_ERR=$(mktemp)
-          if gh api "repos/$REPO/contents/client/src/data/changelog.ts" \
-            -X PUT --input "$PAYLOAD_FILE" > /dev/null 2>"$DIRECT_ERR"; then
-            echo "Changelog committed directly to main"
-            rm -f "$DIRECT_ERR"
-            exit 0
-          fi
-          echo "::warning::Direct commit to main failed:"
-          cat "$DIRECT_ERR"
-          rm -f "$DIRECT_ERR"
-          echo "Falling back to PR..."
-
-          # Fallback: create a PR when direct push is blocked
-          BRANCH="chore/sync-changelog-$(date +%s)"
-          BRANCH_CREATED=false
-
-          # Close any existing open changelog PRs to avoid accumulation
-          EXISTING_PRS=$(gh pr list --repo "$REPO" --author "app/github-actions" --search "chore: sync changelog from GitHub releases in:title" --state open --json number --jq '.[].number' 2>/dev/null || true)
-          for pr_num in $EXISTING_PRS; do
-            echo "Closing stale changelog PR #$pr_num"
-            gh pr close "$pr_num" --repo "$REPO" --delete-branch 2>/dev/null || true
-          done
-
-          echo "Creating branch: $BRANCH"
-          MAIN_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha') || {
-            echo "::error::Failed to fetch main HEAD SHA"; exit 1; }
-          echo "main HEAD: $MAIN_SHA"
-
-          gh api "repos/$REPO/git/refs" \
-            -f ref="refs/heads/$BRANCH" \
-            -f sha="$MAIN_SHA" > /dev/null || {
-            echo "::error::Failed to create branch $BRANCH"; exit 1; }
-          BRANCH_CREATED=true
-
-          # Re-fetch file SHA pinned to the exact commit the branch was created from
-          BRANCH_FILE_SHA=$(gh api "repos/$REPO/contents/client/src/data/changelog.ts?ref=$MAIN_SHA" \
-            --jq '.sha' 2>/dev/null) || BRANCH_FILE_SHA="$FILE_SHA"
-
-          build_payload "$BRANCH_FILE_SHA" "$BRANCH"
-          gh api "repos/$REPO/contents/client/src/data/changelog.ts" \
-            -X PUT --input "$PAYLOAD_FILE" > /dev/null || {
-            echo "::error::Failed to commit changelog to branch $BRANCH"; exit 1; }
-
-          # Retry PR creation — GitHub may need time to propagate the branch/commit
-          PR_URL=""
-          PR_ERR=$(mktemp)
-          for pr_attempt in 1 2 3; do
-            PR_URL=$(gh pr create \
-              --repo "$REPO" \
-              --head "$BRANCH" \
-              --base main \
-              --title "chore: sync changelog from GitHub releases" \
-              --body "Auto-generated changelog update after release publication." 2>"$PR_ERR") && break
-            echo "PR creation attempt $pr_attempt failed: $(cat "$PR_ERR")"
-            PR_URL=""
-            sleep $((pr_attempt * 3))
-          done
-          if [ -z "$PR_URL" ]; then
-            echo "::error::Failed to create PR after 3 attempts: $(cat "$PR_ERR")"
-            rm -f "$PR_ERR"
-            exit 1
-          fi
-          rm -f "$PR_ERR"
-          echo "Created changelog PR: $PR_URL"
-          BRANCH_CREATED=false  # PR owns the branch now; don't delete on exit
-
-          # Enable auto-merge so the PR lands without manual intervention
-          PR_NUM=$(echo "$PR_URL" | grep -oP '\d+$' || true)
-          if [ -n "$PR_NUM" ]; then
-            gh pr merge "$PR_NUM" --repo "$REPO" --squash --auto 2>/dev/null || echo "::warning::Auto-merge not available; PR requires manual merge"
-          fi
+          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} \
+            --repo ${{ github.repository }} --squash --auto 2>/dev/null \
+            || echo "::warning::Auto-merge not available; PR requires manual merge"

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install tsx
         run: |
@@ -138,13 +138,23 @@ jobs:
             -X PUT --input "$PAYLOAD_FILE" > /dev/null || {
             echo "::error::Failed to commit changelog to branch $BRANCH"; exit 1; }
 
-          PR_URL=$(gh pr create \
-            --repo "$REPO" \
-            --head "$BRANCH" \
-            --base main \
-            --title "chore: sync changelog from GitHub releases" \
-            --body "Auto-generated changelog update after release publication.") || {
-            echo "::error::Failed to create PR"; exit 1; }
+          # Wait for GitHub to propagate the branch and commit before creating PR
+          PR_URL=""
+          for pr_attempt in 1 2 3; do
+            PR_URL=$(gh pr create \
+              --repo "$REPO" \
+              --head "$BRANCH" \
+              --base main \
+              --title "chore: sync changelog from GitHub releases" \
+              --body "Auto-generated changelog update after release publication." 2>/dev/null) && break
+            echo "PR creation attempt $pr_attempt failed, retrying in $((pr_attempt * 3))s..."
+            PR_URL=""
+            sleep $((pr_attempt * 3))
+          done
+          if [ -z "$PR_URL" ]; then
+            echo "::error::Failed to create PR after 3 attempts"
+            exit 1
+          fi
           echo "Created changelog PR: $PR_URL"
           BRANCH_CREATED=false  # PR owns the branch now; don't delete on exit
 

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -138,23 +138,26 @@ jobs:
             -X PUT --input "$PAYLOAD_FILE" > /dev/null || {
             echo "::error::Failed to commit changelog to branch $BRANCH"; exit 1; }
 
-          # Wait for GitHub to propagate the branch and commit before creating PR
+          # Retry PR creation — GitHub may need time to propagate the branch/commit
           PR_URL=""
+          PR_ERR=$(mktemp)
           for pr_attempt in 1 2 3; do
             PR_URL=$(gh pr create \
               --repo "$REPO" \
               --head "$BRANCH" \
               --base main \
               --title "chore: sync changelog from GitHub releases" \
-              --body "Auto-generated changelog update after release publication." 2>/dev/null) && break
-            echo "PR creation attempt $pr_attempt failed, retrying in $((pr_attempt * 3))s..."
+              --body "Auto-generated changelog update after release publication." 2>"$PR_ERR") && break
+            echo "PR creation attempt $pr_attempt failed: $(cat "$PR_ERR")"
             PR_URL=""
             sleep $((pr_attempt * 3))
           done
           if [ -z "$PR_URL" ]; then
-            echo "::error::Failed to create PR after 3 attempts"
+            echo "::error::Failed to create PR after 3 attempts: $(cat "$PR_ERR")"
+            rm -f "$PR_ERR"
             exit 1
           fi
+          rm -f "$PR_ERR"
           echo "Created changelog PR: $PR_URL"
           BRANCH_CREATED=false  # PR owns the branch now; don't delete on exit
 

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -45,7 +45,8 @@ jobs:
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} \
+          gh pr merge "$PR_NUMBER" \
             --repo ${{ github.repository }} --squash --auto 2>/dev/null \
             || echo "::warning::Auto-merge not available; PR requires manual merge"

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -46,10 +46,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
         # Auto-merge requires "Allow auto-merge" enabled in repo settings.
         # If branch protection requires reviews, GITHUB_TOKEN cannot self-approve;
         # add github-actions[bot] to the bypass list or merge changelog PRs manually.
         run: |
-          if ! merge_output=$(gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto 2>&1); then
+          if ! merge_output=$(gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --auto 2>&1); then
             echo "::warning::Auto-merge failed: $merge_output"
           fi


### PR DESCRIPTION
## Summary

The sync-changelog CI job was failing with "Process completed with exit code 1" and "Failed to create PR", plus 8 warnings on every release workflow run. This PR replaces the fragile ~120-line shell script (which juggled 3 GitHub APIs with race conditions) with `peter-evans/create-pull-request@v7`, upgrades Node.js 20 → 22, and adds several hardening measures surfaced during review.

## Changes

**Sync-changelog simplification**
- Replace manual Contents API / Refs API / `gh pr create` shell script with `peter-evans/create-pull-request@v7` in both `release.yml` and `sync-changelog.yml`
- Eliminates race condition between branch creation and PR creation that caused the "Failed to create PR" errors
- Fixed branch name `chore/sync-changelog` prevents stale PR accumulation (old approach created unique branches per run)

**Node.js upgrade**
- Upgrade `node-version: 20` → `22` in all `setup-node` steps (3 occurrences) to resolve deprecation warnings

**Release-drafter warnings**
- Add `disable-autolabeler: true` to release-drafter step in `release.yml` — autolabeling is handled by `label-prs.yml`, not needed during draft updates; eliminates 4 `pull_request_target.*` warnings

**Security & hardening (from review phases)**
- Pass `steps.cpr.outputs.pull-request-number` via env var `PR_NUMBER` instead of direct `${{ }}` expression in `run:` block (defense-in-depth against GitHub Actions expression injection)
- Filter `github-actions[bot]` PRs from release-drafter trigger to prevent feedback loop (changelog merge re-triggering draft update)
- Capture `gh pr merge` stderr instead of swallowing with `2>/dev/null`
- Change `cancel-in-progress: false` so sync-changelog runs complete rather than getting killed between PR creation and auto-merge enablement
- Add comments documenting `disable-autolabeler` rationale and auto-merge prerequisites

## How to test

1. **Verify workflow YAML is valid**: Check that the Actions tab shows no syntax errors on the branch
2. **Trigger sync-changelog manually**: Run the `Sync Changelog` workflow via `workflow_dispatch` — it should either create a `chore/sync-changelog` PR or no-op if the changelog is already up to date
3. **Merge a PR to main**: After merge, verify `release.yml` runs, release-drafter has no `pull_request_target` warnings, and Node.js 20 deprecation warnings are gone
4. **Verify feedback loop fix**: When the changelog PR auto-merges, the resulting `pull_request: closed` event should NOT trigger a new release-drafter run (filtered by `github-actions[bot]` check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release and changelog automation reliability and gating so drafts run only for merged PRs (excluding bot-created PRs).
  * Upgraded CI Node.js runtime from 20 to 22.
  * Simplified changelog generation and made sync runs non-canceling to reduce interruptions.
  * Switched to PR-based changelog updates with automatic branch cleanup and streamlined auto-merge with failure warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->