### PR TITLE
fix: resolve GitHub issues + scheduler hardening + 404 dark mode

### DIFF
--- a/client/src/pages/AdminCampaignDetail.tsx
+++ b/client/src/pages/AdminCampaignDetail.tsx
@@ -46,6 +46,7 @@ const statusConfig: Record<string, { variant: "default" | "secondary" | "outline
   sent: { variant: "default", label: "Sent" },
   partially_sent: { variant: "secondary", label: "Partially Sent" },
   cancelled: { variant: "destructive", label: "Cancelled" },
+  failed: { variant: "destructive", label: "Failed" },
 };
 
 const recipientStatusConfig: Record<string, { variant: "default" | "secondary" | "outline" | "destructive"; label: string }> = {

--- a/client/src/pages/AdminCampaigns.tsx
+++ b/client/src/pages/AdminCampaigns.tsx
@@ -77,6 +77,7 @@ const statusConfig: Record<string, { variant: "default" | "secondary" | "outline
   sent: { variant: "default", label: "Sent" },
   partially_sent: { variant: "secondary", label: "Partial" },
   cancelled: { variant: "destructive", label: "Cancelled" },
+  failed: { variant: "destructive", label: "Failed" },
 };
 
 function formatDate(dateStr: string | null | undefined): string {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -91,26 +91,25 @@ export default function Dashboard() {
     }
   }, [prefillParams]);
 
-  // Clear stale prefill values once the user has monitors (i.e. after
-  // successful creation). Without this, storedPrefill persists for the
-  // lifetime of the component mount, causing subsequent dialog opens to
-  // carry stale extension values long after the original prefill was used.
-  useEffect(() => {
-    if (monitors && monitors.length > 0 && storedPrefill) {
-      setStoredPrefill(null);
-    }
-  }, [monitors, storedPrefill]);
-
   // The header dialog is the single externally-controlled instance that
   // auto-opens when prefill params arrive. The empty-state dialog below
   // must NOT be externally controlled, or both dialogs race on the same
-  // externalOpen=true / onExternalOpenChange callback. Keep
-  // `storedPrefill` populated after a dismiss so the empty-state dialog
-  // can still open with the prefill via its own trigger button.
+  // externalOpen=true / onExternalOpenChange callback.
+  //
+  // Clear storedPrefill when the dialog closes so subsequent opens don't
+  // carry stale extension values. Keyed on dialog close (not monitor
+  // count) to avoid racing with React render batching.
   const prefillDialogProps = {
     initialValues: storedPrefill ?? undefined,
+    // `undefined` (not `false`) when closed — avoids externally controlling
+    // the dialog when there is no active prefill.
     externalOpen: prefillDialogOpen ? true : undefined,
-    onExternalOpenChange: (v: boolean) => { if (!v) setPrefillDialogOpen(false); },
+    onExternalOpenChange: (v: boolean) => {
+      if (!v) {
+        setPrefillDialogOpen(false);
+        setStoredPrefill(null);
+      }
+    },
   } as const;
 
   const handleRefresh = async () => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -363,7 +363,10 @@ export default function Dashboard() {
                     instance inherits only the cached initialValues so that
                     clicking its trigger after dismissing the header dialog
                     still produces the prefilled form (fixes #415). */}
-                <CreateMonitorDialog initialValues={storedPrefill ?? undefined} />
+                <CreateMonitorDialog
+                  initialValues={storedPrefill ?? undefined}
+                  onExternalOpenChange={(v) => { if (!v) setStoredPrefill(null); }}
+                />
               </div>
             );
           }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -359,10 +359,10 @@ export default function Dashboard() {
                   Start tracking web pages for changes by creating your first monitor. We'll notify you when content updates.
                 </p>
                 {/* Empty-state dialog is NOT externally controlled — the
-                    header dialog above already auto-opens on prefill. This
-                    instance inherits only the cached initialValues so that
-                    clicking its trigger after dismissing the header dialog
-                    still produces the prefilled form (fixes #415). */}
+                    header dialog above already auto-opens on prefill.
+                    This instance can receive cached initialValues while
+                    prefill is active, and clears cached prefill on close
+                    to prevent stale extension values on later opens. */}
                 <CreateMonitorDialog
                   initialValues={storedPrefill ?? undefined}
                   onExternalOpenChange={(v) => { if (!v) setStoredPrefill(null); }}

