### PR TITLE
fix: extension prefill URL lost during loading skeleton

### DIFF
--- a/client/src/components/CreateMonitorDialog.test.tsx
+++ b/client/src/components/CreateMonitorDialog.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../test/test-utils";
+import { CreateMonitorDialog } from "./CreateMonitorDialog";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ReactElement } from "react";
+
+// Radix UI Switch uses ResizeObserver which jsdom doesn't provide
+beforeAll(() => {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any;
+});
+
+// Mock useAuth to provide a user with tier info
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: { id: "user1", tier: "free", email: "test@example.com" } }),
+}));
+
+function renderDialog(ui: ReactElement) {
+  return renderWithProviders(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+describe("CreateMonitorDialog", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the trigger button", () => {
+    renderDialog(<CreateMonitorDialog />);
+    expect(screen.getByText("Add Page")).toBeInTheDocument();
+  });
+
+  it("pre-fills form fields when initialValues and externalOpen are provided", async () => {
+    const initialValues = {
+      url: "https://example.com/page",
+      selector: ".price-tag",
+      name: "Test Monitor",
+    };
+
+    renderDialog(
+      <CreateMonitorDialog
+        initialValues={initialValues}
+        externalOpen={true}
+        onExternalOpenChange={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Monitor New Page")).toBeInTheDocument();
+    });
+
+    const urlInput = screen.getByPlaceholderText("https://example.com/monitoring") as HTMLInputElement;
+    const nameInput = screen.getByPlaceholderText("Monitor name") as HTMLInputElement;
+    const selectorInput = screen.getByPlaceholderText(".price-tag or #main-content") as HTMLInputElement;
+
+    expect(urlInput.value).toBe("https://example.com/page");
+    expect(selectorInput.value).toBe(".price-tag");
+    expect(nameInput.value).toBe("Test Monitor");
+  });
+
+  it("opens the dialog when externalOpen is true", async () => {
+    renderDialog(
+      <CreateMonitorDialog
+        externalOpen={true}
+        onExternalOpenChange={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Monitor New Page")).toBeInTheDocument();
+    });
+  });
+
+  it("does not open the dialog when externalOpen is undefined", () => {
+    renderDialog(<CreateMonitorDialog />);
+    expect(screen.queryByText("Monitor New Page")).not.toBeInTheDocument();
+  });
+
+  it("calls onExternalOpenChange when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onExternalOpenChange = vi.fn();
+
+    renderDialog(
+      <CreateMonitorDialog
+        initialValues={{ url: "https://example.com", selector: ".test" }}
+        externalOpen={true}
+        onExternalOpenChange={onExternalOpenChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Monitor New Page")).toBeInTheDocument();
+    });
+
+    // Click the Cancel button
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onExternalOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/client/src/components/CreateMonitorDialog.test.tsx
+++ b/client/src/components/CreateMonitorDialog.test.tsx
@@ -23,6 +23,23 @@ vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ user: { id: "user1", tier: "free", email: "test@example.com" } }),
 }));
 
+// Mutable mock for useCreateMonitor — default passes through real behavior,
+// individual tests can override via mockMutateFn.
+let mockMutateFn: ((...args: any[]) => void) | null = null;
+vi.mock("@/hooks/use-monitors", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("@/hooks/use-monitors")>();
+  return {
+    ...orig,
+    useCreateMonitor: () => ({
+      mutate: (...args: any[]) => {
+        if (mockMutateFn) return mockMutateFn(...args);
+        return orig.useCreateMonitor().mutate(...(args as [any]));
+      },
+      isPending: false,
+    }),
+  };
+});
+
 function renderDialog(ui: ReactElement) {
   return renderWithProviders(<TooltipProvider>{ui}</TooltipProvider>);
 }
