### PR TITLE
fix: prevent sync-changelog feedback loop and orphaned branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
-       github.event.pull_request.user.login != 'github-actions[bot]')
+       github.event.pull_request.user.login != 'github-actions[bot]' &&
+       github.event.pull_request.head.ref != 'chore/sync-changelog')
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.drafter.outputs.tag_name }}
@@ -121,6 +122,18 @@ jobs:
             git commit -m "chore: sync changelog from GitHub releases"
             git pull --rebase origin main
             git push origin HEAD:main
+          fi
+
+      - name: Clean up orphaned branch
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Delete the chore/sync-changelog branch if no open PR references it.
+          # Prevents orphaned branches from accumulating after partial failures.
+          if ! gh pr list --repo "$REPO" --head chore/sync-changelog --state open --json number --jq '.[0].number' | grep -q .; then
+            git push origin --delete chore/sync-changelog 2>/dev/null && echo "Deleted orphaned branch" || echo "Branch already gone"
           fi
 
       - name: Enable auto-merge

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -57,6 +57,18 @@ jobs:
             git push origin HEAD:main
           fi
 
+      - name: Clean up orphaned branch
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Delete the chore/sync-changelog branch if no open PR references it.
+          # Prevents orphaned branches from accumulating after partial failures.
+          if ! gh pr list --repo "$REPO" --head chore/sync-changelog --state open --json number --jq '.[0].number' | grep -q .; then
+            git push origin --delete chore/sync-changelog 2>/dev/null && echo "Deleted orphaned branch" || echo "Branch already gone"
+          fi
+
       - name: Enable auto-merge
         if: steps.cpr.outcome == 'success' && steps.cpr.outputs.pull-request-number
         env:


### PR DESCRIPTION
## Summary

Merging a changelog PR (e.g. PR #410) triggered the full release pipeline because the PR author was `bd73-com`, not `github-actions[bot]`. The release pipeline published a release, which ran sync-changelog again, which recreated the `chore/sync-changelog` branch — but with no PR attached. This left an orphaned branch that appeared to "come back from the dead" after deletion.

## Changes

**Feedback loop prevention (`release.yml`)**
- Added `github.event.pull_request.head.ref != 'chore/sync-changelog'` to the `update-release-draft` job condition, so merging a changelog PR never triggers the release → publish → sync-changelog chain

**Orphan branch cleanup (`release.yml` + `sync-changelog.yml`)**
- Added a `Clean up orphaned branch` step (runs `always()`) to both workflow files
- Checks if any open PR references `chore/sync-changelog`; if not, deletes the branch
- Prevents dangling branches from accumulating when `peter-evans/create-pull-request` creates a branch but PR creation fails (due to `continue-on-error: true`) or when no changes are detected

## How to test

1. Verify the `release.yml` trigger condition now has three checks: `merged == true`, `user.login != 'github-actions[bot]'`, and `head.ref != 'chore/sync-changelog'`
2. Verify both `release.yml` and `sync-changelog.yml` have the new "Clean up orphaned branch" step positioned between "Direct commit fallback" and "Enable auto-merge"
3. Confirm the cleanup step uses `gh pr list --head chore/sync-changelog --state open` to check for open PRs before deleting
4. To fully validate: merge a changelog PR and confirm the release pipeline does **not** trigger (check Actions tab — no new "Release Drafter" run should appear for that merge)

https://claude.ai/code/session_01DwdSioFyQqSgXaNqoW7zRw