### PR TITLE
chore: install graphify knowledge graph integration

### DIFF
--- a/.claude/commands/magicwand.md
+++ b/.claude/commands/magicwand.md
@@ -160,6 +160,14 @@ For every documentation surface classified as UPDATE REQUIRED or NEW SECTION NEE
 
 A phase is complete when all UPDATE REQUIRED and NEW SECTION NEEDED surfaces have been patched and `npm run check` exits with code 0.
 
+**End-of-edits graphify rebuild.** After Phase 7 completes, all in-pipeline code edits are done (Phase 8 only zips the extension; Phase 9 only opens a PR). If `graphify-out/graph.json` exists, rebuild the code graph **once** here so the next session inherits a current graph:
+
+```bash
+[ -f graphify-out/graph.json ] && python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))" || true
+```
+
+This satisfies the CLAUDE.md "rebuild once at the end of a task" rule for the entire pipeline. Do not rebuild after each individual fix in earlier phases. If `graphify-out/graph.json` does not exist, skip silently — graphify is not yet primed on this checkout.
+
 ### Phase 8 of 9 — Extension Release
 
 Before delegating, pre-check whether extension files changed:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,15 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -f graphify-out/graph.json ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}' || true"
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -f graphify-out/graph.json ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}' || true"
+            "command": "[ -f \"$CLAUDE_PROJECT_DIR/graphify-out/graph.json\" ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}' || true"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 extension/node_modules/
 extension/build/
 extension/*.zip
+
+# graphify knowledge graph output (generated, per-developer)
+graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,11 @@ See `README.md` for project overview, tech stack, structure, and setup.
 - `.claude/agents/security-auditor.md` — OWASP security analysis (read-only)
 - `.claude/agents/skeptic.md` — adversarial review for edge cases and failure modes (read-only); invoked by magicwand Phase 5
 
-## graphify
+## graphify (optional tooling)
 
-This project has a graphify knowledge graph at graphify-out/.
+Some developers use [graphify](https://github.com/safishamsi/graphify) to maintain a knowledge graph at `graphify-out/`. The directory is gitignored — these rules apply only when graphify is primed on this checkout (i.e. `graphify-out/graph.json` exists). If it doesn't exist, skip everything in this section.
 
-Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- If you modified code files during a task, run the graph rebuild **once at the end** of the task (after all edits are done, before handing back), not after each individual edit. Multi-phase commands like `/magicwand` should rebuild a single time at the end of the pipeline. Rebuild command: `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"`
+Rules (when primed):
+- Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md` for god nodes and community structure
+- If `graphify-out/wiki/index.md` exists, navigate it instead of reading raw files
+- If you modified code files during a task, run the graph rebuild **once at the end** of the task (after all edits are done, before handing back), not after each individual edit. Multi-phase commands like `/magicwand` should rebuild a single time at the end of the pipeline. Rebuild command: `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` (this is the same call graphify's own `graphify hook install` post-commit hook uses — AST-only, no LLM)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,4 +66,4 @@ This project has a graphify knowledge graph at graphify-out/.
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current
+- If you modified code files during a task, run the graph rebuild **once at the end** of the task (after all edits are done, before handing back), not after each individual edit. Multi-phase commands like `/magicwand` should rebuild a single time at the end of the pipeline. Rebuild command: `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,3 +58,12 @@ See `README.md` for project overview, tech stack, structure, and setup.
 - `.claude/agents/pr-creation.md` — automated PR generation
 - `.claude/agents/security-auditor.md` — OWASP security analysis (read-only)
 - `.claude/agents/skeptic.md` — adversarial review for edge cases and failure modes (read-only); invoked by magicwand Phase 5
+
+## graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current


### PR DESCRIPTION
## Summary

Wires [graphify](https://github.com/safishamsi/graphify) into the project so Claude Code (and any other graphify-aware AI assistant) can consult a persistent knowledge graph of the codebase before searching files. Graphify combines deterministic Tree-sitter AST extraction with LLM-driven semantic extraction to produce a graph stored in `graphify-out/` that surfaces god nodes, community clusters, and cross-document connections.

The graph itself is **not** committed — it's per-developer build output. This PR only adds the integration: project-level instructions, a PreToolUse hook, a `/magicwand` rebuild step, and the gitignore entry.

## Changes

**`CLAUDE.md`** — adds a `## graphify` section instructing Claude to:
- Read `graphify-out/GRAPH_REPORT.md` before answering architecture questions
- Navigate `graphify-out/wiki/index.md` (when present) instead of raw files
- Rebuild the graph **once at the end of a task**, not after every individual code edit (debounced rule for multi-phase commands like `/magicwand`)

**`.claude/settings.json`** — registers a `PreToolUse` hook on `Glob|Grep` matchers. The hook runs a one-line shell guard: when `graphify-out/graph.json` exists, it injects an `additionalContext` reminder to consult `GRAPH_REPORT.md` first; when the graph file does not exist, the hook is a silent no-op (`|| true`). No effect for developers who haven't built the graph.

**`.claude/commands/magicwand.md`** — appends an end-of-edits rebuild step at the close of Phase 7 (Documentation Review, the last phase that can modify code). Gated on `graphify-out/graph.json` existing. This satisfies the "rebuild once at end of task" rule for the entire 9-phase pipeline so a magicwand run with N code fixes triggers 1 rebuild instead of N.

**`.gitignore`** — excludes `graphify-out/` (interpreter pin, detect cache, `graph.json`, `GRAPH_REPORT.md`, `cache/`, `cost.json`, etc.). The directory is regenerated build output and contains per-developer state.

## How to test

1. Pull this branch: `git checkout claude/install-graphify-lQt2k`
2. Verify the gitignore + hook + CLAUDE.md changes apply cleanly: `git diff main...HEAD`
3. Run `npm run check && npm run test` — should pass (no source code changed)
4. **Optional — exercise the integration:**
   - Install graphify: `pip install graphifyy && graphify install` (writes `~/.claude/skills/graphify/SKILL.md`, user-scope, not repo-scope)
   - In Claude Code, run `/graphify .` to build the initial knowledge graph (~10 minutes including parallel semantic subagents on docs/images)
   - After the build completes, confirm `graphify-out/graph.json`, `graph.html`, and `GRAPH_REPORT.md` exist
   - Trigger any tool that uses Glob or Grep — Claude should receive the additional-context reminder about `GRAPH_REPORT.md`
5. **Verify the no-op behavior:** without running `/graphify .` first, normal Glob/Grep calls should behave identically to today (the hook short-circuits via the `[ -f graphify-out/graph.json ]` test).

## Notes for reviewers

- No production source files (`server/`, `client/`, `shared/`, `extension/`) are touched.
- The `pip install graphifyy` step is a per-developer choice; the repo only describes the integration. Developers who don't install graphify see no behavior change.
- Graphify is MIT-licensed and runs entirely locally (Tree-sitter AST stays on machine; semantic extraction uses your existing Claude session).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated code-graph rebuild that runs once after edit sessions complete
  * Integrated knowledge-graph context emission to assist tooling prior to searches
  * Updated ignore rules to exclude generated graph output

* **Documentation**
  * Expanded guidance on knowledge-graph usage and the post-edit rebuild workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->