### PR TITLE
fix: replace dead /docs/extension URL with /support in welcome email

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -262,7 +262,16 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
     try {
       if (campaignConfigsReady) {
         const { bootstrapWelcomeCampaign, patchWelcomeCampaignUrls } = await import("./services/automatedCampaigns");
-        await patchWelcomeCampaignUrls();
+        // Run the URL patch in its own try-catch so a transient DB hiccup during
+        // the one-time migration cannot prevent the welcome campaign bootstrap.
+        try {
+          await patchWelcomeCampaignUrls();
+        } catch (err) {
+          console.error(
+            "[Patch] Welcome campaign URL patch failed, continuing to bootstrap:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
         const campaignPromise = bootstrapWelcomeCampaign();
         let timedOut = false;
         // Log outcome if the underlying promise fails after timeout fires.

--- a/server/index.ts
+++ b/server/index.ts
@@ -261,7 +261,8 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
     const BOOTSTRAP_TIMEOUT_MS = 5_000;
     try {
       if (campaignConfigsReady) {
-        const { bootstrapWelcomeCampaign } = await import("./services/automatedCampaigns");
+        const { bootstrapWelcomeCampaign, patchWelcomeCampaignUrls } = await import("./services/automatedCampaigns");
+        await patchWelcomeCampaignUrls();
         const campaignPromise = bootstrapWelcomeCampaign();
         let timedOut = false;
         // Log outcome if the underlying promise fails after timeout fires.

--- a/server/services/automatedCampaigns.test.ts
+++ b/server/services/automatedCampaigns.test.ts
@@ -340,14 +340,22 @@ describe("patchWelcomeCampaignUrls", () => {
     expect(mockDbSet).not.toHaveBeenCalled();
   });
 
-  it("updates htmlBody and textBody when the stored htmlBody still contains the deprecated URL", async () => {
+  it("does a targeted URL replacement and preserves surrounding custom content", async () => {
+    const customHtml =
+      "<p>Hi, welcome — special offer inside!</p>" +
+      "<a href=\"https://ftc.bd73.com/docs/extension\">Get the extension</a>" +
+      "<p>Signed, Christian</p>";
+    const customText =
+      "Hi, welcome — special offer inside!\n" +
+      "Get the extension: https://ftc.bd73.com/docs/extension\n" +
+      "Signed, Christian";
     const staleConfig = {
       id: 1,
       key: "welcome",
       name: "Welcome",
       subject: "Welcome",
-      htmlBody: "<a href=\"https://ftc.bd73.com/docs/extension\">Get the extension</a>",
-      textBody: "Old link: https://ftc.bd73.com/docs/extension",
+      htmlBody: customHtml,
+      textBody: customText,
       enabled: true,
       lastRunAt: null,
       nextRunAt: null,
@@ -360,12 +368,64 @@ describe("patchWelcomeCampaignUrls", () => {
 
     expect(mockDbSet).toHaveBeenCalledTimes(1);
     const setArg = mockDbSet.mock.calls[0][0];
-    expect(setArg.htmlBody).toBe(WELCOME_CAMPAIGN_DEFAULTS.htmlBody);
-    expect(setArg.textBody).toBe(WELCOME_CAMPAIGN_DEFAULTS.textBody);
+    // Targeted replacement: URL swapped, surrounding custom content preserved
+    expect(setArg.htmlBody).toBe(customHtml.replace("/docs/extension", "/support"));
+    expect(setArg.textBody).toBe(customText.replace("/docs/extension", "/support"));
     expect(setArg.updatedAt).toBeInstanceOf(Date);
-    // The replacement body must not carry the legacy URL forward
+    // Custom copy must survive the patch
+    expect(setArg.htmlBody).toContain("special offer inside");
+    expect(setArg.htmlBody).toContain("Signed, Christian");
+    expect(setArg.textBody).toContain("special offer inside");
+    // And the legacy URL must be gone
     expect(setArg.htmlBody).not.toContain("/docs/extension");
     expect(setArg.textBody).not.toContain("/docs/extension");
+  });
+
+  it("patches textBody even when htmlBody was already manually fixed", async () => {
+    const config = {
+      id: 1,
+      key: "welcome",
+      name: "Welcome",
+      subject: "Welcome",
+      htmlBody: "<a href=\"https://ftc.bd73.com/support\">Get the extension</a>",
+      textBody: "Old link: https://ftc.bd73.com/docs/extension",
+      enabled: true,
+      lastRunAt: null,
+      nextRunAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockDbLimit.mockResolvedValue([config]);
+
+    await patchWelcomeCampaignUrls();
+
+    expect(mockDbSet).toHaveBeenCalledTimes(1);
+    const setArg = mockDbSet.mock.calls[0][0];
+    // htmlBody was already clean, left untouched
+    expect(setArg.htmlBody).toBe(config.htmlBody);
+    // textBody had the legacy URL, now replaced
+    expect(setArg.textBody).toBe("Old link: https://ftc.bd73.com/support");
+  });
+
+  it("no-ops when textBody is null and htmlBody is already clean", async () => {
+    const config = {
+      id: 1,
+      key: "welcome",
+      name: "Welcome",
+      subject: "Welcome",
+      htmlBody: "<a href=\"https://ftc.bd73.com/support\">ok</a>",
+      textBody: null,
+      enabled: true,
+      lastRunAt: null,
+      nextRunAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockDbLimit.mockResolvedValue([config]);
+
+    await patchWelcomeCampaignUrls();
+
+    expect(mockDbSet).not.toHaveBeenCalled();
   });
 
   it("is idempotent when invoked twice after the first run patches the row", async () => {
@@ -382,16 +442,16 @@ describe("patchWelcomeCampaignUrls", () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     };
-    // First call: returns stale config → triggers update
-    // Second call: returns updated config (matching the defaults) → no-op
-    const updatedConfig = {
+    // First call: returns stale config → triggers targeted patch
+    // Second call: returns config after patch (URL replaced) → no-op
+    const patchedConfig = {
       ...staleConfig,
-      htmlBody: WELCOME_CAMPAIGN_DEFAULTS.htmlBody,
-      textBody: WELCOME_CAMPAIGN_DEFAULTS.textBody,
+      htmlBody: staleConfig.htmlBody.replace("/docs/extension", "/support"),
+      textBody: staleConfig.textBody,
     };
     mockDbLimit
       .mockResolvedValueOnce([staleConfig])
-      .mockResolvedValueOnce([updatedConfig]);
+      .mockResolvedValueOnce([patchedConfig]);
 
     await patchWelcomeCampaignUrls();
     await patchWelcomeCampaignUrls();

--- a/server/services/automatedCampaigns.test.ts
+++ b/server/services/automatedCampaigns.test.ts
@@ -287,7 +287,7 @@ describe("WELCOME_CAMPAIGN_DEFAULTS", () => {
   });
 
   it("HTML body contains extension and dashboard links", () => {
-    expect(WELCOME_CAMPAIGN_DEFAULTS.htmlBody).toContain("https://ftc.bd73.com/docs/extension");
+    expect(WELCOME_CAMPAIGN_DEFAULTS.htmlBody).toContain("https://ftc.bd73.com/support");
     expect(WELCOME_CAMPAIGN_DEFAULTS.htmlBody).toContain("https://ftc.bd73.com/dashboard");
   });
 });

--- a/server/services/automatedCampaigns.test.ts
+++ b/server/services/automatedCampaigns.test.ts
@@ -85,7 +85,7 @@ vi.mock("./logger", () => ({
   },
 }));
 
-import { computeNextRunAt, ensureWelcomeConfig, bootstrapWelcomeCampaign, processAutomatedCampaigns, runWelcomeCampaign, WELCOME_CAMPAIGN_DEFAULTS } from "./automatedCampaigns";
+import { computeNextRunAt, ensureWelcomeConfig, bootstrapWelcomeCampaign, patchWelcomeCampaignUrls, processAutomatedCampaigns, runWelcomeCampaign, WELCOME_CAMPAIGN_DEFAULTS } from "./automatedCampaigns";
 
 describe("computeNextRunAt", () => {
   it("Jan 1 00:00 UTC → Jan 15", () => {
@@ -289,6 +289,115 @@ describe("WELCOME_CAMPAIGN_DEFAULTS", () => {
   it("HTML body contains extension and dashboard links", () => {
     expect(WELCOME_CAMPAIGN_DEFAULTS.htmlBody).toContain("https://ftc.bd73.com/support");
     expect(WELCOME_CAMPAIGN_DEFAULTS.htmlBody).toContain("https://ftc.bd73.com/dashboard");
+  });
+
+  it("text body uses /support instead of legacy /docs/extension", () => {
+    expect(WELCOME_CAMPAIGN_DEFAULTS.textBody).toContain("https://ftc.bd73.com/support");
+    expect(WELCOME_CAMPAIGN_DEFAULTS.textBody).not.toContain("/docs/extension");
+  });
+
+  it("HTML body no longer references the deprecated /docs/extension URL", () => {
+    expect(WELCOME_CAMPAIGN_DEFAULTS.htmlBody).not.toContain("/docs/extension");
+  });
+});
+
+describe("patchWelcomeCampaignUrls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbFrom.mockReturnValue({ where: mockDbWhere, orderBy: mockDbOrderBy });
+    mockDbWhere.mockReturnValue({ limit: mockDbLimit, returning: mockDbReturning });
+    mockDbSet.mockReturnValue({ where: mockDbWhere });
+    mockDbValues.mockReturnValue({ returning: mockDbReturning, onConflictDoNothing: vi.fn().mockResolvedValue(undefined) });
+  });
+
+  it("is a no-op when the welcome config row does not exist", async () => {
+    mockDbLimit.mockResolvedValue([]);
+
+    await patchWelcomeCampaignUrls();
+
+    // Should only have done a select; no update
+    expect(mockDbSet).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the stored htmlBody does not contain the deprecated URL", async () => {
+    const config = {
+      id: 1,
+      key: "welcome",
+      name: "Welcome",
+      subject: "Welcome",
+      htmlBody: "<a href=\"https://ftc.bd73.com/support\">Get the extension</a>",
+      textBody: "See https://ftc.bd73.com/support",
+      enabled: true,
+      lastRunAt: null,
+      nextRunAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockDbLimit.mockResolvedValue([config]);
+
+    await patchWelcomeCampaignUrls();
+
+    expect(mockDbSet).not.toHaveBeenCalled();
+  });
+
+  it("updates htmlBody and textBody when the stored htmlBody still contains the deprecated URL", async () => {
+    const staleConfig = {
+      id: 1,
+      key: "welcome",
+      name: "Welcome",
+      subject: "Welcome",
+      htmlBody: "<a href=\"https://ftc.bd73.com/docs/extension\">Get the extension</a>",
+      textBody: "Old link: https://ftc.bd73.com/docs/extension",
+      enabled: true,
+      lastRunAt: null,
+      nextRunAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockDbLimit.mockResolvedValue([staleConfig]);
+
+    await patchWelcomeCampaignUrls();
+
+    expect(mockDbSet).toHaveBeenCalledTimes(1);
+    const setArg = mockDbSet.mock.calls[0][0];
+    expect(setArg.htmlBody).toBe(WELCOME_CAMPAIGN_DEFAULTS.htmlBody);
+    expect(setArg.textBody).toBe(WELCOME_CAMPAIGN_DEFAULTS.textBody);
+    expect(setArg.updatedAt).toBeInstanceOf(Date);
+    // The replacement body must not carry the legacy URL forward
+    expect(setArg.htmlBody).not.toContain("/docs/extension");
+    expect(setArg.textBody).not.toContain("/docs/extension");
+  });
+
+  it("is idempotent when invoked twice after the first run patches the row", async () => {
+    const staleConfig = {
+      id: 1,
+      key: "welcome",
+      name: "Welcome",
+      subject: "Welcome",
+      htmlBody: "<a href=\"https://ftc.bd73.com/docs/extension\">x</a>",
+      textBody: "x",
+      enabled: true,
+      lastRunAt: null,
+      nextRunAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    // First call: returns stale config → triggers update
+    // Second call: returns updated config (matching the defaults) → no-op
+    const updatedConfig = {
+      ...staleConfig,
+      htmlBody: WELCOME_CAMPAIGN_DEFAULTS.htmlBody,
+      textBody: WELCOME_CAMPAIGN_DEFAULTS.textBody,
+    };
+    mockDbLimit
+      .mockResolvedValueOnce([staleConfig])
+      .mockResolvedValueOnce([updatedConfig]);
+
+    await patchWelcomeCampaignUrls();
+    await patchWelcomeCampaignUrls();
+
+    // Only the first invocation should have issued an update
+    expect(mockDbSet).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/server/services/automatedCampaigns.ts
+++ b/server/services/automatedCampaigns.ts
@@ -47,7 +47,7 @@ export const WELCOME_CAMPAIGN_DEFAULTS = {
               <table cellpadding="0" cellspacing="0" style="margin:20px 0;">
                 <tr>
                   <td style="background:#6366f1;border-radius:8px;padding:12px 24px;">
-                    <a href="https://ftc.bd73.com/docs/extension" style="color:#fff;text-decoration:none;font-size:15px;font-weight:600;">
+                    <a href="https://ftc.bd73.com/support" style="color:#fff;text-decoration:none;font-size:15px;font-weight:600;">
                       → Get the Chrome extension
                     </a>
                   </td>
@@ -105,7 +105,7 @@ Welcome to FetchTheChange. You're set up and ready to go.
 
 The fastest way to start: install the Chrome extension. Hover over any element on any page, click it, and your monitor is live — no CSS selectors needed.
 
-→ Get the extension: https://ftc.bd73.com/docs/extension
+→ Get the extension: https://ftc.bd73.com/support
 
 Or go straight to the dashboard and create a monitor manually if you already know your selector:
 
@@ -201,6 +201,36 @@ export async function ensureWelcomeConfig(): Promise<AutomatedCampaignConfig> {
     .limit(1);
 
   return inserted;
+}
+
+/**
+ * One-time patch: update the welcome campaign config row if its html_body still
+ * contains the deprecated /docs/extension URL. Idempotent — once the bad URL is
+ * gone, this is a no-op, so it's safe to call on every deployment.
+ *
+ * Only patches the config template row; already-sent campaign records are left
+ * untouched.
+ */
+export async function patchWelcomeCampaignUrls(): Promise<void> {
+  const [config] = await db
+    .select()
+    .from(automatedCampaignConfigs)
+    .where(eq(automatedCampaignConfigs.key, "welcome"))
+    .limit(1);
+
+  if (!config) return;
+  if (!config.htmlBody.includes("ftc.bd73.com/docs/extension")) return;
+
+  await db
+    .update(automatedCampaignConfigs)
+    .set({
+      htmlBody: WELCOME_CAMPAIGN_DEFAULTS.htmlBody,
+      textBody: WELCOME_CAMPAIGN_DEFAULTS.textBody,
+      updatedAt: new Date(),
+    })
+    .where(eq(automatedCampaignConfigs.key, "welcome"));
+
+  console.log("[Patch] Welcome campaign URLs updated: /docs/extension → /support");
 }
 
 /**

--- a/server/services/automatedCampaigns.ts
+++ b/server/services/automatedCampaigns.ts
@@ -204,14 +204,21 @@ export async function ensureWelcomeConfig(): Promise<AutomatedCampaignConfig> {
 }
 
 /**
- * One-time patch: update the welcome campaign config row if its html_body still
- * contains the deprecated /docs/extension URL. Idempotent — once the bad URL is
- * gone, this is a no-op, so it's safe to call on every deployment.
+ * One-time patch: update the welcome campaign config row if its html_body or
+ * text_body still contains the deprecated /docs/extension URL. Idempotent —
+ * once the bad URL is gone from both bodies, this is a no-op, so it's safe to
+ * call on every deployment.
+ *
+ * Does a targeted string replacement rather than overwriting with defaults, so
+ * any admin customizations to the rest of the template are preserved.
  *
  * Only patches the config template row; already-sent campaign records are left
  * untouched.
  */
 export async function patchWelcomeCampaignUrls(): Promise<void> {
+  const LEGACY_URL = "ftc.bd73.com/docs/extension";
+  const NEW_URL = "ftc.bd73.com/support";
+
   const [config] = await db
     .select()
     .from(automatedCampaignConfigs)
@@ -219,13 +226,24 @@ export async function patchWelcomeCampaignUrls(): Promise<void> {
     .limit(1);
 
   if (!config) return;
-  if (!config.htmlBody.includes("ftc.bd73.com/docs/extension")) return;
+
+  const htmlNeedsPatch = config.htmlBody.includes(LEGACY_URL);
+  const textNeedsPatch = config.textBody?.includes(LEGACY_URL) ?? false;
+
+  if (!htmlNeedsPatch && !textNeedsPatch) return;
+
+  const patchedHtmlBody = htmlNeedsPatch
+    ? config.htmlBody.split(LEGACY_URL).join(NEW_URL)
+    : config.htmlBody;
+  const patchedTextBody = textNeedsPatch
+    ? config.textBody!.split(LEGACY_URL).join(NEW_URL)
+    : config.textBody;
 
   await db
     .update(automatedCampaignConfigs)
     .set({
-      htmlBody: WELCOME_CAMPAIGN_DEFAULTS.htmlBody,
-      textBody: WELCOME_CAMPAIGN_DEFAULTS.textBody,
+      htmlBody: patchedHtmlBody,
+      textBody: patchedTextBody,
       updatedAt: new Date(),
     })
     .where(eq(automatedCampaignConfigs.key, "welcome"));


### PR DESCRIPTION
## Summary

The welcome email's "Get the Chrome extension" CTA pointed at `https://ftc.bd73.com/docs/extension`, which is a 404 — that route doesn't exist in the client. This PR swaps the URL for `/support` (which already has a Browser Extension FAQ section) in both the source constant and the persisted DB row that was seeded from it.

## Changes

### Email template (`server/services/automatedCampaigns.ts`)
- `WELCOME_CAMPAIGN_DEFAULTS.htmlBody` and `.textBody` now point to `https://ftc.bd73.com/support` instead of the dead `/docs/extension` route.
- New exported function `patchWelcomeCampaignUrls()` that performs an idempotent one-time DB migration on the `automated_campaign_configs` row keyed `"welcome"`:
  - Targeted string replacement (`.split().join()`) — the URL is swapped in place rather than overwriting the whole body. Any admin customizations around the URL are preserved.
  - Independently checks `htmlBody` and `textBody`; only touches the bodies that still contain the legacy URL.
  - Guard clause makes it a no-op once the bad URL is gone, so it's safe to leave in place across deploys.
  - Already-sent `campaigns` table records are left untouched (sent emails snapshot the template at send time).

### Startup wiring (`server/index.ts`)
- The bootstrap IIFE now calls `patchWelcomeCampaignUrls()` immediately before `bootstrapWelcomeCampaign()`.
- The patch is wrapped in its own `try/catch` so a transient DB hiccup during the migration cannot prevent the welcome-campaign bootstrap from running.

### Tests (`server/services/automatedCampaigns.test.ts`)
- Six new unit tests covering: no row, already-clean row, targeted URL replacement preserving custom content, textBody-only patch when htmlBody was manually fixed, no-op when textBody is null and htmlBody is clean, and idempotency across two sequential invocations.
- Updated existing assertions on `WELCOME_CAMPAIGN_DEFAULTS` to expect `/support`.

## How to test

1. Pull the branch and run `npm run check && npm run test` — all 91 test files / 2290 tests should pass.
2. Local DB sanity check (with a dev `automated_campaign_configs` row containing the legacy URL):
   - Boot the server. Look for `[Patch] Welcome campaign URLs updated: /docs/extension → /support` in startup logs.
   - Re-boot. The log line should NOT appear the second time (idempotent).
   - Inspect the DB row: `htmlBody` and `textBody` no longer contain `ftc.bd73.com/docs/extension`.
3. Trigger a fresh welcome send (e.g., by clearing `lastRunAt` on the welcome row in dev) and verify the rendered email's CTA links to `https://ftc.bd73.com/support`.

## Pipeline notes

Shipped via `/magicwand`: tests written, security/architecture/code/skeptic reviews passed, doc surfaces unchanged. Pre-existing bug surfaced during the bug-reporter scan (`processAutomatedCampaigns` does not roll back `lastRunAt` if a send fails) filed as bd73-com/fetchthechange#418 — out of scope for this PR.

https://claude.ai/code/session_01Bm5WCDvUoAk1GwmrePx3Q6