--- a/client/src/pages/blog-integrity.test.ts
+++ b/client/src/pages/blog-integrity.test.ts
@@ -244,7 +244,7 @@ describe("BlogSlackAlerts page integrity", () => {
     const headlineMatch = slackAlertsSource.match(/headline:\s*"([^"]+)"/);
     expect(headlineMatch).not.toBeNull();
     const headline = headlineMatch![1];
-    const h1Pattern = new RegExp(`<h1[^>]*>\\s*${headline.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}\\s*</h1>`);
+    const h1Pattern = new RegExp(`<h1[^>]*>\\s*${headline.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*</h1>`);
     expect(slackAlertsSource).toMatch(h1Pattern);
   });
 });

--- a/client/src/pages/not-found.test.tsx
+++ b/client/src/pages/not-found.test.tsx
@@ -96,4 +96,11 @@ describe("NotFound noindex meta tag", () => {
     expect(getByText("404 Page Not Found")).toBeDefined();
     unmount();
   });
+
+  it("renders user-facing description (not developer-facing copy)", () => {
+    const { getByText, queryByText, unmount } = render(<NotFound />);
+    expect(getByText(/doesn't exist or has been moved/)).toBeDefined();
+    expect(queryByText(/forget to add the page to the router/)).toBeNull();
+    unmount();
+  });
 });

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -56,16 +56,16 @@ export default function NotFound() {
   }, []);
 
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen w-full flex items-center justify-center bg-background">
       <Card className="w-full max-w-md mx-4">
         <CardContent className="pt-6">
           <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+            <AlertCircle className="h-8 w-8 text-destructive" />
+            <h1 className="text-2xl font-bold text-foreground">404 Page Not Found</h1>
           </div>
 
