### PR TITLE
docs: add Slack webpage change alerts blog post

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import BlogPriceMonitoring from "@/pages/BlogPriceMonitoring";
 import BlogSelectorBreakage from "@/pages/BlogSelectorBreakage";
 import BlogUseCases from "@/pages/BlogUseCases";
 import BlogNoCode from "@/pages/BlogNoCode";
+import BlogSlackAlerts from "@/pages/BlogSlackAlerts";
 import Pricing from "@/pages/Pricing";
 import Support from "@/pages/Support";
 import DocsWebhooks from "@/pages/DocsWebhooks";
@@ -85,6 +86,7 @@ function Router() {
       <Route path="/blog/css-selectors-keep-breaking-why-and-how-to-fix" component={BlogSelectorBreakage} />
       <Route path="/blog/website-change-monitoring-use-cases-beyond-price-tracking" component={BlogUseCases} />
       <Route path="/blog/monitor-website-changes-without-writing-code" component={BlogNoCode} />
+      <Route path="/blog/slack-webpage-change-alerts" component={BlogSlackAlerts} />
       <Route path="/pricing" component={Pricing} />
       <Route path="/support" component={Support} />
       <Route path="/changelog" component={Changelog} />

--- a/client/src/pages/Blog.tsx
+++ b/client/src/pages/Blog.tsx
@@ -7,6 +7,13 @@ import PublicNav from "@/components/PublicNav";
 
 const blogPosts = [
   {
+    slug: "slack-webpage-change-alerts",
+    title: "How to Get a Slack Alert When Any Webpage Changes",
+    description: "Set up Slack notifications for webpage changes in minutes. Monitor prices, stock levels, competitor pages, or any site element — alerts go straight to your Slack channel.",
+    category: "Integrations",
+    date: "2026-04-15",
+  },
+  {
     slug: "monitor-website-changes-without-writing-code",
     title: "How to Monitor Website Changes Without Writing Code",
     description: "You don't need to be a developer to track changes on a website. A step-by-step guide to monitoring any webpage using a point-and-click browser extension — no coding required.",

--- a/client/src/pages/BlogSlackAlerts.tsx
+++ b/client/src/pages/BlogSlackAlerts.tsx
@@ -1,0 +1,166 @@
+import { useMemo } from "react";
+import { formatDate } from "@/lib/date-format";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ArrowRight } from "lucide-react";
+import { Link } from "wouter";
+import PublicNav from "@/components/PublicNav";
+import SEOHead, { getCanonicalUrl } from "@/components/SEOHead";
+
+const BLOG_PATH = "/blog/slack-webpage-change-alerts";
+const PUBLISH_DATE = "2026-04-15";
+const AUTHOR = "Christian - developer of FetchTheChange";
+
+export default function BlogSlackAlerts() {
+  const jsonLd = useMemo(() => ({
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: "How to Get a Slack Alert When Any Webpage Changes",
+    description: "Set up Slack notifications for webpage changes in minutes. Monitor prices, stock levels, competitor pages, or any site element — alerts go straight to your Slack channel.",
+    author: { "@type": "Person", name: AUTHOR },
+    publisher: { "@type": "Organization", name: "FetchTheChange" },
+    mainEntityOfPage: getCanonicalUrl(BLOG_PATH),
+    datePublished: PUBLISH_DATE,
+    dateModified: PUBLISH_DATE,
+  }), []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="How to Get a Slack Alert When Any Webpage Changes | FetchTheChange"
+        description="Set up Slack notifications for webpage changes in minutes. Monitor prices, stock levels, competitor pages, or any site element — alerts go straight to your Slack channel."
+        path={BLOG_PATH}
+        ogType="article"
+        jsonLd={jsonLd}
+      />
+      <PublicNav />
+
+      <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 md:py-16">
+        <div className="mb-6">
+          <Button variant="ghost" asChild data-testid="button-back-blog-top">
+            <Link href="/blog">
+              Back to Blog
+            </Link>
+          </Button>
+        </div>
+
+        <header className="mb-10">
+          <Badge variant="secondary" className="mb-4">Integrations</Badge>
+          <h1 className="text-3xl md:text-4xl font-display font-bold leading-tight mb-4">
+            How to get a Slack alert when any webpage changes
+          </h1>
+          <p className="text-muted-foreground">
+            By {AUTHOR} · Published {formatDate(PUBLISH_DATE)}
+          </p>
+        </header>
+
+        <div className="prose prose-invert max-w-none space-y-6">
+          <p className="text-lg text-muted-foreground leading-relaxed">
+            Email notifications for webpage changes get buried. By the time someone opens their inbox, the competitor's price has already moved, the product has sold out again, or the status page has gone back to green. Slack puts the alert where the team is already working — in a channel, visible to everyone who needs to know, the moment the change happens.
+          </p>
+
+          <h2 className="text-2xl font-display font-bold mt-10 mb-4">Why Slack beats email for webpage monitoring</h2>
+          <p>
+            Email is personal and asynchronous. Webpage change alerts usually are not. When a competitor drops their price or a product comes back in stock, the whole team needs to know at once — not one person's inbox at whatever time they happen to check it.
+          </p>
+          <p>
+            A shared Slack channel makes webpage change alerts a team signal instead of a personal one. The pricing analyst sees the competitor move at the same time as the category manager. Ops and engineering see the status page change together. No forwarding, no "did you see this?" follow-ups, no single point of failure.
+          </p>
+
+          <h2 className="text-2xl font-display font-bold mt-10 mb-4">What you can monitor</h2>
+          <p>
+            Slack alerts work for any change a monitor can detect. Some of the most common use cases:
+          </p>
+          <ul className="list-disc list-inside space-y-3 ml-4">
+            <li><strong className="text-foreground">Competitor pricing pages</strong> — know the moment a price changes, before a customer notices it first.</li>
+            <li><strong className="text-foreground">Job boards and careers pages</strong> — alert a channel when new roles appear at a company you're tracking.</li>
+            <li><strong className="text-foreground">Government or regulatory pages</strong> — track policy updates, guidance changes, and effective dates as they are published.</li>
+            <li><strong className="text-foreground">SaaS status pages</strong> — get notified before your customers do, so your on-call team can respond first.</li>
+            <li><strong className="text-foreground">Product availability</strong> — stock alerts for high-demand items that sell out fast and restock without warning.</li>
+          </ul>
+
+          <h2 className="text-2xl font-display font-bold mt-10 mb-4">How to connect Slack to FetchTheChange</h2>
+          <p>
+            Setup takes a minute or two. You only connect your workspace once — after that, each monitor picks its own channel.
+          </p>
+          <ol className="list-decimal list-inside space-y-3 ml-4">
+            <li><strong className="text-foreground">Open your monitor</strong> — Go to the FetchTheChange dashboard and open the monitor you want Slack alerts for, or create a new one.</li>
+            <li><strong className="text-foreground">Go to Notifications</strong> — In the monitor settings, scroll to the Notifications section.</li>
+            <li><strong className="text-foreground">Click Connect Slack</strong> — This opens the standard Slack OAuth flow. Authorise FetchTheChange to post to your workspace.</li>
+            <li><strong className="text-foreground">Select a channel</strong> — Pick the channel where alerts should go. You can choose a different channel for every monitor.</li>
+            <li><strong className="text-foreground">Toggle Slack on</strong> — Enable Slack in the notification channel picker. Email and Slack are independent — turning one on does not disable the other.</li>
+            <li><strong className="text-foreground">Save the monitor</strong> — The next time the tracked value changes, an alert fires to the channel you chose.</li>
+          </ol>
+
+          <h2 className="text-2xl font-display font-bold mt-10 mb-4">What a Slack alert looks like</h2>
+          <p>
+            Each alert posts as a structured Slack message, not a bare text line. The message shows the monitor name, the old value, the new value, and the time the change was detected. It also includes a direct link back to the monitor in the FetchTheChange dashboard, so anyone in the channel can click through to see the full change history and the page being tracked.
+          </p>
+          <p>
+            If you have multiple monitors posting to the same channel, each alert is clearly labelled by monitor name. There's no ambiguity about which page changed — you don't have to reverse-engineer the message to work out whether it was the pricing page or the status page.
+          </p>
+
+          <h2 className="text-2xl font-display font-bold mt-10 mb-4">Per-monitor channel routing</h2>
+          <p>
+            You're not limited to one channel. A common pattern is to route competitor price monitors to <code className="bg-secondary/50 px-1.5 py-0.5 rounded text-sm">#competitive-intel</code>, stock and availability alerts to <code className="bg-secondary/50 px-1.5 py-0.5 rounded text-sm">#ops</code>, and status page monitors to <code className="bg-secondary/50 px-1.5 py-0.5 rounded text-sm">#engineering</code>.
+          </p>
+          <p>
+            Each monitor has its own channel setting, and you can change them independently at any time. Moving a monitor to a different channel doesn't reset its history or require reconnecting Slack — it's a single setting change.
+          </p>
+
+          <h2 className="text-2xl font-display font-bold mt-10 mb-4">Availability</h2>
+          <p>
+            Slack integration is available on the Pro and Power plans. You can connect as many monitors to Slack as your tier allows — there's no separate cap on Slack-enabled monitors beyond the overall monitor count for your plan.
+          </p>
+
+          <div className="bg-secondary/50 rounded-lg p-6 mt-10 border border-border">
+            <h3 className="text-xl font-display font-bold mb-3">Start monitoring with Slack alerts</h3>
+            <p className="text-muted-foreground mb-4">
+              Set up a monitor, connect Slack once, and route alerts for prices, stock, status pages, or any page element straight into the channel where your team already works.
+            </p>
+            <Button asChild data-testid="button-cta-start-monitoring">
+              <a href="/api/login">
+                Set up a monitor <ArrowRight className="ml-2 h-4 w-4" />
+              </a>
+            </Button>
+          </div>
+
+          <h2 className="text-2xl font-display font-bold mt-12 mb-4">More in this series</h2>
+          <p>
+            This is post 1 of a 5-part series on FetchTheChange integrations:
+          </p>
+          <ul className="list-disc list-inside space-y-3 ml-4">
+            <li>
+              <Link href="/blog/webhook-webpage-change-trigger" className="text-primary hover:underline">
+                Trigger any automation when a webpage changes using webhooks
+              </Link>
+            </li>
+            <li>
+              <Link href="/blog/zapier-webpage-change-automation" className="text-primary hover:underline">
+                Connect webpage monitoring to 7,000+ apps with Zapier
+              </Link>
+            </li>
+            <li>
+              <Link href="/blog/webpage-monitoring-api" className="text-primary hover:underline">
+                Monitor webpages programmatically with the FetchTheChange API
+              </Link>
+            </li>
+            <li>
+              <Link href="/blog/chrome-extension-webpage-monitor" className="text-primary hover:underline">
+                Monitor any element on any page without writing CSS selectors
+              </Link>
+            </li>
+          </ul>
+        </div>
+
+        <footer className="mt-12 pt-8 border-t border-border">
+          <Button variant="ghost" asChild data-testid="button-back-blog-bottom">
+            <Link href="/blog">
+              Back to Blog
+            </Link>
+          </Button>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/client/src/pages/BlogSlackAlerts.tsx
+++ b/client/src/pages/BlogSlackAlerts.tsx
@@ -15,7 +15,7 @@ export default function BlogSlackAlerts() {
   const jsonLd = useMemo(() => ({
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    headline: "How to Get a Slack Alert When Any Webpage Changes",
+    headline: "How to get a Slack alert when any webpage changes",
     description: "Set up Slack notifications for webpage changes in minutes. Monitor prices, stock levels, competitor pages, or any site element — alerts go straight to your Slack channel.",
     author: { "@type": "Person", name: AUTHOR },
     publisher: { "@type": "Organization", name: "FetchTheChange" },
@@ -85,8 +85,8 @@ export default function BlogSlackAlerts() {
           </p>
           <ol className="list-decimal list-inside space-y-3 ml-4">
             <li><strong className="text-foreground">Open your monitor</strong> — Go to the FetchTheChange dashboard and open the monitor you want Slack alerts for, or create a new one.</li>
-            <li><strong className="text-foreground">Go to Notifications</strong> — In the monitor settings, scroll to the Notifications section.</li>
-            <li><strong className="text-foreground">Click Connect Slack</strong> — This opens the standard Slack OAuth flow. Authorise FetchTheChange to post to your workspace.</li>
+            <li><strong className="text-foreground">Open Notification Channels</strong> — In the monitor settings, scroll to the Notification Channels section.</li>
+            <li><strong className="text-foreground">Click Connect to Slack</strong> — This opens the standard Slack OAuth flow. Authorise FetchTheChange to post to your workspace.</li>
             <li><strong className="text-foreground">Select a channel</strong> — Pick the channel where alerts should go. You can choose a different channel for every monitor.</li>
             <li><strong className="text-foreground">Toggle Slack on</strong> — Enable Slack in the notification channel picker. Email and Slack are independent — turning one on does not disable the other.</li>
             <li><strong className="text-foreground">Save the monitor</strong> — The next time the tracked value changes, an alert fires to the channel you chose.</li>
@@ -131,22 +131,22 @@ export default function BlogSlackAlerts() {
           </p>
           <ul className="list-disc list-inside space-y-3 ml-4">
             <li>
-              <Link href="/blog/webhook-webpage-change-trigger" className="text-primary hover:underline">
+              <Link href="/blog/webhook-webpage-change-trigger" rel="nofollow" className="text-primary hover:underline">
                 Trigger any automation when a webpage changes using webhooks
               </Link>
             </li>
             <li>
-              <Link href="/blog/zapier-webpage-change-automation" className="text-primary hover:underline">
+              <Link href="/blog/zapier-webpage-change-automation" rel="nofollow" className="text-primary hover:underline">
                 Connect webpage monitoring to 7,000+ apps with Zapier
               </Link>
             </li>
             <li>
-              <Link href="/blog/webpage-monitoring-api" className="text-primary hover:underline">
+              <Link href="/blog/webpage-monitoring-api" rel="nofollow" className="text-primary hover:underline">
                 Monitor webpages programmatically with the FetchTheChange API
               </Link>
             </li>
             <li>
-              <Link href="/blog/chrome-extension-webpage-monitor" className="text-primary hover:underline">
+              <Link href="/blog/chrome-extension-webpage-monitor" rel="nofollow" className="text-primary hover:underline">
                 Monitor any element on any page without writing CSS selectors
               </Link>
             </li>

--- a/client/src/pages/Support.tsx
+++ b/client/src/pages/Support.tsx
@@ -243,12 +243,12 @@ const faqSections: FAQSection[] = [
       {
         question: "How do I connect Slack?",
         answer:
-          "Go to your dashboard settings and click \"Connect Slack\". This starts a standard OAuth flow — you'll authorise FetchTheChange to post to your workspace. Once connected, open a monitor's detail page, enable the Slack channel, and pick the channel you want alerts sent to.",
+          "Open a monitor's detail page and scroll to the Notification Channels section. Click \"Connect to Slack\" — this starts a standard OAuth flow where you authorise FetchTheChange to post to your workspace. Once connected, enable the Slack channel on that monitor and pick the channel you want alerts sent to.",
       },
       {
         question: "Can I disconnect Slack?",
         answer:
-          "Yes. Visit your integrations settings and click \"Disconnect Slack\". This removes FetchTheChange's access to your workspace and disables all Slack notification channels across your monitors.",
+          "Yes. Open the Notification Channels section on any monitor that has Slack connected and click \"Disconnect\". This removes FetchTheChange's access to your workspace and disables all Slack notification channels across your monitors.",
       },
       {
         question: "My webhook stopped delivering. What should I check?",

--- a/client/src/pages/blog-integrity.test.ts
+++ b/client/src/pages/blog-integrity.test.ts
@@ -170,6 +170,59 @@ describe("BlogNoCode page integrity", () => {
   });
 });
 
+describe("BlogSlackAlerts page integrity", () => {
+  const slackAlertsSource = fs.readFileSync(
+    path.join(PAGES_DIR, "BlogSlackAlerts.tsx"),
+    "utf-8",
+  );
+
+  it("has matching BLOG_PATH and route in App.tsx", () => {
+    const match = slackAlertsSource.match(/BLOG_PATH\s*=\s*"([^"]+)"/);
+    expect(match).not.toBeNull();
+    const blogPath = match![1];
+    expect(routes).toContain(blogPath);
+  });
+
+  it("has a valid PUBLISH_DATE", () => {
+    const match = slackAlertsSource.match(/PUBLISH_DATE\s*=\s*"([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("contains required Schema.org BlogPosting properties", () => {
+    expect(slackAlertsSource).toContain('"@type": "BlogPosting"');
+    expect(slackAlertsSource).toContain("datePublished");
+    expect(slackAlertsSource).toContain("publisher");
+    expect(slackAlertsSource).toContain("author");
+  });
+
+  it("CTA button links to /api/login", () => {
+    expect(slackAlertsSource).toContain('href="/api/login"');
+  });
+
+  it("has correct SEO title with brand suffix", () => {
+    expect(slackAlertsSource).toContain("| FetchTheChange");
+  });
+
+  it("Badge shows 'Integrations' category", () => {
+    expect(slackAlertsSource).toContain(">Integrations<");
+  });
+
+  it("includes stub links to the 4 planned series posts", () => {
+    // The spec requires stubbed Link hrefs to the other 4 integration
+    // series posts so they go live automatically when those posts ship.
+    const seriesSlugs = [
+      "/blog/webhook-webpage-change-trigger",
+      "/blog/zapier-webpage-change-automation",
+      "/blog/webpage-monitoring-api",
+      "/blog/chrome-extension-webpage-monitor",
+    ];
+    for (const href of seriesSlugs) {
+      expect(slackAlertsSource).toContain(`href="${href}"`);
+    }
+  });
+});
+
 describe("each blog post has a corresponding page file", () => {
   for (const slug of slugs) {
     it(`page file exists for slug "${slug}"`, () => {

--- a/client/src/pages/blog-integrity.test.ts
+++ b/client/src/pages/blog-integrity.test.ts
@@ -221,6 +221,57 @@ describe("BlogSlackAlerts page integrity", () => {
       expect(slackAlertsSource).toContain(`href="${href}"`);
     }
   });
+
+  it("every /blog/ href is either an existing route or a planned series stub", () => {
+    // This assertion intentionally replaces the standard "internal links
+    // point to existing blog routes" check. The four planned-series stubs
+    // are allowed because they ship as nofollow Links that go live when
+    // later posts in the series land. Any other /blog/ href (e.g. a typo
+    // in one of the stubs) must resolve to a real route today.
+    const plannedStubs = new Set([
+      "/blog/webhook-webpage-change-trigger",
+      "/blog/zapier-webpage-change-automation",
+      "/blog/webpage-monitoring-api",
+      "/blog/chrome-extension-webpage-monitor",
+    ]);
+    const hrefMatches = [
+      ...slackAlertsSource.matchAll(/href="(\/blog\/[^"]+)"/g),
+    ];
+    const linkedPaths = hrefMatches.map((m) => m[1]);
+    expect(linkedPaths.length).toBeGreaterThanOrEqual(3);
+    for (const href of linkedPaths) {
+      if (plannedStubs.has(href)) continue;
+      expect(routes).toContain(href);
+    }
+  });
+
+  it("planned-series stub links carry rel=\"nofollow\"", () => {
+    // Prevents Google from treating the not-yet-routed targets as
+    // soft-404s during the window before each series post ships.
+    const plannedStubs = [
+      "/blog/webhook-webpage-change-trigger",
+      "/blog/zapier-webpage-change-automation",
+      "/blog/webpage-monitoring-api",
+      "/blog/chrome-extension-webpage-monitor",
+    ];
+    for (const href of plannedStubs) {
+      const pattern = new RegExp(
+        `href="${href.replace(/\//g, "\\/")}"[^>]*rel="nofollow"|rel="nofollow"[^>]*href="${href.replace(/\//g, "\\/")}"`,
+      );
+      expect(slackAlertsSource).toMatch(pattern);
+    }
+  });
+
+  it("JSON-LD headline matches the rendered H1", () => {
+    // Google Rich Results expects the structured-data headline to match
+    // the visible page headline. This assertion prevents future case or
+    // wording drift between the two.
+    const headlineMatch = slackAlertsSource.match(/headline:\s*"([^"]+)"/);
+    expect(headlineMatch).not.toBeNull();
+    const headline = headlineMatch![1];
+    const h1Pattern = new RegExp(`<h1[^>]*>\\s*${headline.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}\\s*</h1>`);
+    expect(slackAlertsSource).toMatch(h1Pattern);
+  });
 });
 
 describe("each blog post has a corresponding page file", () => {


### PR DESCRIPTION
## Summary

Adds a new marketing/SEO blog post at `/blog/slack-webpage-change-alerts` — post 1 of a planned 5-part integrations series. Describes the existing Slack integration (per-monitor channel routing, OAuth flow, Pro/Power tier gate). Also corrects stale Slack-related copy on the Support FAQ so the public surfaces describe the shipped UI consistently.

## Changes

### New blog post
- `client/src/pages/BlogSlackAlerts.tsx` — new static page following the `BlogPriceMonitoring` pattern (SEOHead, JSON-LD `BlogPosting`, Integrations badge, CTA to `/api/login`).
- `client/src/pages/Blog.tsx` — prepended the index entry (date `2026-04-15`, keeps reverse-chronological order).
- `client/src/App.tsx` — registered the `/blog/slack-webpage-change-alerts` route.

### SEO hardening (from skeptic review)
- JSON-LD `headline` aligned with the rendered H1 (sentence case) so Google Rich Results sees matching structured data and visible content.
- Four stub links to the remaining series posts (`/blog/webhook-webpage-change-trigger`, `/blog/zapier-webpage-change-automation`, `/blog/webpage-monitoring-api`, `/blog/chrome-extension-webpage-monitor`) carry `rel="nofollow"` so crawlers don't follow them into soft-404 territory before those posts ship.
- Setup copy updated to match actual UI labels: "Notification Channels" (not "Notifications"), "Connect to Slack" (not "Connect Slack").

### Support FAQ correction
- `client/src/pages/Support.tsx` — "How do I connect Slack?" and "Can I disconnect Slack?" answers now reference the per-monitor Notification Channels panel and correct button labels. Previous copy pointed to non-existent "dashboard settings" / "integrations settings" screens.

### Tests
- `client/src/pages/blog-integrity.test.ts` — added `BlogSlackAlerts page integrity` suite covering BLOG_PATH routing, valid ISO date, Schema.org properties, CTA target, SEO title suffix, Integrations badge, stub-link allowlist, `rel="nofollow"` on each stub, and JSON-LD↔H1 parity.

## How to test

1. `npm run check && npm run test` — all 91 test files / 2296 tests pass.
2. `npm run dev` and visit http://localhost:5000/blog/slack-webpage-change-alerts. Verify:
   - Page renders with the "Integrations" badge and the 6-step setup flow.
   - Title tag in DevTools reads "How to Get a Slack Alert When Any Webpage Changes | FetchTheChange".
   - Canonical link points to the current origin + `/blog/slack-webpage-change-alerts`.
   - Clicking any of the four "More in this series" links falls through to the 404 page (expected — those routes ship later); inspect each anchor and confirm `rel="nofollow"`.
   - CTA "Set up a monitor" sends you to `/api/login`.
3. Visit `/blog` and confirm the new card is the top entry.
4. Visit `/support`, open "Webhooks & Slack" → "How do I connect Slack?" and confirm the answer now references the Notification Channels section and "Connect to Slack" button.

## Related

Surfaced during the magicwand pipeline — pre-existing bugs in adjacent pages filed separately:
- bd73-com/fetchthechange#414 — NotFound page missing noindex meta
- bd73-com/fetchthechange#415 — Empty-state CreateMonitorDialog loses prefill props
- bd73-com/fetchthechange#416 — Blog index page missing SEOHead
- bd73-com/fetchthechange#417 — Pricing page missing SEOHead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new blog post: "How to Get a Slack Alert When Any Webpage Changes" in the Integrations category.

* **Documentation**
  * Updated FAQ answers for Slack connection and disconnection workflows to reflect current product UI.

* **Tests**
  * Added test suite for new blog post integrity and SEO validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->