### PR TITLE
fix: support extension JWT auth in rate limiter middleware

### DIFF
--- a/server/middleware/rateLimiter.test.ts
+++ b/server/middleware/rateLimiter.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Response, NextFunction } from "express";
+
+// Mock authStorage before importing the module under test
+const mockGetUser = vi.fn();
+vi.mock("../replit_integrations/auth/storage", () => ({
+  authStorage: { getUser: (...args: any[]) => mockGetUser(...args) },
+}));
+
+// Import after mocks are set up
+import {
+  generalRateLimiter,
+  createMonitorRateLimiter,
+  checkMonitorRateLimiter,
+} from "./rateLimiter";
+
+function mockReq(overrides: Record<string, any> = {}): any {
+  return {
+    ip: "127.0.0.1",
+    headers: {},
+    params: {},
+    ...overrides,
+  };
+}
+
+function mockRes(): any {
+  const res: any = {
+    _status: 0,
+    _json: null,
+    headersSent: false,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(data: any) {
+      res._json = data;
+      return res;
+    },
+    setHeader() { return res; },
+    getHeader() { return undefined; },
+    set() { return res; },
+    get() { return undefined; },
+  };
+  return res;
+}
+
+describe("rate limiter middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ id: "user-1", tier: "free" });
+  });
+
+  describe("resolveUserId (tested via middleware)", () => {
+    it("returns 401 when neither req.user nor req.extensionUser is set", async () => {
+      const req = mockReq();
+      const res = mockRes();
+      const next = vi.fn();
+
+      await generalRateLimiter(req, res, next);
+
+      expect(res._status).toBe(401);
+      expect(res._json).toEqual({ message: "Unauthorized" });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("authenticates via req.extensionUser (extension JWT)", async () => {
+      const req = mockReq({ extensionUser: { id: "ext-user-1", tier: "pro" } });
+      const res = mockRes();
+      const next = vi.fn();
+
+      await generalRateLimiter(req, res, next);
+
+      expect(mockGetUser).toHaveBeenCalledWith("ext-user-1");
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("authenticates via req.user.claims.sub (session auth)", async () => {
+      const req = mockReq({ user: { claims: { sub: "session-user-1" } } });
+      const res = mockRes();
+      const next = vi.fn();
+
+      await createMonitorRateLimiter(req, res, next);
+
+      expect(mockGetUser).toHaveBeenCalledWith("session-user-1");
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("prefers extensionUser over session user when both are present", async () => {
+      const req = mockReq({
+        extensionUser: { id: "ext-user", tier: "pro" },
+        user: { claims: { sub: "session-user" } },
+      });
+      const res = mockRes();
+      const next = vi.fn();
+
+      await generalRateLimiter(req, res, next);
+
+      expect(mockGetUser).toHaveBeenCalledWith("ext-user");
+    });
+
+    it("does not throw when req.user exists but claims is undefined", async () => {
+      // This was the original crash scenario — req.user set by a stale session
+      // without the claims property.
+      const req = mockReq({ user: {} });
+      const res = mockRes();
+      const next = vi.fn();
+
+      await generalRateLimiter(req, res, next);
+
+      expect(res._status).toBe(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when req.user.claims exists but sub is undefined", async () => {
+      const req = mockReq({ user: { claims: {} } });
+      const res = mockRes();
+      const next = vi.fn();
+
+      await generalRateLimiter(req, res, next);
+
+      expect(res._status).toBe(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getUserTier DB error handling", () => {
+    it("defaults to free tier when DB lookup fails", async () => {
+      mockGetUser.mockRejectedValue(new Error("connection timeout"));
+
+      const req = mockReq({ extensionUser: { id: "user-1", tier: "pro" } });
+      const res = mockRes();
+      const next = vi.fn();
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await generalRateLimiter(req, res, next);
+
+      // Should still call next (using free tier limits, not crash)
+      expect(next).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[RateLimiter] DB lookup failed"),
+        expect.stringContaining("connection timeout"),
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("checkMonitorRateLimiter keyGenerator", () => {
+    it("uses extensionUser ID in rate limit key", async () => {
+      const req = mockReq({
+        extensionUser: { id: "ext-user-1", tier: "free" },
+        params: { id: "42" },
+      });
+      const res = mockRes();
+      const next = vi.fn();
+
+      await checkMonitorRateLimiter(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/middleware/rateLimiter.ts
+++ b/server/middleware/rateLimiter.ts
@@ -45,17 +45,27 @@ function getOrCreateLimiter(key: string, config: TierConfig, message: string, ti
   return limiters.get(cacheKey)!;
 }
 
+/**
+ * Extracts userId from either session auth (req.user.claims.sub) or
+ * extension JWT auth (req.extensionUser.id).
+ */
+function resolveUserId(req: any): string | null {
+  if (req.extensionUser?.id) return req.extensionUser.id;
+  if (req.user?.claims?.sub) return req.user.claims.sub;
+  return null;
+}
+
 function createTieredRateLimiter(name: string, config: TieredRateLimiterConfig) {
   return async (req: any, res: Response, next: NextFunction) => {
-    if (!req.user) {
+    const userId = resolveUserId(req);
+    if (!userId) {
       return res.status(401).json({ message: "Unauthorized" });
     }
 
-    const userId = req.user.claims.sub;
     const tier = await getUserTier(userId);
     const tierConfig = config[tier];
 
-    const keyGen = config.keyGenerator || ((r: any) => r.user.claims.sub);
+    const keyGen = config.keyGenerator || ((r: any) => resolveUserId(r) || "unknown");
     const limiter = getOrCreateLimiter(name, tierConfig, config.message, tier, keyGen);
 
     return limiter(req, res, next);
@@ -82,7 +92,7 @@ export const checkMonitorRateLimiter = createTieredRateLimiter("checkMonitor", {
   power: { max: 500, windowMs: 60 * 60 * 1000 },
   message: "Free tier: You can check each monitor once per 24 hours. Upgrade to Pro for more frequent checks.",
   keyGenerator: (req: any) => {
-    const userId = req.user.claims.sub;
+    const userId = resolveUserId(req) || "unknown";
     const monitorId = req.params.id;
     return `${userId}:${monitorId}`;
   }

--- a/server/middleware/rateLimiter.ts
+++ b/server/middleware/rateLimiter.ts
@@ -71,7 +71,8 @@ function createTieredRateLimiter(name: string, config: TieredRateLimiterConfig) 
     const tier = await getUserTier(userId);
     const tierConfig = config[tier];
 
-    const keyGen = config.keyGenerator || ((r: any) => resolveUserId(r) || "unknown");
+    // Use userId (already validated above) as fallback to avoid a shared "unknown" bucket
+    const keyGen = config.keyGenerator || ((r: any) => resolveUserId(r) || `anon:${r.ip}`);
     const limiter = getOrCreateLimiter(name, tierConfig, config.message, tier, keyGen);
 
     return limiter(req, res, next);
@@ -98,7 +99,7 @@ export const checkMonitorRateLimiter = createTieredRateLimiter("checkMonitor", {
   power: { max: 500, windowMs: 60 * 60 * 1000 },
   message: "Free tier: You can check each monitor once per 24 hours. Upgrade to Pro for more frequent checks.",
   keyGenerator: (req: any) => {
-    const userId = resolveUserId(req) || "unknown";
+    const userId = resolveUserId(req) || `anon:${req.ip}`;
     const monitorId = req.params.id;
     return `${userId}:${monitorId}`;
   }

--- a/server/middleware/rateLimiter.ts
+++ b/server/middleware/rateLimiter.ts
@@ -4,8 +4,14 @@ import { authStorage } from "../replit_integrations/auth/storage";
 import { type UserTier } from "@shared/models/auth";
 
 async function getUserTier(userId: string): Promise<UserTier> {
-  const user = await authStorage.getUser(userId);
-  return (user?.tier || "free") as UserTier;
+  try {
+    const user = await authStorage.getUser(userId);
+    return (user?.tier || "free") as UserTier;
+  } catch (err) {
+    console.warn("[RateLimiter] DB lookup failed, defaulting to free tier:",
+      err instanceof Error ? err.message : String(err));
+    return "free";
+  }
 }
 
 interface TierConfig {

--- a/server/routes/extension.ts
+++ b/server/routes/extension.ts
@@ -75,17 +75,14 @@ router.get("/verify", extensionAuth, async (req: any, res) => {
 router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: any, res) => {
   try {
     const { id: userId, tier: tokenTier } = req.extensionUser!;
-    console.log(`[Extension] POST /monitors — userId=${userId}, tokenTier=${tokenTier}, body keys=${Object.keys(req.body || {}).join(",")}`);
 
     // Fetch fresh user data for tier (may have changed since token was issued)
     const user = await authStorage.getUser(userId);
     const tier = (user?.tier || tokenTier || "free") as UserTier;
-    console.log(`[Extension] POST /monitors — resolved tier=${tier}`);
 
     // Tier limit check
     const limitErr = await checkMonitorLimit(userId, tier);
     if (limitErr) {
-      console.log(`[Extension] POST /monitors — tier limit reached: ${limitErr.code}`);
       return res.status(limitErr.status).json({
         message: limitErr.error,
         code: limitErr.code,
@@ -94,7 +91,6 @@ router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: an
 
     // Validate input
     const input = api.monitors.create.input.parse(req.body);
-    console.log(`[Extension] POST /monitors — input parsed: url=${safeHostname(input.url)}, selector=${(input.selector || "").slice(0, 80)}, freq=${input.frequency}`);
 
     // Frequency tier check
     const freqErr = checkFrequencyTier(input.frequency, tier);
@@ -108,11 +104,9 @@ router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: an
       if (validationErr.code === "SSRF_BLOCKED") {
         console.warn(`[Extension] SSRF blocked for userId=${userId}, hostname=${safeHostname(input.url)}`);
       }
-      console.log(`[Extension] POST /monitors — validation error: ${validationErr.code}`);
       return res.status(validationErr.status).json({ message: validationErr.error, code: validationErr.code });
     }
 
-    console.log(`[Extension] POST /monitors — inserting into DB...`);
     const monitor = await storage.createMonitor({
       ...input,
       userId,
@@ -129,7 +123,6 @@ router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: an
     res.status(201).json(monitor);
   } catch (error: any) {
     if (error.name === "ZodError") {
-      console.warn("[Extension] POST /monitors — ZodError:", error.errors);
       return res.status(400).json({ message: "Invalid input", errors: error.errors });
     }
     console.error("[Extension] Monitor creation error:", error);

--- a/server/routes/extension.ts
+++ b/server/routes/extension.ts
@@ -47,12 +47,7 @@ router.post("/token", isAuthenticated, async (req: any, res) => {
   } catch (error: any) {
     const detail = error instanceof Error ? error.message : String(error);
     console.error("[Extension] Failed to issue token:", detail);
-    // Surface config errors to help operators diagnose; redact everything
-    // else to avoid leaking DB connection strings or internal paths.
-    const safeMsg = detail.includes("EXTENSION_JWT_SECRET")
-      ? "Extension signing key not configured. Contact the site administrator."
-      : "Failed to generate extension token";
-    res.status(500).json({ message: safeMsg });
+    res.status(500).json({ message: "Failed to generate extension token" });
   }
 });
 
@@ -76,9 +71,16 @@ router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: an
   try {
     const { id: userId, tier: tokenTier } = req.extensionUser!;
 
-    // Fetch fresh user data for tier (may have changed since token was issued)
-    const user = await authStorage.getUser(userId);
-    const tier = (user?.tier || tokenTier || "free") as UserTier;
+    // Fetch fresh user data for tier (may have changed since token was issued).
+    // Non-fatal: fall back to the JWT-embedded tier if the DB is slow/timing out.
+    let tier: UserTier = (tokenTier || "free") as UserTier;
+    try {
+      const user = await authStorage.getUser(userId);
+      tier = (user?.tier || tokenTier || "free") as UserTier;
+    } catch (dbErr) {
+      console.warn("[Extension] DB lookup failed for monitor creation, using token tier:",
+        dbErr instanceof Error ? dbErr.message : String(dbErr));
+    }
 
     // Tier limit check
     const limitErr = await checkMonitorLimit(userId, tier);

--- a/server/routes/extension.ts
+++ b/server/routes/extension.ts
@@ -47,7 +47,7 @@ router.post("/token", isAuthenticated, async (req: any, res) => {
   } catch (error: any) {
     const detail = error instanceof Error ? error.message : String(error);
     console.error("[Extension] Failed to issue token:", detail);
-    res.status(500).json({ message: "Failed to generate extension token" });
+    res.status(500).json({ message: "Failed to generate extension token", code: "TOKEN_GENERATION_FAILED" });
   }
 });
 

--- a/server/routes/extension.ts
+++ b/server/routes/extension.ts
@@ -75,14 +75,17 @@ router.get("/verify", extensionAuth, async (req: any, res) => {
 router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: any, res) => {
   try {
     const { id: userId, tier: tokenTier } = req.extensionUser!;
+    console.log(`[Extension] POST /monitors — userId=${userId}, tokenTier=${tokenTier}, body keys=${Object.keys(req.body || {}).join(",")}`);
 
     // Fetch fresh user data for tier (may have changed since token was issued)
     const user = await authStorage.getUser(userId);
     const tier = (user?.tier || tokenTier || "free") as UserTier;
+    console.log(`[Extension] POST /monitors — resolved tier=${tier}`);
 
     // Tier limit check
     const limitErr = await checkMonitorLimit(userId, tier);
     if (limitErr) {
+      console.log(`[Extension] POST /monitors — tier limit reached: ${limitErr.code}`);
       return res.status(limitErr.status).json({
         message: limitErr.error,
         code: limitErr.code,
@@ -91,6 +94,7 @@ router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: an
 
     // Validate input
     const input = api.monitors.create.input.parse(req.body);
+    console.log(`[Extension] POST /monitors — input parsed: url=${safeHostname(input.url)}, selector=${(input.selector || "").slice(0, 80)}, freq=${input.frequency}`);
 
     // Frequency tier check
     const freqErr = checkFrequencyTier(input.frequency, tier);
@@ -104,9 +108,11 @@ router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: an
       if (validationErr.code === "SSRF_BLOCKED") {
         console.warn(`[Extension] SSRF blocked for userId=${userId}, hostname=${safeHostname(input.url)}`);
       }
+      console.log(`[Extension] POST /monitors — validation error: ${validationErr.code}`);
       return res.status(validationErr.status).json({ message: validationErr.error, code: validationErr.code });
     }
 
+    console.log(`[Extension] POST /monitors — inserting into DB...`);
     const monitor = await storage.createMonitor({
       ...input,
       userId,
@@ -123,6 +129,7 @@ router.post("/monitors", extensionAuth, createMonitorRateLimiter, async (req: an
     res.status(201).json(monitor);
   } catch (error: any) {
     if (error.name === "ZodError") {
+      console.warn("[Extension] POST /monitors — ZodError:", error.errors);
       return res.status(400).json({ message: "Invalid input", errors: error.errors });
     }
     console.error("[Extension] Monitor creation error:", error);


### PR DESCRIPTION
## Summary

The Chrome extension's "Create monitor" flow returned a 500 "Internal server error" because the rate limiter middleware assumed session auth (`req.user.claims.sub`) which doesn't exist on extension routes that use JWT auth (`req.extensionUser.id`). This PR fixes the rate limiter to support both auth patterns and hardens the extension endpoints against DB timeouts.

## Changes

**Rate limiter (`server/middleware/rateLimiter.ts`)**
- Add `resolveUserId()` helper that checks `req.extensionUser?.id` first, then `req.user?.claims?.sub` — supports both extension JWT and session auth
- Wrap `getUserTier()` in try/catch defaulting to "free" tier on DB errors (prevents 500s during DB degradation)
- Replace `"unknown"` rate limit key fallback with `"anon:<ip>"` to prevent cross-user shared bucket interference
- Update `checkMonitorRateLimiter` custom keyGenerator to use `resolveUserId()`

**Extension routes (`server/routes/extension.ts`)**
- Wrap `/monitors` POST DB tier lookup in nested try/catch with JWT-embedded tier fallback (mirrors `/token` endpoint pattern)
- Remove `EXTENSION_JWT_SECRET` config key name from client-facing error messages
- Remove verbose debug `console.log` statements added during investigation

**Tests (`server/middleware/rateLimiter.test.ts`)**
- New test file with 8 tests covering: both auth patterns, extensionUser priority, stale session edge cases (missing `claims`, missing `sub`), DB error fallback, and custom keyGenerator with extension auth

## How to test

1. Install the Chrome extension (v1.0.7) and connect your account
2. Navigate to any webpage and pick an element to track
3. Click "Create monitor" — should succeed (previously returned "Internal server error")
4. Verify the monitor appears in the dashboard
5. Run `npm run check && npm run test` — 89 test files, 2262 tests pass

https://claude.ai/code/session_01845UaSacYVNae1VyF6YG7Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for rate limiting when database lookups fail; services now gracefully degrade with fallback tier assignments instead of returning errors.
  * Monitor creation can now proceed when database is slow or temporarily unavailable.
  * Rate limiting now correctly handles missing authentication data and returns appropriate authorization errors.

* **Tests**
  * Added comprehensive test coverage for rate-limiter middleware authentication resolution, error handling, and database failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->