@@ -30,6 +47,7 @@ function renderDialog(ui: ReactElement) {
 describe("CreateMonitorDialog", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    mockMutateFn = null;
   });
 
   it("renders the trigger button", () => {
@@ -81,6 +99,40 @@ describe("CreateMonitorDialog", () => {
   it("does not open the dialog when externalOpen is undefined", () => {
     renderDialog(<CreateMonitorDialog />);
     expect(screen.queryByText("Monitor New Page")).not.toBeInTheDocument();
+  });
+
+  it("calls onExternalOpenChange(false) on successful creation", async () => {
+    let capturedOnSuccess: (() => void) | null = null;
+    mockMutateFn = vi.fn((_data: any, opts: any) => {
+      capturedOnSuccess = () => opts.onSuccess({ monitor: { id: 1 }, selectorWarning: null });
+    });
+
+    const user = userEvent.setup();
+    const onExternalOpenChange = vi.fn();
+
+    renderDialog(
+      <CreateMonitorDialog
+        initialValues={{ url: "https://example.com", selector: ".test", name: "Test" }}
+        externalOpen={true}
+        onExternalOpenChange={onExternalOpenChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Monitor New Page")).toBeInTheDocument();
+    });
+
+    // Submit the form
+    await user.click(screen.getByRole("button", { name: "Create Monitor" }));
+
+    // mutate should have been called
+    expect(mockMutateFn).toHaveBeenCalled();
+
+    // Simulate server success
+    capturedOnSuccess?.();
+
+    // The success handler should call handleOpenChange(false) → onExternalOpenChange(false)
+    expect(onExternalOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("calls onExternalOpenChange when Cancel is clicked", async () => {

--- a/client/src/components/CreateMonitorDialog.tsx
+++ b/client/src/components/CreateMonitorDialog.tsx
@@ -110,9 +110,7 @@ export function CreateMonitorDialog({ initialValues, externalOpen, onExternalOpe
             },
           });
         }
-        setOpen(false);
-        form.reset();
-        setSelectedTagIds([]);
+        handleOpenChange(false);
       },
     });
   };

--- a/client/src/pages/Dashboard.test.ts
+++ b/client/src/pages/Dashboard.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+
+/**
+ * Extract the prefill-param parsing logic from Dashboard so it can be unit-tested
+ * without mounting the full component (which has many provider dependencies).
+ *
+ * This mirrors the useMemo in Dashboard.tsx that reads ?url=&selector=&name=
+ * query params from the URL when the extension opens the dashboard.
+ */
+function parsePrefillParams(searchString: string) {
+  const params = new URLSearchParams(searchString);
+  if (params.has("checkout")) return null;
+  const url = params.get("url");
+  if (!url) return null;
+  return {
+    url,
+    selector: params.get("selector") || undefined,
+    name: params.get("name") || undefined,
+  };
+}
+
+describe("Dashboard prefill param parsing", () => {
+  it("extracts url, selector, and name from query string", () => {
+    const result = parsePrefillParams("?url=https%3A%2F%2Fexample.com&selector=.price&name=My+Monitor");
+    expect(result).toEqual({
+      url: "https://example.com",
+      selector: ".price",
+      name: "My Monitor",
+    });
+  });
+
+  it("works without leading ? in search string", () => {
+    const result = parsePrefillParams("url=https%3A%2F%2Fexample.com&selector=.price");
+    expect(result).toEqual({
+      url: "https://example.com",
+      selector: ".price",
+      name: undefined,
+    });
+  });
+
+  it("returns null when url param is missing", () => {
+    expect(parsePrefillParams("?selector=.price")).toBeNull();
+  });
+
+  it("returns null when url param is empty", () => {
+    expect(parsePrefillParams("?url=&selector=.price")).toBeNull();
+  });
+
+  it("returns null when checkout param is present (Stripe redirect)", () => {
+    const result = parsePrefillParams("?checkout=success&url=https%3A%2F%2Fexample.com");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when checkout=cancelled is present", () => {
+    const result = parsePrefillParams("?checkout=cancelled&url=https%3A%2F%2Fexample.com");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty search string", () => {
+    expect(parsePrefillParams("")).toBeNull();
+  });
+
+  it("preserves complex URLs with query params and fragments", () => {
+    const complexUrl = "https://example.com/page?a=1&b=2#section";
+    const encoded = new URLSearchParams({ url: complexUrl, selector: "div.main" }).toString();
+    const result = parsePrefillParams(encoded);
+    expect(result).toEqual({
+      url: complexUrl,
+      selector: "div.main",
+      name: undefined,
+    });
+  });
+
+  it("omits selector and name when not provided", () => {
+    const result = parsePrefillParams("?url=https%3A%2F%2Fexample.com");
+    expect(result).toEqual({
+      url: "https://example.com",
+      selector: undefined,
+      name: undefined,
+    });
+  });
+});

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -76,9 +76,15 @@ export default function Dashboard() {
   }, [searchString]);
 
   const [prefillDialogOpen, setPrefillDialogOpen] = useState(false);
+  // Store prefill values in state so they persist after the URL is cleared.
+  // Without this, the CreateMonitorDialog may not be mounted yet when the
+  // useEffect clears the URL (e.g. during the loading skeleton phase),
+  // causing it to mount later with empty values.
+  const [storedPrefill, setStoredPrefill] = useState<typeof prefillParams>(null);
 
   useEffect(() => {
     if (prefillParams) {
+      setStoredPrefill(prefillParams);
       setPrefillDialogOpen(true);
       // Clear query params so reopening doesn't re-trigger
       window.history.replaceState({}, "", "/dashboard");
@@ -225,9 +231,9 @@ export default function Dashboard() {
                )}
             </Button>
             <CreateMonitorDialog
-              initialValues={prefillParams ?? undefined}
+              initialValues={storedPrefill ?? undefined}
               externalOpen={prefillDialogOpen ? true : undefined}
-              onExternalOpenChange={(v) => { if (!v) setPrefillDialogOpen(false); }}
+              onExternalOpenChange={(v) => { if (!v) { setPrefillDialogOpen(false); setStoredPrefill(null); } }}
             />
           </div>
         </div>
@@ -336,9 +342,9 @@ export default function Dashboard() {
                   Start tracking web pages for changes by creating your first monitor. We'll notify you when content updates.
                 </p>
                 <CreateMonitorDialog
-                  initialValues={prefillParams ?? undefined}
+                  initialValues={storedPrefill ?? undefined}
                   externalOpen={prefillDialogOpen ? true : undefined}
-                  onExternalOpenChange={(v) => { if (!v) setPrefillDialogOpen(false); }}
+                  onExternalOpenChange={(v) => { if (!v) { setPrefillDialogOpen(false); setStoredPrefill(null); } }}
                 />
               </div>
             );

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -91,6 +91,12 @@ export default function Dashboard() {
     }
   }, [prefillParams]);
 
+  const prefillDialogProps = {
+    initialValues: storedPrefill ?? undefined,
+    externalOpen: prefillDialogOpen ? true : undefined,
+    onExternalOpenChange: (v: boolean) => { if (!v) { setPrefillDialogOpen(false); setStoredPrefill(null); } },
+  } as const;
+
   const handleRefresh = async () => {
     console.log("Refreshing monitors...");
     // First refetch the list
@@ -230,11 +236,7 @@ export default function Dashboard() {
                  <RefreshCw className="h-4 w-4" />
                )}
             </Button>
-            <CreateMonitorDialog
-              initialValues={storedPrefill ?? undefined}
-              externalOpen={prefillDialogOpen ? true : undefined}
-              onExternalOpenChange={(v) => { if (!v) { setPrefillDialogOpen(false); setStoredPrefill(null); } }}
-            />
+            <CreateMonitorDialog {...prefillDialogProps} />
           </div>
         </div>
 
@@ -341,11 +343,7 @@ export default function Dashboard() {
                 <p className="text-muted-foreground max-w-sm mx-auto mb-6">
                   Start tracking web pages for changes by creating your first monitor. We'll notify you when content updates.
                 </p>
-                <CreateMonitorDialog
-                  initialValues={storedPrefill ?? undefined}
-                  externalOpen={prefillDialogOpen ? true : undefined}
-                  onExternalOpenChange={(v) => { if (!v) { setPrefillDialogOpen(false); setStoredPrefill(null); } }}
-                />
+                <CreateMonitorDialog />
               </div>
             );
           }


### PR DESCRIPTION
## Summary
- **Root cause**: When the Chrome extension opened `/dashboard?url=...`, the `useEffect` cleared the URL params via `replaceState` before `CreateMonitorDialog` mounted (hidden behind the loading skeleton). The dialog opened with an empty URL field, causing "Invalid URL format" on submit.
- **Fix**: Store prefill values in React state (`storedPrefill`) so they persist after the URL is cleared, regardless of when the dialog mounts.
- **Hardening** (from review phases): Extract shared dialog props to prevent duplication, make the empty-state dialog uncontrolled to prevent dual-mount when `monitors.length === 0`, and route the success handler through `handleOpenChange` to properly reset the form.

## Test plan
- [ ] 9 new tests for prefill param parsing (`Dashboard.test.ts`)
- [ ] 5 new tests for dialog external open + prefill rendering (`CreateMonitorDialog.test.tsx`)
- [ ] `npm run check` passes
- [ ] `npm run test` passes (2281 tests, 91 files)
- [ ] `npm run build` succeeds
- [ ] Manual: open extension on a page → pick element → "Create monitor" → dashboard opens with URL pre-filled → submit succeeds

https://claude.ai/code/session_01XPqFK2RBHAqDzaMFzHJxU9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dialog state retention when prefilling monitor creation details from URL parameters so prefill persists correctly after URL clearance.

* **Refactor**
  * Unified dialog-close and reset logic so successful monitor creation follows a single close/reset path.

* **Tests**
  * Added tests covering monitor creation dialog behavior, form prefill, open/close interactions, and dashboard prefill parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->