### PR TITLE
fix: resolve four open bugs (#394, #396, #397, #399)

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -15,5 +15,6 @@ jobs:
       - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
+          disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/extension/src/content/picker.ts
+++ b/extension/src/content/picker.ts
@@ -138,6 +138,7 @@ interface Candidate {
 
 function findCandidates(): Candidate[] {
   const scored = new Map<Element, number>();
+  const elementBonusApplied = new Set<Element>();
 
   const priceRegex = /[$\u20AC\u00A3][\d,]+\.?\d*/;
   const currencyRegex = /\d+(\.\d+)?\s*(USD|EUR|GBP|CAD|AUD)/i;
@@ -171,29 +172,35 @@ function findCandidates(): Candidate[] {
 
     let score = scored.get(el) || 0;
 
+    // Text-node-level bonuses (applied per text node)
     if (priceRegex.test(text) || currencyRegex.test(text)) score += 3;
     if (stockRegex.test(text)) score += 2;
 
-    const classList = typeof el.className === "string" ? el.className : "";
-    if (classRegex.test(classList)) score += 2;
+    // Element-level bonuses (applied once per element)
+    if (!elementBonusApplied.has(el)) {
+      elementBonusApplied.add(el);
 
-    for (const attr of Array.from(el.attributes)) {
-      if (attr.name.startsWith("data-") && dataAttrRegex.test(attr.name)) {
-        score += 2;
-        break;
+      const classList = typeof el.className === "string" ? el.className : "";
+      if (classRegex.test(classList)) score += 2;
+
+      for (const attr of Array.from(el.attributes)) {
+        if (attr.name.startsWith("data-") && dataAttrRegex.test(attr.name)) {
+          score += 2;
+          break;
+        }
       }
-    }
 
-    if (el.id && idRegex.test(el.id)) score += 1;
+      if (el.id && idRegex.test(el.id)) score += 1;
 
-    // Prefer shallower elements
-    let depth = 0;
-    let parent = el.parentElement;
-    while (parent && parent !== document.body) {
-      depth++;
-      parent = parent.parentElement;
+      // Prefer shallower elements
+      let depth = 0;
+      let parent = el.parentElement;
+      while (parent && parent !== document.body) {
+        depth++;
+        parent = parent.parentElement;
+      }
+      score -= Math.floor(depth / 5);
     }
-    score -= Math.floor(depth / 5);
 
     if (score > (scored.get(el) || 0)) {
       scored.set(el, score);

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -464,6 +464,12 @@ function renderAuthenticated(): void {
 
   // Pick element button
   document.getElementById("pick-btn")?.addEventListener("click", () => {
+    if (!currentTabUrl.startsWith("http://") && !currentTabUrl.startsWith("https://")) {
+      errorMessage = "The picker only works on web pages (http/https). Try navigating to a website first.";
+      state = "error";
+      render();
+      return;
+    }
     chrome.runtime.sendMessage({ type: MSG.START_PICKER, tabId: currentTabId });
     state = "picking";
     render();

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -465,9 +465,16 @@ function renderAuthenticated(): void {
   // Pick element button
   document.getElementById("pick-btn")?.addEventListener("click", () => {
     if (!currentTabUrl.startsWith("http://") && !currentTabUrl.startsWith("https://")) {
-      errorMessage = "The picker only works on web pages (http/https). Try navigating to a website first.";
-      state = "error";
-      render();
+      // Show inline warning without leaving authenticated state — the global
+      // "error" state renders "Couldn't create monitor" which is misleading here.
+      const pickBtn = document.getElementById("pick-btn");
+      const existing = document.querySelector(".ftc-picker-warning");
+      if (existing) existing.remove();
+      const warning = document.createElement("div");
+      warning.className = "ftc-picker-warning";
+      warning.style.cssText = "color: #f59e0b; font-size: 13px; margin-top: 8px; padding: 8px; border-radius: 6px; background: rgba(245,158,11,0.1);";
+      warning.textContent = "The picker only works on web pages (http/https). Navigate to a website first.";
+      pickBtn?.after(warning);
       return;
     }
     chrome.runtime.sendMessage({ type: MSG.START_PICKER, tabId: currentTabId });

--- a/server/index.ts
+++ b/server/index.ts
@@ -415,6 +415,9 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
     // Wait for in-flight monitor checks to finish (up to 5s)
     const { waitForActiveChecks } = await import("./services/scheduler");
     await waitForActiveChecks(5000);
+    // Clear pending jittered timeouts so no new checks start during HTTP close
+    console.log("Stopping scheduler...");
+    stopScheduler();
     // Stop accepting new connections and wait for in-flight requests to finish
     console.log("Closing HTTP server...");
     await new Promise<void>((resolve) => {
@@ -432,9 +435,8 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
         }
       }, 9_000).unref();
     });
-    // Stop cron jobs and intervals before closing DB pool
-    console.log("Stopping scheduler and timers...");
-    stopScheduler();
+    // Stop route timers before closing DB pool
+    console.log("Stopping route timers...");
     stopRouteTimers();
     // Drain warm browsers
     let cleanupFailed = false;


### PR DESCRIPTION
## Summary

Fixes all four open GitHub issues in a single batch. These are all low-severity bugs affecting the CI workflow, Chrome extension element picker, popup UX on non-HTTP tabs, and graceful shutdown ordering.

Closes #394, closes #396, closes #397, closes #399.

## Changes

**CI / Workflows**
- `.github/workflows/label-prs.yml`: Add `disable-releaser: true` to the release-drafter step so autolabeling PRs no longer creates/updates draft releases as a side effect (#399)

**Chrome extension — element picker scoring**
- `extension/src/content/picker.ts`: Introduce an `elementBonusApplied` Set in `findCandidates()` so element-level bonuses (CSS class regex +2, data-attribute regex +2, ID regex +1) and the depth penalty are applied once per element, not once per text node. Text-node-level bonuses (price/currency/stock regex) are still applied per text node as before (#397)

**Chrome extension — popup picker on non-HTTP tabs**
- `extension/src/popup/popup.ts`: Check `currentTabUrl` before sending `START_PICKER` to the service worker. If the active tab is not `http://` or `https://` (e.g. `chrome://`, `about:blank`, `file://`), show an error message instead of silently entering the stuck "picking" state (#396)

**Server — graceful shutdown ordering**
- `server/index.ts`: Move `stopScheduler()` to run immediately after `waitForActiveChecks()` resolves, before the HTTP server close begins. Previously, jittered `trackTimeout` callbacks (0–30s random delay) could fire during the HTTP server close window and start new monitor checks whose DB queries would race against `dbPool.end()` (#394)

## How to test

**#399 — label-prs.yml**
1. Open any PR and check the "Label PRs" workflow run.
2. Verify the step passes and labels are applied.
3. Verify the repository's draft releases are **not** updated by this workflow (only `release.yml` on merge should update them).

**#397 — picker scoring**
1. Navigate to a page with a price element that has multiple text nodes (e.g. `<span class="price">$<span>29.99</span></span>`).
2. Open the extension popup — the candidates list should show the element with a correct score (class bonus counted once, not per text node).

**#396 — picker on non-HTTP tabs**
1. Navigate to `chrome://extensions` or `about:blank`.
2. Open the extension popup and click "Pick an element on this page".
3. Verify an error message appears: "The picker only works on web pages (http/https)."
4. Verify the popup does **not** enter the "picking" state.

**#394 — shutdown ordering**
1. Start the server with active monitors due for a check.
2. Send `SIGTERM` while jittered timeouts are pending.
3. Verify logs show "Stopping scheduler..." immediately after active checks drain, before "Closing HTTP server...".
4. Verify no "Cannot use a pool after calling end" errors appear.

https://claude.ai/code/session_01M7J3CtXfaa2uPxMa4rXKUp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Picker now validates page URLs and shows a warning on non-HTTP(S) pages to prevent errors
  * Improved element detection scoring in the picker for more accurate candidate selection
  * Optimized graceful shutdown to ensure pending operations are cleared before stopping

* **Chores**
  * Temporarily disabled automated release drafting in CI workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->