-          <p className="mt-4 text-sm text-gray-600">
-            Did you forget to add the page to the router?
+          <p className="mt-4 text-sm text-muted-foreground">
+            The page you're looking for doesn't exist or has been moved.
           </p>
         </CardContent>
       </Card>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2027,7 +2027,7 @@ export async function registerRoutes(
 
       const statusFilter = req.query.status as string | undefined;
       let results;
-      if (statusFilter && ["draft", "sending", "sent", "partially_sent", "cancelled"].includes(statusFilter)) {
+      if (statusFilter && ["draft", "sending", "sent", "partially_sent", "cancelled", "failed"].includes(statusFilter)) {
         results = await db
           .select()
           .from(campaignsTable)
@@ -2170,7 +2170,7 @@ export async function registerRoutes(
         .limit(1);
 
       if (!existing) return res.status(404).json({ message: "Campaign not found" });
-      if (existing.status !== "draft") return res.status(400).json({ message: "Only draft campaigns can be deleted" });
+      if (existing.status !== "draft" && existing.status !== "failed") return res.status(400).json({ message: "Only draft or failed campaigns can be deleted" });
 
       // Cascade delete recipients first
       await db.delete(campaignRecipientsTable).where(eq(campaignRecipientsTable.campaignId, id));

--- a/server/services/automatedCampaigns.ts
+++ b/server/services/automatedCampaigns.ts
@@ -341,7 +341,7 @@ export async function bootstrapWelcomeCampaign(): Promise<void> {
         // claimed in between, or a PG timestamp-precision mismatch
         // defeated the equality check. Route through ErrorLogger so
         // this triggers alerting, not just a console warning.
-        const msg = `Rollback WHERE guard matched zero rows for config ${config.id}; the config row may remain in a permanently advanced state.`;
+        const msg = `Rollback WHERE guard matched zero rows for config ${config.id}; the config row may remain in a permanently advanced state. Recovery: UPDATE automated_campaign_configs SET last_run_at = NULL, next_run_at = NULL, updated_at = NOW() WHERE id = ${config.id};`;
         console.warn(`[Bootstrap] ${msg}`);
         try {
           await ErrorLogger.error("scheduler", msg, null, { configId: config.id, configKey: config.key });
@@ -564,7 +564,7 @@ export async function processAutomatedCampaigns(): Promise<void> {
             // claimed in between, or a PG timestamp-precision mismatch
             // defeated the equality check. Route through ErrorLogger so
             // this triggers alerting, not just a console warning.
-            const msg = `Rollback WHERE guard matched zero rows for config '${config.key}' (id=${config.id}); the config row may remain in a permanently advanced state.`;
+            const msg = `Rollback WHERE guard matched zero rows for config '${config.key}' (id=${config.id}); the config row may remain in a permanently advanced state. Recovery: UPDATE automated_campaign_configs SET last_run_at = ${previousLastRunAt ? `'${previousLastRunAt.toISOString()}'` : 'NULL'}, next_run_at = ${previousNextRunAt ? `'${previousNextRunAt.toISOString()}'` : 'NULL'}, updated_at = NOW() WHERE id = ${config.id};`;
             console.warn(`[AutoCampaign] ${msg}`);
             try {
               await ErrorLogger.error("scheduler", msg, null, { configId: config.id, configKey: config.key });

--- a/server/services/campaignEmail.ts
+++ b/server/services/campaignEmail.ts
@@ -538,7 +538,7 @@ export async function cancelCampaign(campaignId: number): Promise<{ sentSoFar: n
         FOR UPDATE
       `);
       const currentStatus = (statusResult.rows[0] as any)?.status;
-      const terminalStatuses = ["sent", "cancelled", "partially_sent"];
+      const terminalStatuses = ["sent", "cancelled", "partially_sent", "failed"];
       if (!currentStatus || terminalStatuses.includes(currentStatus)) {
         skipped = true;
         return;

--- a/server/services/campaignEmail.ts
+++ b/server/services/campaignEmail.ts
@@ -487,7 +487,7 @@ async function finalizeCampaign(campaignId: number, status: string): Promise<voi
             completed_at = NOW()
             ${failedCount > 0 ? sql`, failed_count = COALESCE(failed_count, 0) + ${failedCount}` : sql``}
         WHERE id = ${campaignId}
-          AND status NOT IN ('sent', 'cancelled', 'partially_sent')
+          AND status NOT IN ('sent', 'cancelled', 'partially_sent', 'failed')
       `);
     });
   } else {
@@ -497,7 +497,7 @@ async function finalizeCampaign(campaignId: number, status: string): Promise<voi
       SET status = ${status},
           completed_at = NOW()
       WHERE id = ${campaignId}
-        AND status NOT IN ('sent', 'cancelled', 'partially_sent')
+        AND status NOT IN ('sent', 'cancelled', 'partially_sent', 'failed')
     `);
   }
 
@@ -563,7 +563,7 @@ export async function cancelCampaign(campaignId: number): Promise<{ sentSoFar: n
             completed_at = NOW()
             ${failedCount > 0 ? sql`, failed_count = COALESCE(failed_count, 0) + ${failedCount}` : sql``}
         WHERE id = ${campaignId}
-          AND status NOT IN ('sent', 'cancelled', 'partially_sent')
+          AND status NOT IN ('sent', 'cancelled', 'partially_sent', 'failed')
       `);
     });
 
@@ -596,7 +596,7 @@ export async function cancelCampaign(campaignId: number): Promise<{ sentSoFar: n
         UPDATE campaigns
         SET failed_count = COALESCE(failed_count, 0) + ${actualCancelled}
         WHERE id = ${campaignId}
-          AND status NOT IN ('sent', 'cancelled', 'partially_sent')
+          AND status NOT IN ('sent', 'cancelled', 'partially_sent', 'failed')
       `);
     }
   });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -144,7 +144,7 @@ export const campaigns = pgTable("campaigns", {
   subject: text("subject").notNull(),
   htmlBody: text("html_body").notNull(),
   textBody: text("text_body"),
-  status: text("status").default("draft").notNull(), // 'draft' | 'sending' | 'sent' | 'partially_sent' | 'cancelled'
+  status: text("status").default("draft").notNull(), // 'draft' | 'sending' | 'sent' | 'partially_sent' | 'cancelled' | 'failed'
   type: text("type").default("manual").notNull(), // 'manual' | 'automated'
   filters: jsonb("filters"), // { tier?: string[], signupBefore?, signupAfter?, minMonitors?, maxMonitors?, hasActiveMonitors? }
   totalRecipients: integer("total_recipients").default(0).notNull(),


### PR DESCRIPTION
## Summary

Resolves multiple GitHub issues (#412–#423) covering extension prefill persistence, welcome email URL migration, scheduler rollback hardening, SEO improvements, a new blog post, and the 404 page dark mode fix. Adds the "failed" campaign status across all surfaces (admin UI, schema, API filter, delete guard, terminal status guards) and hardens the automated campaign system against send failures with claim rollback and orphaned draft cleanup.

## Changes

**Bug fixes**
- Fix 404 page using hardcoded light-mode colors — use semantic Tailwind tokens (`bg-background`, `text-foreground`, `text-muted-foreground`, `text-destructive`) and replace developer-facing copy with user-friendly message (closes #423)
- Fix extension prefill URL lost during Dashboard loading skeleton — persist values in `storedPrefill` state (#412)
- Fix `CreateMonitorDialog` not calling `onExternalOpenChange` on successful creation — use `handleOpenChange(false)` (#415)
- Replace dead `/docs/extension` URL with `/support` in welcome email template + one-time DB migration via `patchWelcomeCampaignUrls()` (#420)
- Clear `storedPrefill` on dialog close (event-driven) instead of eager `monitors.length` heuristic
- Fix double-escaped regex in blog-integrity test

**Scheduler hardening**
- Roll back `lastRunAt`/`nextRunAt` on send failure in both `bootstrapWelcomeCampaign` and `processAutomatedCampaigns` — prevents permanently skipping user cohorts
- Clean up orphaned draft campaigns on send failure in `runWelcomeCampaign`; mark orphaned "sending" campaigns as "failed"
- Add "failed" to campaign status across all surfaces: schema comment, admin UI badge maps, API status filter allowlist, delete guard, and `finalizeCampaign`/`cancelCampaign` terminal status guards
- Include recovery SQL in rollback zero-rows error messages for faster incident response

**SEO & content**
- Add `SEOHead` to LandingPage, Blog index, and Pricing pages
- Add new blog post: "How to Get a Slack Alert When Any Webpage Changes"
- Add `seo-integrity.test.ts` enforcing every public page includes `SEOHead`
- Add noindex meta tag to 404 page to prevent soft-404 indexing
- Update Support FAQ copy for Slack connection/disconnection flow

**Infrastructure**
- Add graphify knowledge graph integration (`.gitignore`, `CLAUDE.md`, `.claude/settings.json`)

## How to test

1. Navigate to a non-existent route (e.g. `/nonexistent`) — verify 404 page uses dark theme colors and shows "The page you're looking for doesn't exist or has been moved."
2. Visit `/blog/slack-webpage-change-alerts` — verify blog post renders with JSON-LD, SEO head, back links, and CTA
3. Visit `/blog`, `/pricing`, `/` — verify each has a document title and meta description (inspect `<head>`)
4. Admin: visit `/admin/campaigns` — verify "Failed" badge renders with red destructive variant; verify filtering by status=failed returns only failed campaigns; verify failed campaigns can be deleted
5. Run `npm run check && npm run test` — all 2332 tests pass across 93 files
6. Run `npm run build` — production build succeeds

https://claude.ai/code/session_01TWz4mjCFJy1GXgeondhu9h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Failed" campaign status with destructive badge styling across campaign listings and detail views.
  * Admin campaign list and delete actions now recognize and support the "Failed" status.

* **Bug Fixes**
  * Create Monitor dialogs now reliably clear cached prefill when closed.
  * 404 page updated with friendlier text and theme-based colors.

* **Tests**
  * Added/adjusted tests for 404 content and JSON-LD headline matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->