### PR TITLE
fix: resolve open bug backlog #433–#444 with hardening pass

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -34,8 +34,8 @@
     <!--
       Direct <link> instead of a CSS @import so the font stylesheet fetches in
       parallel with index.css rather than serially blocking it on first paint.
-      Kept in sync with index.css; remove the @import there when touching this.
-      See issue #443.
+      Kept in sync with the font families referenced from client/src/index.css
+      — update both when changing fonts. See issue #443.
     -->
     <link
       rel="stylesheet"

--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <!--
+      No maximum-scale so low-vision users can still pinch-zoom (WCAG 2.1 SC
+      1.4.4, Level AA). The iOS auto-zoom-on-input behavior is handled by
+      ensuring form inputs use 16px+ font-size, not by suppressing zoom.
+      See issue #444.
+    -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0f172a" />
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#14b8a6" />
 
@@ -25,6 +31,16 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!--
+      Direct <link> instead of a CSS @import so the font stylesheet fetches in
+      parallel with index.css rather than serially blocking it on first paint.
+      Kept in sync with index.css; remove the @import there when touching this.
+      See issue #443.
+    -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -62,7 +62,12 @@ function ProtectedRoute({ component: Component, requiredTier, ...rest }: any) {
   }
 
   if (!user) {
-    return <LandingPage />;
+    // Pass the actual URL so LandingPage emits canonical/og:url/JSON-LD for
+    // the real path (e.g. "/dashboard") instead of lying about it being "/".
+    // See GitHub issue #439.
+    const currentPath =
+      typeof window !== "undefined" ? window.location.pathname : "/";
+    return <LandingPage path={currentPath} />;
   }
 
   if (requiredTier && user.tier !== requiredTier) {

--- a/client/src/hooks/use-monitors.test.ts
+++ b/client/src/hooks/use-monitors.test.ts
@@ -744,9 +744,11 @@ describe("useUpdateMonitorSilent", () => {
 
 describe("useCheckMonitor AbortSignal behavior (#437)", () => {
   it("aborts in-flight check fetches when the component unmounts", async () => {
+    let fetchStarted = false;
     let aborted = false;
     server.use(
       http.post(api.monitors.check.path, async ({ request }) => {
+        fetchStarted = true;
         await new Promise<void>((resolve) => {
           request.signal.addEventListener("abort", () => {
             aborted = true;
@@ -765,18 +767,17 @@ describe("useCheckMonitor AbortSignal behavior (#437)", () => {
       result.current.mutate(1);
     });
 
-    // Give the mutation a tick to dispatch the fetch
-    await new Promise((r) => setTimeout(r, 20));
+    await waitFor(() => expect(fetchStarted).toBe(true));
     unmount();
-    await new Promise((r) => setTimeout(r, 20));
-
-    expect(aborted).toBe(true);
+    await waitFor(() => expect(aborted).toBe(true));
   });
 
   it("useCheckMonitorSilent also aborts in-flight fetches on unmount", async () => {
+    let fetchStarted = false;
     let aborted = false;
     server.use(
       http.post(api.monitors.check.path, async ({ request }) => {
+        fetchStarted = true;
         await new Promise<void>((resolve) => {
           request.signal.addEventListener("abort", () => {
             aborted = true;
@@ -795,10 +796,8 @@ describe("useCheckMonitor AbortSignal behavior (#437)", () => {
       result.current.mutate(1);
     });
 
-    await new Promise((r) => setTimeout(r, 20));
+    await waitFor(() => expect(fetchStarted).toBe(true));
     unmount();
-    await new Promise((r) => setTimeout(r, 20));
-
-    expect(aborted).toBe(true);
+    await waitFor(() => expect(aborted).toBe(true));
   });
 });

--- a/client/src/hooks/use-monitors.test.ts
+++ b/client/src/hooks/use-monitors.test.ts
@@ -741,3 +741,64 @@ describe("useUpdateMonitorSilent", () => {
     expect(patchedId).toBe("1");
   });
 });
+
+describe("useCheckMonitor AbortSignal behavior (#437)", () => {
+  it("aborts in-flight check fetches when the component unmounts", async () => {
+    let aborted = false;
+    server.use(
+      http.post(api.monitors.check.path, async ({ request }) => {
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => {
+            aborted = true;
+            resolve();
+          });
+        });
+        return new Promise(() => {}) as Promise<Response>;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useCheckMonitor(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate(1);
+    });
+
+    // Give the mutation a tick to dispatch the fetch
+    await new Promise((r) => setTimeout(r, 20));
+    unmount();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(aborted).toBe(true);
+  });
+
+  it("useCheckMonitorSilent also aborts in-flight fetches on unmount", async () => {
+    let aborted = false;
+    server.use(
+      http.post(api.monitors.check.path, async ({ request }) => {
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => {
+            aborted = true;
+            resolve();
+          });
+        });
+        return new Promise(() => {}) as Promise<Response>;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useCheckMonitorSilent(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate(1);
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    unmount();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(aborted).toBe(true);
+  });
+});

--- a/client/src/hooks/use-monitors.ts
+++ b/client/src/hooks/use-monitors.ts
@@ -1,7 +1,28 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { api, buildUrl } from "@shared/routes";
 import { type InsertMonitor } from "@shared/schema";
 import { useToast } from "@/hooks/use-toast";
+
+/**
+ * Tracks a set of AbortControllers for in-flight mutation fetches and aborts
+ * them all on unmount. React Query v5's `mutationFn` does not receive a
+ * cancellation signal (unlike `queryFn`), so we plumb one in ourselves. Used
+ * by useCheckMonitor / useCheckMonitorSilent so an in-flight monitor check
+ * stops burning browserless/scraper quota once the user navigates away.
+ * See GitHub issue #437.
+ */
+function useAbortableFetchers() {
+  const controllersRef = useRef<Set<AbortController>>(new Set());
+  useEffect(() => {
+    const controllers = controllersRef.current;
+    return () => {
+      controllers.forEach((c) => c.abort());
+      controllers.clear();
+    };
+  }, []);
+  return controllersRef;
+}
 
 // GET /api/monitors
 export function useMonitors() {
@@ -161,24 +182,32 @@ export function useDeleteMonitor() {
 export function useCheckMonitor() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const controllersRef = useAbortableFetchers();
 
   return useMutation({
     mutationFn: async (id: number) => {
+      const controller = new AbortController();
+      controllersRef.current.add(controller);
       const url = buildUrl(api.monitors.check.path, { id });
-      const res = await fetch(url, {
-        method: api.monitors.check.method,
-        credentials: "include",
-      });
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}));
-        if (res.status === 429) {
-          throw new Error(errorData.message || "Rate limit reached. Please try again later.");
+      try {
+        const res = await fetch(url, {
+          method: api.monitors.check.method,
+          credentials: "include",
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          const errorData = await res.json().catch(() => ({}));
+          if (res.status === 429) {
+            throw new Error(errorData.message || "Rate limit reached. Please try again later.");
+          }
+          throw new Error(errorData.message || "Failed to check monitor");
         }
-        throw new Error(errorData.message || "Failed to check monitor");
+        return api.monitors.check.responses[200].parse(await res.json().catch(() => {
+          throw new Error("Unexpected response format from server");
+        }));
+      } finally {
+        controllersRef.current.delete(controller);
       }
-      return api.monitors.check.responses[200].parse(await res.json().catch(() => {
-        throw new Error("Unexpected response format from server");
-      }));
     },
     onSuccess: (data, id) => {
       queryClient.invalidateQueries({ queryKey: [api.monitors.list.path] });
@@ -200,21 +229,29 @@ export function useCheckMonitor() {
 // POST /api/monitors/:id/check (silent version for fix selector flow)
 export function useCheckMonitorSilent() {
   const queryClient = useQueryClient();
+  const controllersRef = useAbortableFetchers();
 
   return useMutation({
     mutationFn: async (id: number) => {
+      const controller = new AbortController();
+      controllersRef.current.add(controller);
       const url = buildUrl(api.monitors.check.path, { id });
-      const res = await fetch(url, {
-        method: api.monitors.check.method,
-        credentials: "include",
-      });
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}));
-        throw new Error(errorData.message || "Failed to check monitor");
+      try {
+        const res = await fetch(url, {
+          method: api.monitors.check.method,
+          credentials: "include",
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          const errorData = await res.json().catch(() => ({}));
+          throw new Error(errorData.message || "Failed to check monitor");
+        }
+        return api.monitors.check.responses[200].parse(await res.json().catch(() => {
+          throw new Error("Unexpected response format from server");
+        }));
+      } finally {
+        controllersRef.current.delete(controller);
       }
-      return api.monitors.check.responses[200].parse(await res.json().catch(() => {
-        throw new Error("Unexpected response format from server");
-      }));
     },
     onSuccess: (_, id) => {
       queryClient.invalidateQueries({ queryKey: [api.monitors.list.path] });

--- a/client/src/hooks/use-monitors.ts
+++ b/client/src/hooks/use-monitors.ts
@@ -14,9 +14,18 @@ import { useToast } from "@/hooks/use-toast";
  */
 function useAbortableFetchers() {
   const controllersRef = useRef<Set<AbortController>>(new Set());
+  // Tracks whether the component is currently mounted. Without this, React 18
+  // StrictMode's double-invoke (mount → cleanup → mount) would abort every
+  // controller started in the mount window and leave the hook permanently
+  // cleared. Mutations started after the real mount re-set this to true.
+  const mountedRef = useRef(true);
   useEffect(() => {
+    mountedRef.current = true;
+    // Capture the Set reference so the cleanup aborts the same object the
+    // effect opened with, even if the ref's .current is ever reassigned.
     const controllers = controllersRef.current;
     return () => {
+      mountedRef.current = false;
       controllers.forEach((c) => c.abort());
       controllers.clear();
     };

--- a/client/src/hooks/use-monitors.ts
+++ b/client/src/hooks/use-monitors.ts
@@ -14,18 +14,11 @@ import { useToast } from "@/hooks/use-toast";
  */
 function useAbortableFetchers() {
   const controllersRef = useRef<Set<AbortController>>(new Set());
-  // Tracks whether the component is currently mounted. Without this, React 18
-  // StrictMode's double-invoke (mount → cleanup → mount) would abort every
-  // controller started in the mount window and leave the hook permanently
-  // cleared. Mutations started after the real mount re-set this to true.
-  const mountedRef = useRef(true);
   useEffect(() => {
-    mountedRef.current = true;
     // Capture the Set reference so the cleanup aborts the same object the
     // effect opened with, even if the ref's .current is ever reassigned.
     const controllers = controllersRef.current;
     return () => {
-      mountedRef.current = false;
       controllers.forEach((c) => c.abort());
       controllers.clear();
     };

--- a/client/src/hooks/use-page-title.test.ts
+++ b/client/src/hooks/use-page-title.test.ts
@@ -31,6 +31,14 @@ describe("usePageTitle", () => {
     expect(document.title).toBe("unchanged");
   });
 
+  it("does not change title when given an empty string", () => {
+    // Locks down the `!title` guard so a future tightening to `=== undefined`
+    // doesn't silently clobber document.title with "".
+    document.title = "unchanged";
+    renderHook(() => usePageTitle(""));
+    expect(document.title).toBe("unchanged");
+  });
+
   it("updates title when the prop changes", () => {
     const { rerender } = renderHook(
       ({ title }: { title: string }) => usePageTitle(title),

--- a/client/src/hooks/use-page-title.test.ts
+++ b/client/src/hooks/use-page-title.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests: usePageTitle hook (GitHub issue #441)
+ *
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { usePageTitle } from "./use-page-title";
+
+describe("usePageTitle", () => {
+  beforeEach(() => {
+    document.title = "initial";
+  });
+
+  it("sets document.title on mount", () => {
+    renderHook(() => usePageTitle("My Page — FetchTheChange"));
+    expect(document.title).toBe("My Page — FetchTheChange");
+  });
+
+  it("restores the previous title on unmount", () => {
+    document.title = "previous";
+    const { unmount } = renderHook(() => usePageTitle("My Page"));
+    expect(document.title).toBe("My Page");
+    unmount();
+    expect(document.title).toBe("previous");
+  });
+
+  it("does not change title when given undefined", () => {
+    document.title = "unchanged";
+    renderHook(() => usePageTitle(undefined));
+    expect(document.title).toBe("unchanged");
+  });
+
+  it("updates title when the prop changes", () => {
+    const { rerender } = renderHook(
+      ({ title }: { title: string }) => usePageTitle(title),
+      { initialProps: { title: "First" } },
+    );
+    expect(document.title).toBe("First");
+    rerender({ title: "Second" });
+    expect(document.title).toBe("Second");
+  });
+
+  it("nested unmount still restores the outer title", () => {
+    document.title = "outer";
+    const outer = renderHook(() => usePageTitle("outer-page"));
+    expect(document.title).toBe("outer-page");
+    const inner = renderHook(() => usePageTitle("inner-page"));
+    expect(document.title).toBe("inner-page");
+    inner.unmount();
+    // After inner unmounts its title effect restores the value that was
+    // current when it mounted — which was outer-page.
+    expect(document.title).toBe("outer-page");
+    outer.unmount();
+    expect(document.title).toBe("outer");
+  });
+});

--- a/client/src/hooks/use-page-title.ts
+++ b/client/src/hooks/use-page-title.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+/**
+ * Sets document.title for authenticated, noindex pages where SEOHead isn't
+ * warranted. Restores the previous title on unmount so navigating between
+ * authenticated pages doesn't leave a stale label when one doesn't set its
+ * own title. See GitHub issue #441.
+ */
+export function usePageTitle(title: string | undefined): void {
+  useEffect(() => {
+    if (!title) return;
+    const previous = document.title;
+    document.title = title;
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,9 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap');
+/*
+ * Google Fonts are now loaded via a direct <link> in client/index.html so the
+ * stylesheet fetch parallelizes with this file instead of blocking first paint
+ * behind a serial @import. Keep that tag's family list in sync when changing
+ * fonts. See issue #443.
+ */
 
 @tailwind base;
 @tailwind components;
@@ -7,6 +12,15 @@
 :root {
   --font-display: 'Outfit', sans-serif;
   --font-body: 'Inter', sans-serif;
+  /*
+   * Referenced by tailwind.config.ts's fontFamily.{sans,serif,mono}.
+   * Without these declarations, `font-mono` (API keys, CSS selectors, error
+   * codes, stack traces) falls back to Inter and renders in a proportional
+   * sans-serif, making O/0 and I/l visually indistinguishable. See issue #442.
+   */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
   /* Elegant Teal & Slate Palette */
   --background: 210 40% 98%;

--- a/client/src/pages/AdminCampaignDetail.tsx
+++ b/client/src/pages/AdminCampaignDetail.tsx
@@ -39,6 +39,7 @@ import { Link, useParams } from "wouter";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import DashboardNav from "@/components/DashboardNav";
 import { useCampaignAnalytics, useCancelCampaign } from "@/hooks/use-campaigns";
+import { usePageTitle } from "@/hooks/use-page-title";
 
 const statusConfig: Record<string, { variant: "default" | "secondary" | "outline" | "destructive"; label: string }> = {
   draft: { variant: "outline", label: "Draft" },
@@ -74,6 +75,7 @@ export default function AdminCampaignDetail() {
   const params = useParams<{ id: string }>();
   const id = Number(params.id);
   const { data, isLoading } = useCampaignAnalytics(id);
+  usePageTitle(data?.campaign?.name ? `${data.campaign.name} — FetchTheChange` : "Campaign — FetchTheChange");
   const cancelCampaign = useCancelCampaign();
 
   if (isLoading || !data) {

--- a/client/src/pages/AdminCampaigns.tsx
+++ b/client/src/pages/AdminCampaigns.tsx
@@ -55,6 +55,7 @@ import {
 } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import DashboardNav from "@/components/DashboardNav";
+import { usePageTitle } from "@/hooks/use-page-title";
 import {
   useCampaigns,
   useCampaignDashboard,
@@ -696,6 +697,7 @@ function AutomatedCampaignsTab() {
 }
 
 export default function AdminCampaigns() {
+  usePageTitle("Admin: Campaigns — FetchTheChange");
   const [, navigate] = useLocation();
   const { data: campaigns, isLoading } = useCampaigns();
   const { data: dashboard } = useCampaignDashboard();

--- a/client/src/pages/AdminErrors.tsx
+++ b/client/src/pages/AdminErrors.tsx
@@ -14,6 +14,7 @@ import { ERROR_LOG_SOURCES } from "@shared/routes";
 import type { ErrorLog } from "@shared/schema";
 import { queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { ToastAction } from "@/components/ui/toast";
 
 /** JSON-serialized ErrorLog — Date fields become strings over the wire. */
@@ -65,6 +66,7 @@ const levelConfig: Record<string, { icon: typeof XCircle; variant: "destructive"
 const UNDO_TIMEOUT_MS = 5000;
 
 export default function AdminErrors() {
+  usePageTitle("Admin: Errors — FetchTheChange");
   const [levelFilter, setLevelFilter] = useState<string>("all");
   const [sourceFilter, setSourceFilter] = useState<string>("all");
   const [expandedId, setExpandedId] = useState<number | null>(null);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@/hooks/use-auth";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { useMonitors, useCheckMonitor } from "@/hooks/use-monitors";
 import { useQueryClient } from "@tanstack/react-query";
 import { api, buildUrl } from "@shared/routes";
@@ -25,6 +26,7 @@ const BANNER_CUTOFF = new Date("2026-02-27T00:00:00Z");
 const BANNER_KEY = "ftc-free-tier-banner-dismissed";
 
 export default function Dashboard() {
+  usePageTitle("Dashboard — FetchTheChange");
   const { user, logout } = useAuth();
   const { data: monitors, isLoading, error, refetch } = useMonitors();
   const { mutate: checkMonitor, isPending: isChecking } = useCheckMonitor();
@@ -131,7 +133,19 @@ export default function Dashboard() {
   const handleRefresh = async () => {
     console.log("Refreshing monitors...");
     // Use the fresh data returned by refetch() instead of the stale closure variable
-    const { data: freshMonitors } = await refetch();
+    const { data: freshMonitors, error: refetchError } = await refetch();
+
+    // refetch() resolves with {data:undefined,error} on network/HTTP failure —
+    // surface that distinctly so users aren't told "No monitors" when the real
+    // cause is a failed GET /api/monitors. See GitHub issue #435.
+    if (refetchError) {
+      toast({
+        variant: "destructive",
+        title: "Refresh failed",
+        description: refetchError.message || "Could not load monitors. Please try again.",
+      });
+      return;
+    }
 
     if (!freshMonitors || freshMonitors.length === 0) {
       toast({ title: "No monitors", description: "Create a monitor first to refresh data." });

--- a/client/src/pages/ExtensionAuth.tsx
+++ b/client/src/pages/ExtensionAuth.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "@/hooks/use-auth";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { Button } from "@/components/ui/button";
 import { Loader2, CheckCircle2, Chrome } from "lucide-react";
 
@@ -46,6 +47,7 @@ async function requestToken(): Promise<{ token: string; expiresAt: string }> {
 }
 
 export default function ExtensionAuth() {
+  usePageTitle("Connect Extension — FetchTheChange");
   const { user, isLoading } = useAuth();
   const [tokenSent, setTokenSent] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -60,7 +60,18 @@ export const LANDING_PLAN_PRICES_USD: ReadonlyArray<{
   { name: "Power", price: 29 },
 ];
 
-export default function LandingPage() {
+interface LandingPageProps {
+  /**
+   * Override the path emitted in canonical / og:url / JSON-LD `@id`. Defaults
+   * to "/" (the intended public URL). ProtectedRoute passes the actual
+   * `window.location.pathname` when rendering LandingPage as the unauthed
+   * fallback on protected paths like `/dashboard`, so canonical and og:url
+   * reflect the real URL instead of lying about it. See GitHub issue #439.
+   */
+  path?: string;
+}
+
+export default function LandingPage({ path = "/" }: LandingPageProps = {}) {
   const jsonLd = useMemo(
     () => ({
       "@context": "https://schema.org",
@@ -111,7 +122,7 @@ export default function LandingPage() {
       <SEOHead
         title="FetchTheChange — Monitor any web value. Get alerted when it changes."
         description="Website change monitoring that works on modern, JavaScript-heavy sites. Track prices, availability, text, and any DOM value — and get told when tracking breaks, not just when values change."
-        path="/"
+        path={path}
         ogDescription="Monitor any web value. Get alerted when it changes. Works on JavaScript-heavy sites and tells you when tracking breaks."
         twitterDescription="Monitor any web value. Get alerted when it changes. Works on JavaScript-heavy sites and tells you when tracking breaks."
         jsonLd={jsonLd}

--- a/client/src/pages/MonitorDetails.tsx
+++ b/client/src/pages/MonitorDetails.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useRoute, Link } from "wouter";
 import { formatDateTime } from "@/lib/date-format";
 import { useAuth } from "@/hooks/use-auth";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { useMonitor, useMonitorHistory, useCheckMonitor, useDeleteMonitor, useUpdateMonitor } from "@/hooks/use-monitors";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -40,6 +41,7 @@ export default function MonitorDetails() {
   const [isEditing, setIsEditing] = useState(false);
   
   const { data: monitor, isLoading: loadingMonitor, error } = useMonitor(id);
+  usePageTitle(monitor ? `${monitor.name} — FetchTheChange` : "Monitor — FetchTheChange");
   const { data: history, isLoading: loadingHistory } = useMonitorHistory(id);
   const { mutate: checkNow, isPending: isChecking } = useCheckMonitor();
   const { mutate: deleteMonitor, isPending: isDeleting } = useDeleteMonitor();

--- a/client/src/pages/page-metadata-parity.test.ts
+++ b/client/src/pages/page-metadata-parity.test.ts
@@ -41,7 +41,18 @@ function extractSEOPath(src: string): string | null {
   const seoBlock = src.match(/<SEOHead[\s\S]*?\/>/);
   if (!seoBlock) return null;
   const staticPath = seoBlock[0].match(/path\s*=\s*"([^"]+)"/);
-  return staticPath ? staticPath[1] : null;
+  if (staticPath) return staticPath[1];
+  // Resolve one level of const indirection (e.g., blog pages use
+  // `path={BLOG_PATH}` with `const BLOG_PATH = "..."` defined in the same
+  // file). Without this, all 7 blog posts silently bypass the parity test —
+  // exactly the surface most likely to drift (Phase 5 skeptic Concern 1).
+  const constRefMatch = seoBlock[0].match(/path\s*=\s*\{(\w+)\}/);
+  if (!constRefMatch) return null;
+  const varName = constRefMatch[1];
+  const constDef = src.match(
+    new RegExp(`const\\s+${varName}\\s*=\\s*"([^"]+)"`),
+  );
+  return constDef ? constDef[1] : null;
 }
 
 // Pages where SEOHead receives a path literal AND the title/description are

--- a/client/src/pages/page-metadata-parity.test.ts
+++ b/client/src/pages/page-metadata-parity.test.ts
@@ -25,11 +25,15 @@ function readPage(file: string): string {
   return fs.readFileSync(path.join(PAGES_DIR, file), "utf-8");
 }
 
+// Match both the self-closing form (`<SEOHead ... />`) and the element form
+// (`<SEOHead ...>children</SEOHead>`). Without the second branch, any page
+// that adds SEOHead children (or accidentally wraps props such that the tag
+// closes with `>` instead of `/>`) silently bypasses the parity test — which
+// is exactly the drift scenario this file exists to catch.
+const SEO_BLOCK_RE = /<SEOHead\b[\s\S]*?(?:\/>|>)/;
+
 function extractSEOProp(src: string, prop: string): string | null {
-  // Match prop="..." inside a <SEOHead> block. Doesn't handle JSX expressions
-  // like title={foo} — those pages are excluded from the parity check
-  // because they compute metadata dynamically.
-  const seoBlock = src.match(/<SEOHead[\s\S]*?\/>/);
+  const seoBlock = src.match(SEO_BLOCK_RE);
   if (!seoBlock) return null;
   const m = seoBlock[0].match(
     new RegExp(`${prop}\\s*=\\s*"((?:[^"\\\\]|\\\\.)*)"`),
@@ -38,7 +42,7 @@ function extractSEOProp(src: string, prop: string): string | null {
 }
 
 function extractSEOPath(src: string): string | null {
-  const seoBlock = src.match(/<SEOHead[\s\S]*?\/>/);
+  const seoBlock = src.match(SEO_BLOCK_RE);
   if (!seoBlock) return null;
   const staticPath = seoBlock[0].match(/path\s*=\s*"([^"]+)"/);
   if (staticPath) return staticPath[1];
@@ -55,18 +59,40 @@ function extractSEOPath(src: string): string | null {
   return constDef ? constDef[1] : null;
 }
 
+// LandingPage intentionally computes its path prop dynamically (to support
+// ProtectedRoute rendering it at /dashboard / /monitors/:id for logged-out
+// visitors — see issue #439). Every OTHER SEOHead-rendering public page must
+// resolve to a literal path and survive parity. Keeping this opt-out list
+// explicit so the "no silent bypass" assertion below can include LandingPage
+// in the denominator without false-positiving.
+const INTENTIONALLY_DYNAMIC_PAGES = new Set(["LandingPage.tsx"]);
+
 // Pages where SEOHead receives a path literal AND the title/description are
-// also literals — those are the ones we can statically compare. LandingPage
-// takes an optional path prop so its SEOHead call uses {path}, skipped here.
+// also literals — those are the ones we can statically compare.
 const publicPageFiles = fs
   .readdirSync(PAGES_DIR)
   .filter((f) => f.endsWith(".tsx") && !f.endsWith(".test.tsx"))
   .filter((f) => readPage(f).includes("PublicNav"))
+  .filter((f) => !INTENTIONALLY_DYNAMIC_PAGES.has(f))
   .filter((f) => extractSEOPath(readPage(f)) !== null);
 
 describe("PAGE_METADATA ↔ SEOHead parity (issue #440)", () => {
   it("finds at least 5 pages to compare (sanity)", () => {
     expect(publicPageFiles.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("covers every PublicNav page that renders <SEOHead> (no silent bypass)", () => {
+    // If a page adds <SEOHead ...> but extractSEOPath fails to resolve its
+    // path (e.g., a new non-literal prop pattern), this assertion flags the
+    // gap instead of letting the page silently drop out of coverage.
+    // LandingPage is excluded because its path prop is intentionally dynamic.
+    const allSeoPages = fs
+      .readdirSync(PAGES_DIR)
+      .filter((f) => f.endsWith(".tsx") && !f.endsWith(".test.tsx"))
+      .filter((f) => readPage(f).includes("PublicNav"))
+      .filter((f) => !INTENTIONALLY_DYNAMIC_PAGES.has(f))
+      .filter((f) => readPage(f).includes("<SEOHead"));
+    expect(publicPageFiles.length).toBe(allSeoPages.length);
   });
 
   for (const file of publicPageFiles) {

--- a/client/src/pages/page-metadata-parity.test.ts
+++ b/client/src/pages/page-metadata-parity.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Parity test between PAGE_METADATA (server-side, for crawlers) and each
+ * page's <SEOHead> call (client-side, for human visitors after JS runs).
+ *
+ * Link unfurls on Facebook/X/Slack/LinkedIn/Discord don't execute JS, so
+ * server/crawlerMeta.ts rewrites index.html's <head> using PAGE_METADATA.
+ * That means every public page now has two titles and two descriptions —
+ * one in PAGE_METADATA and one in SEOHead props. Without an integrity test,
+ * they silently drift as pages are edited.
+ *
+ * This test statically reads each page's source and asserts that the
+ * <SEOHead path="…"> value has a matching PAGE_METADATA entry. Titles and
+ * descriptions must match character-for-character where both are present.
+ *
+ * See GitHub issue #440 and Phase 3 architect review.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { PAGE_METADATA } from "@shared/pageMetadata";
+
+const PAGES_DIR = path.resolve(__dirname);
+
+function readPage(file: string): string {
+  return fs.readFileSync(path.join(PAGES_DIR, file), "utf-8");
+}
+
+function extractSEOProp(src: string, prop: string): string | null {
+  // Match prop="..." inside a <SEOHead> block. Doesn't handle JSX expressions
+  // like title={foo} — those pages are excluded from the parity check
+  // because they compute metadata dynamically.
+  const seoBlock = src.match(/<SEOHead[\s\S]*?\/>/);
+  if (!seoBlock) return null;
+  const m = seoBlock[0].match(
+    new RegExp(`${prop}\\s*=\\s*"((?:[^"\\\\]|\\\\.)*)"`),
+  );
+  return m ? m[1] : null;
+}
+
+function extractSEOPath(src: string): string | null {
+  const seoBlock = src.match(/<SEOHead[\s\S]*?\/>/);
+  if (!seoBlock) return null;
+  const staticPath = seoBlock[0].match(/path\s*=\s*"([^"]+)"/);
+  return staticPath ? staticPath[1] : null;
+}
+
+// Pages where SEOHead receives a path literal AND the title/description are
+// also literals — those are the ones we can statically compare. LandingPage
+// takes an optional path prop so its SEOHead call uses {path}, skipped here.
+const publicPageFiles = fs
+  .readdirSync(PAGES_DIR)
+  .filter((f) => f.endsWith(".tsx") && !f.endsWith(".test.tsx"))
+  .filter((f) => readPage(f).includes("PublicNav"))
+  .filter((f) => extractSEOPath(readPage(f)) !== null);
+
+describe("PAGE_METADATA ↔ SEOHead parity (issue #440)", () => {
+  it("finds at least 5 pages to compare (sanity)", () => {
+    expect(publicPageFiles.length).toBeGreaterThanOrEqual(5);
+  });
+
+  for (const file of publicPageFiles) {
+    const src = readPage(file);
+    const seoPath = extractSEOPath(src)!;
+
+    it(`${file}: PAGE_METADATA["${seoPath}"] exists`, () => {
+      expect(PAGE_METADATA[seoPath]).toBeDefined();
+    });
+
+    const seoTitle = extractSEOProp(src, "title");
+    if (seoTitle) {
+      it(`${file}: title matches PAGE_METADATA["${seoPath}"].title`, () => {
+        expect(PAGE_METADATA[seoPath]?.title).toBe(seoTitle);
+      });
+    }
+
+    const seoDesc = extractSEOProp(src, "description");
+    if (seoDesc) {
+      it(`${file}: description matches PAGE_METADATA["${seoPath}"].description`, () => {
+        expect(PAGE_METADATA[seoPath]?.description).toBe(seoDesc);
+      });
+    }
+  }
+});

--- a/client/src/pages/seo-integrity.test.ts
+++ b/client/src/pages/seo-integrity.test.ts
@@ -44,7 +44,10 @@ describe("LandingPage SEOHead props", () => {
     expect(src).toMatch(/description="[^"]+"/);
   });
 
-  it('uses path="/"', () => {
-    expect(src).toContain('path="/"');
+  it('defaults path to "/" (with optional override for ProtectedRoute fallback)', () => {
+    // LandingPage accepts an optional path prop so ProtectedRoute can render
+    // it at protected paths (/dashboard, /monitors/:id) with the real URL in
+    // canonical/og:url rather than lying about it being "/". See issue #439.
+    expect(src).toMatch(/path\s*=\s*"\/"/);
   });
 });

--- a/server/crawlerMeta.test.ts
+++ b/server/crawlerMeta.test.ts
@@ -100,6 +100,46 @@ describe("rewriteIndexHtmlForCrawler", () => {
     expect(ogDescMatch).not.toBeNull();
     expect(ogDescMatch?.[1]).not.toMatch(/[^&]".*"/); // no unescaped quote pairs
   });
+
+  it("rewrites tags even when attributes are split across multiple lines", () => {
+    // \s+ in JS regex matches newlines by default, but lock that in so a
+    // future prettier reformat or hand-edit that line-wraps attributes
+    // doesn't silently break the rewriter.
+    const multilineTemplate = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta
+      name="description"
+      content="landing description"
+    />
+    <meta
+      property="og:title"
+      content="landing title"
+    />
+    <meta
+      property="og:url"
+      content="https://old.example.com/"
+    />
+  </head>
+</html>`;
+    const out = rewriteIndexHtmlForCrawler(
+      multilineTemplate,
+      "/pricing",
+      "https://ftc.bd73.com",
+    );
+    const pricingMeta = getPageMetadata("/pricing");
+    expect(out).toContain(
+      `<meta name="description" content="${pricingMeta.description.replace(/&/g, "&amp;").replace(/"/g, "&quot;")}" />`,
+    );
+    expect(out).toContain(
+      `<meta property="og:title" content="${pricingMeta.title}" />`,
+    );
+    expect(out).toContain(
+      '<meta property="og:url" content="https://ftc.bd73.com/pricing" />',
+    );
+    expect(out).not.toContain("landing description");
+    expect(out).not.toContain("landing title");
+  });
 });
 
 describe("getPageMetadata", () => {
@@ -117,6 +157,82 @@ describe("getPageMetadata", () => {
   it("falls back to landing metadata for an unknown path", () => {
     const meta = getPageMetadata("/no-such-route-exists");
     expect(meta.title).toContain("FetchTheChange");
+  });
+
+  it("normalizes trailing slash before lookup (#440 skeptic Concern 7)", () => {
+    expect(getPageMetadata("/pricing/").title).toBe(
+      getPageMetadata("/pricing").title,
+    );
+  });
+
+  it("does not strip the root path's slash", () => {
+    expect(getPageMetadata("/").title).toContain("FetchTheChange");
+  });
+});
+
+describe("rewriteIndexHtmlForCrawler noindex for unknown paths (Concern 2)", () => {
+  it("injects robots noindex when the path has no PAGE_METADATA entry", () => {
+    const out = rewriteIndexHtmlForCrawler(
+      TEMPLATE,
+      "/no-such-path",
+      "https://ftc.bd73.com",
+    );
+    expect(out).toContain('<meta name="robots" content="noindex" />');
+    // og:url still reflects the real path so a caller can see what was hit
+    expect(out).toContain(
+      '<meta property="og:url" content="https://ftc.bd73.com/no-such-path" />',
+    );
+  });
+
+  it("does NOT inject noindex for known paths", () => {
+    const out = rewriteIndexHtmlForCrawler(
+      TEMPLATE,
+      "/pricing",
+      "https://ftc.bd73.com",
+    );
+    expect(out).not.toContain('<meta name="robots" content="noindex" />');
+  });
+
+  it("normalizes trailing slash so /pricing/ is treated as known", () => {
+    const out = rewriteIndexHtmlForCrawler(
+      TEMPLATE,
+      "/pricing/",
+      "https://ftc.bd73.com",
+    );
+    expect(out).not.toContain('<meta name="robots" content="noindex" />');
+    // Canonical should point at the trailing-slash-stripped URL
+    expect(out).toContain(
+      '<link rel="canonical" href="https://ftc.bd73.com/pricing" />',
+    );
+  });
+});
+
+describe("client/index.html contains exactly one of each rewritten tag", () => {
+  // The regex rewriter replaces only the first occurrence. A duplicate meta
+  // tag (from a Vite plugin injection or hand-edit) would leave the second
+  // copy showing landing-page content. Lock in the invariant. See Phase 5
+  // skeptic Concern 7.
+  const clientIndex = fs.readFileSync(
+    path.resolve(__dirname, "..", "client", "index.html"),
+    "utf-8",
+  );
+  const countOccurrences = (re: RegExp): number =>
+    (clientIndex.match(re) ?? []).length;
+
+  it.each([
+    ["<title>", /<title>/gi],
+    ["description", /<meta\s+name="description"/gi],
+    ["canonical link", /<link\s+rel="canonical"/gi],
+    ["og:type", /<meta\s+property="og:type"/gi],
+    ["og:title", /<meta\s+property="og:title"/gi],
+    ["og:description", /<meta\s+property="og:description"/gi],
+    ["og:url", /<meta\s+property="og:url"/gi],
+    ["og:image", /<meta\s+property="og:image"/gi],
+    ["twitter:title", /<meta\s+name="twitter:title"/gi],
+    ["twitter:description", /<meta\s+name="twitter:description"/gi],
+    ["twitter:image", /<meta\s+name="twitter:image"/gi],
+  ])("has exactly one %s tag", (_label, re) => {
+    expect(countOccurrences(re)).toBe(1);
   });
 });
 

--- a/server/crawlerMeta.test.ts
+++ b/server/crawlerMeta.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
 import {
   isCrawlerUserAgent,
   rewriteIndexHtmlForCrawler,
@@ -115,5 +117,46 @@ describe("getPageMetadata", () => {
   it("falls back to landing metadata for an unknown path", () => {
     const meta = getPageMetadata("/no-such-route-exists");
     expect(meta.title).toContain("FetchTheChange");
+  });
+});
+
+describe("rewriteIndexHtmlForCrawler runs against the real client/index.html", () => {
+  // Prevents silent drift: if someone edits client/index.html to reorder
+  // attributes, single-quote values, or split a tag across lines, the regex-
+  // based rewriter in crawlerMeta.ts would otherwise no-op and crawlers would
+  // keep seeing the landing-page fallback. See Phase 3 architecture review.
+  const clientIndexPath = path.resolve(__dirname, "..", "client", "index.html");
+  const realTemplate = fs.readFileSync(clientIndexPath, "utf-8");
+
+  it("rewrites every expected head tag in the real template", () => {
+    const out = rewriteIndexHtmlForCrawler(
+      realTemplate,
+      "/pricing",
+      "https://ftc.bd73.com",
+    );
+
+    const pricingMeta = getPageMetadata("/pricing");
+
+    // Every tag we claim to rewrite must actually be rewritten. We check by
+    // requiring the new content to be present — the old landing copy MUST
+    // have been replaced.
+    expect(out).toContain(`<title>${pricingMeta.title}</title>`);
+    expect(out).toContain(
+      '<link rel="canonical" href="https://ftc.bd73.com/pricing" />',
+    );
+    expect(out).toContain(
+      '<meta property="og:url" content="https://ftc.bd73.com/pricing" />',
+    );
+    expect(out).toContain(
+      `<meta property="og:title" content="${pricingMeta.title}" />`,
+    );
+    expect(out).toContain(
+      `<meta name="twitter:title" content="${pricingMeta.title}" />`,
+    );
+
+    // And the old landing copy must no longer appear in those slots.
+    expect(out).not.toContain(
+      '<meta property="og:title" content="FetchTheChange — Monitor any web value. Get alerted when it changes."',
+    );
   });
 });

--- a/server/crawlerMeta.test.ts
+++ b/server/crawlerMeta.test.ts
@@ -93,12 +93,22 @@ describe("rewriteIndexHtmlForCrawler", () => {
     );
   });
 
-  it("escapes special characters in title/description", () => {
+  it("HTML-escapes metadata before emitting into attributes/text", () => {
     const out = rewriteIndexHtmlForCrawler(TEMPLATE, "/pricing", "https://ftc.bd73.com");
-    // no stray unescaped quote breaking the attribute
-    const ogDescMatch = out.match(/<meta\s+property="og:description"\s+content="([^"]*)"/);
+    // The attribute-context captured group cannot contain a bare quote or
+    // angle bracket — escapeAttr would emit &quot; / &lt; / &gt;.
+    const ogDescMatch = out.match(
+      /<meta\s+property="og:description"\s+content="([^"]*)"/,
+    );
     expect(ogDescMatch).not.toBeNull();
-    expect(ogDescMatch?.[1]).not.toMatch(/[^&]".*"/); // no unescaped quote pairs
+    expect(ogDescMatch?.[1]).not.toContain("<");
+    expect(ogDescMatch?.[1]).not.toContain(">");
+    // Title is text-context, not attribute — escapeHtmlText replaces &/</>
+    // but leaves quotes. Prove the angle brackets never leak through.
+    const titleMatch = out.match(/<title>([\s\S]*?)<\/title>/);
+    expect(titleMatch).not.toBeNull();
+    expect(titleMatch?.[1]).not.toContain("<");
+    expect(titleMatch?.[1]).not.toContain(">");
   });
 
   it("rewrites tags even when attributes are split across multiple lines", () => {
@@ -191,6 +201,21 @@ describe("rewriteIndexHtmlForCrawler noindex for unknown paths (Concern 2)", () 
       "https://ftc.bd73.com",
     );
     expect(out).not.toContain('<meta name="robots" content="noindex" />');
+  });
+
+  it("tolerates a trailing slash on baseUrl (no double-slash in og:url)", () => {
+    const out = rewriteIndexHtmlForCrawler(
+      TEMPLATE,
+      "/pricing",
+      "https://ftc.bd73.com/",
+    );
+    expect(out).toContain(
+      '<link rel="canonical" href="https://ftc.bd73.com/pricing" />',
+    );
+    expect(out).toContain(
+      '<meta property="og:url" content="https://ftc.bd73.com/pricing" />',
+    );
+    expect(out).not.toContain("com//pricing");
   });
 
   it("normalizes trailing slash so /pricing/ is treated as known", () => {

--- a/server/crawlerMeta.test.ts
+++ b/server/crawlerMeta.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  isCrawlerUserAgent,
+  rewriteIndexHtmlForCrawler,
+  getPageMetadata,
+} from "./crawlerMeta";
+
+const TEMPLATE = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>FetchTheChange — Monitor any web value. Get alerted when it changes.</title>
+    <meta name="description" content="Website change monitoring that works on modern, JavaScript-heavy sites." />
+    <link rel="canonical" href="https://fetch-the-change.replit.app/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="FetchTheChange — Monitor any web value. Get alerted when it changes." />
+    <meta property="og:description" content="Website change monitoring that works on modern, JavaScript-heavy sites." />
+    <meta property="og:url" content="https://fetch-the-change.replit.app/" />
+    <meta property="og:image" content="https://fetch-the-change.replit.app/images/fix-selector-showcase.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="FetchTheChange — Monitor any web value. Get alerted when it changes." />
+    <meta name="twitter:description" content="Website change monitoring that works on modern, JavaScript-heavy sites." />
+    <meta name="twitter:image" content="https://fetch-the-change.replit.app/images/fix-selector-showcase.png" />
+  </head>
+  <body><div id="root"></div></body>
+</html>`;
+
+describe("isCrawlerUserAgent", () => {
+  it("detects Facebook, X, Slack, Discord, LinkedIn, Google, Bing bots", () => {
+    expect(isCrawlerUserAgent("facebookexternalhit/1.1")).toBe(true);
+    expect(isCrawlerUserAgent("Twitterbot/1.0")).toBe(true);
+    expect(isCrawlerUserAgent("Slackbot-LinkExpanding 1.0")).toBe(true);
+    expect(isCrawlerUserAgent("Discordbot/2.0")).toBe(true);
+    expect(isCrawlerUserAgent("LinkedInBot/1.0")).toBe(true);
+    expect(isCrawlerUserAgent("Googlebot/2.1")).toBe(true);
+    expect(isCrawlerUserAgent("Mozilla/5.0 (compatible; bingbot/2.0)")).toBe(true);
+  });
+
+  it("returns false for a normal browser UA", () => {
+    expect(
+      isCrawlerUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for undefined/null/empty", () => {
+    expect(isCrawlerUserAgent(undefined)).toBe(false);
+    expect(isCrawlerUserAgent(null)).toBe(false);
+    expect(isCrawlerUserAgent("")).toBe(false);
+  });
+});
+
+describe("rewriteIndexHtmlForCrawler", () => {
+  it("rewrites title, description, canonical, og:*, twitter:* for a blog post path", () => {
+    const out = rewriteIndexHtmlForCrawler(
+      TEMPLATE,
+      "/blog/slack-webpage-change-alerts",
+      "https://ftc.bd73.com",
+    );
+    expect(out).toContain(
+      "<title>How to Get a Slack Alert When Any Webpage Changes | FetchTheChange</title>",
+    );
+    expect(out).toContain(
+      'content="Set up Slack notifications for webpage changes in minutes. Monitor prices, stock levels, competitor pages, or any site element — alerts go straight to your Slack channel."',
+    );
+    expect(out).toContain(
+      '<link rel="canonical" href="https://ftc.bd73.com/blog/slack-webpage-change-alerts" />',
+    );
+    expect(out).toContain('<meta property="og:type" content="article" />');
+    expect(out).toContain(
+      '<meta property="og:url" content="https://ftc.bd73.com/blog/slack-webpage-change-alerts" />',
+    );
+    expect(out).toContain(
+      '<meta property="og:title" content="How to Get a Slack Alert When Any Webpage Changes | FetchTheChange" />',
+    );
+    expect(out).toContain(
+      '<meta name="twitter:title" content="How to Get a Slack Alert When Any Webpage Changes | FetchTheChange" />',
+    );
+  });
+
+  it("falls back to landing metadata for unknown paths", () => {
+    const out = rewriteIndexHtmlForCrawler(
+      TEMPLATE,
+      "/some/unknown/path",
+      "https://ftc.bd73.com",
+    );
+    // og:url still reflects the actual path even when metadata falls back
+    expect(out).toContain(
+      '<meta property="og:url" content="https://ftc.bd73.com/some/unknown/path" />',
+    );
+  });
+
+  it("escapes special characters in title/description", () => {
+    const out = rewriteIndexHtmlForCrawler(TEMPLATE, "/pricing", "https://ftc.bd73.com");
+    // no stray unescaped quote breaking the attribute
+    const ogDescMatch = out.match(/<meta\s+property="og:description"\s+content="([^"]*)"/);
+    expect(ogDescMatch).not.toBeNull();
+    expect(ogDescMatch?.[1]).not.toMatch(/[^&]".*"/); // no unescaped quote pairs
+  });
+});
+
+describe("getPageMetadata", () => {
+  it("returns landing metadata for /", () => {
+    const meta = getPageMetadata("/");
+    expect(meta.title).toContain("FetchTheChange");
+  });
+
+  it("returns per-blog metadata", () => {
+    const meta = getPageMetadata("/blog/slack-webpage-change-alerts");
+    expect(meta.ogType).toBe("article");
+    expect(meta.title).toContain("Slack Alert");
+  });
+
+  it("falls back to landing metadata for an unknown path", () => {
+    const meta = getPageMetadata("/no-such-route-exists");
+    expect(meta.title).toContain("FetchTheChange");
+  });
+});

--- a/server/crawlerMeta.ts
+++ b/server/crawlerMeta.ts
@@ -89,12 +89,22 @@ export function rewriteIndexHtmlForCrawler(
   const normalized = normalizePath(path);
   const meta = getPageMetadata(normalized);
   const isKnown = hasKnownPageMetadata(normalized);
-  const canonicalUrl = `${baseUrl}${normalized}`;
+  // Defensive normalization: if a caller ever passes `https://host/` as the
+  // base, naive concatenation yields `//pricing`, which crawlers treat as a
+  // distinct URL and silently breaks canonicalization.
+  const cleanBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  const canonicalUrl = `${cleanBase}${normalized}`;
+  // Accept absolute `https://` / `http://` and protocol-relative `//cdn/…`;
+  // everything else is treated as a site-relative path and prefixed with the
+  // canonical origin. `startsWith("http")` was too loose — it matched
+  // `httpunknown:…` and missed protocol-relative.
+  const isAbsolute = (u: string): boolean =>
+    /^https?:\/\//i.test(u) || u.startsWith("//");
   const ogImage = meta.image
-    ? meta.image.startsWith("http")
+    ? isAbsolute(meta.image)
       ? meta.image
-      : `${baseUrl}${meta.image}`
-    : `${baseUrl}/images/fix-selector-showcase.png`;
+      : `${cleanBase}${meta.image}`
+    : `${cleanBase}/images/fix-selector-showcase.png`;
   const ogType = meta.ogType ?? "website";
 
   const titleAttr = escapeHtmlText(meta.title);
@@ -153,11 +163,12 @@ export function rewriteIndexHtmlForCrawler(
 
   if (!isKnown) {
     // Inject noindex so Googlebot doesn't index typo / stale URLs as 200s.
-    // Prepend into <head> — the test suite asserts this flags unknown paths
-    // distinctly so clients can tell whether a bot fetched a known page.
+    // Prepend into <head> — the regex tolerates attributes on the head tag
+    // (e.g., `<head lang="en">` or `<head prefix="og: …">`) so the injection
+    // doesn't silently no-op when someone adds one.
     out = out.replace(
-      /<head>/i,
-      '<head>\n    <meta name="robots" content="noindex" />',
+      /<head(\s[^>]*)?>/i,
+      (match) => `${match}\n    <meta name="robots" content="noindex" />`,
     );
   }
 

--- a/server/crawlerMeta.ts
+++ b/server/crawlerMeta.ts
@@ -1,0 +1,132 @@
+import { PAGE_METADATA, DEFAULT_PAGE_METADATA, type PageMeta } from "@shared/pageMetadata";
+
+/**
+ * Link-unfurl bots don't execute JavaScript, so without server-side rewriting
+ * they only see the static meta tags in client/index.html — which describe
+ * the landing page. This middleware detects those bots and rewrites the head
+ * with per-route metadata so a blog post shared on Slack unfurls as the blog
+ * post, not the landing page. See GitHub issue #440.
+ */
+
+// Case-insensitive match against user-agent substrings. Covers the major
+// scrapers that power link previews on Facebook/X/Slack/LinkedIn/Discord/etc.
+const CRAWLER_UA_PATTERNS = [
+  "facebookexternalhit",
+  "facebot",
+  "twitterbot",
+  "linkedinbot",
+  "slackbot",
+  "discordbot",
+  "telegrambot",
+  "whatsapp",
+  "skypeuripreview",
+  "applebot",
+  "pinterest",
+  "redditbot",
+  "embedly",
+  "googlebot", // also needs per-page meta for indexation
+  "bingbot",
+  "duckduckbot",
+];
+
+export function isCrawlerUserAgent(ua: string | undefined | null): boolean {
+  if (!ua) return false;
+  const lower = ua.toLowerCase();
+  return CRAWLER_UA_PATTERNS.some((p) => lower.includes(p));
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeHtmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function getPageMetadata(path: string): PageMeta {
+  return PAGE_METADATA[path] ?? DEFAULT_PAGE_METADATA;
+}
+
+/**
+ * Rewrites the static OG/Twitter/canonical/title tags in an index.html string
+ * with per-path metadata. Uses regex replacements against the well-known tag
+ * shape emitted from client/index.html — when that template changes, this
+ * pattern-matching may need to change too (covered by crawlerMeta.test.ts).
+ */
+export function rewriteIndexHtmlForCrawler(
+  template: string,
+  path: string,
+  baseUrl: string,
+): string {
+  const meta = getPageMetadata(path);
+  const canonicalUrl = `${baseUrl}${path}`;
+  const ogImage = meta.image
+    ? meta.image.startsWith("http")
+      ? meta.image
+      : `${baseUrl}${meta.image}`
+    : `${baseUrl}/images/fix-selector-showcase.png`;
+  const ogType = meta.ogType ?? "website";
+
+  const titleAttr = escapeHtmlText(meta.title);
+  const descAttr = escapeAttr(meta.description);
+  const titleA = escapeAttr(meta.title);
+  const urlA = escapeAttr(canonicalUrl);
+  const imageA = escapeAttr(ogImage);
+  const typeA = escapeAttr(ogType);
+
+  let out = template;
+
+  out = out.replace(/<title>[\s\S]*?<\/title>/i, `<title>${titleAttr}</title>`);
+
+  out = out.replace(
+    /<meta\s+name="description"\s+content="[^"]*"\s*\/?>/i,
+    `<meta name="description" content="${descAttr}" />`,
+  );
+
+  out = out.replace(
+    /<link\s+rel="canonical"\s+href="[^"]*"\s*\/?>/i,
+    `<link rel="canonical" href="${urlA}" />`,
+  );
+
+  out = out.replace(
+    /<meta\s+property="og:type"\s+content="[^"]*"\s*\/?>/i,
+    `<meta property="og:type" content="${typeA}" />`,
+  );
+  out = out.replace(
+    /<meta\s+property="og:title"\s+content="[^"]*"\s*\/?>/i,
+    `<meta property="og:title" content="${titleA}" />`,
+  );
+  out = out.replace(
+    /<meta\s+property="og:description"\s+content="[^"]*"\s*\/?>/i,
+    `<meta property="og:description" content="${descAttr}" />`,
+  );
+  out = out.replace(
+    /<meta\s+property="og:url"\s+content="[^"]*"\s*\/?>/i,
+    `<meta property="og:url" content="${urlA}" />`,
+  );
+  out = out.replace(
+    /<meta\s+property="og:image"\s+content="[^"]*"\s*\/?>/i,
+    `<meta property="og:image" content="${imageA}" />`,
+  );
+  out = out.replace(
+    /<meta\s+name="twitter:title"\s+content="[^"]*"\s*\/?>/i,
+    `<meta name="twitter:title" content="${titleA}" />`,
+  );
+  out = out.replace(
+    /<meta\s+name="twitter:description"\s+content="[^"]*"\s*\/?>/i,
+    `<meta name="twitter:description" content="${descAttr}" />`,
+  );
+  out = out.replace(
+    /<meta\s+name="twitter:image"\s+content="[^"]*"\s*\/?>/i,
+    `<meta name="twitter:image" content="${imageA}" />`,
+  );
+
+  return out;
+}

--- a/server/crawlerMeta.ts
+++ b/server/crawlerMeta.ts
@@ -50,8 +50,24 @@ function escapeHtmlText(value: string): string {
     .replace(/>/g, "&gt;");
 }
 
+/**
+ * Normalize a request path for metadata lookup: strip trailing slash (except
+ * for root "/"). Without this, `/pricing/` would miss PAGE_METADATA and fall
+ * back to the landing metadata with a non-canonical `og:url`. See Phase 5
+ * skeptic Concern 7.
+ */
+function normalizePath(path: string): string {
+  if (path.length > 1 && path.endsWith("/")) return path.slice(0, -1);
+  return path;
+}
+
 export function getPageMetadata(path: string): PageMeta {
-  return PAGE_METADATA[path] ?? DEFAULT_PAGE_METADATA;
+  return PAGE_METADATA[normalizePath(path)] ?? DEFAULT_PAGE_METADATA;
+}
+
+/** Returns true when the given path has a known PAGE_METADATA entry. */
+export function hasKnownPageMetadata(path: string): boolean {
+  return PAGE_METADATA[normalizePath(path)] !== undefined;
 }
 
 /**
@@ -59,14 +75,21 @@ export function getPageMetadata(path: string): PageMeta {
  * with per-path metadata. Uses regex replacements against the well-known tag
  * shape emitted from client/index.html — when that template changes, this
  * pattern-matching may need to change too (covered by crawlerMeta.test.ts).
+ *
+ * When the path has no PAGE_METADATA entry (e.g., a typo or stale URL), the
+ * rewriter additionally injects `<meta name="robots" content="noindex">` so
+ * crawlers don't index arbitrary 404-equivalent paths with landing-page
+ * content. See Phase 5 skeptic Concern 2.
  */
 export function rewriteIndexHtmlForCrawler(
   template: string,
   path: string,
   baseUrl: string,
 ): string {
-  const meta = getPageMetadata(path);
-  const canonicalUrl = `${baseUrl}${path}`;
+  const normalized = normalizePath(path);
+  const meta = getPageMetadata(normalized);
+  const isKnown = hasKnownPageMetadata(normalized);
+  const canonicalUrl = `${baseUrl}${normalized}`;
   const ogImage = meta.image
     ? meta.image.startsWith("http")
       ? meta.image
@@ -127,6 +150,16 @@ export function rewriteIndexHtmlForCrawler(
     /<meta\s+name="twitter:image"\s+content="[^"]*"\s*\/?>/i,
     `<meta name="twitter:image" content="${imageA}" />`,
   );
+
+  if (!isKnown) {
+    // Inject noindex so Googlebot doesn't index typo / stale URLs as 200s.
+    // Prepend into <head> — the test suite asserts this flags unknown paths
+    // distinctly so clients can tell whether a bot fetched a known page.
+    out = out.replace(
+      /<head>/i,
+      '<head>\n    <meta name="robots" content="noindex" />',
+    );
+  }
 
   return out;
 }

--- a/server/partial-index-invariants.test.ts
+++ b/server/partial-index-invariants.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Invariant tests linking runtime constants to partial-index predicates
+ * hardcoded in shared/schema.ts. Without these, a constant change silently
+ * causes the planner to regress because the index no longer covers the new
+ * status values. See Phase 5 skeptic Concern 3.
+ *
+ * Reads the campaignEmail.ts and schema.ts source as text rather than
+ * importing them — the service module pulls in db.ts which requires a live
+ * DATABASE_URL, and this test only needs to compare string predicates.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const CAMPAIGN_EMAIL_SRC = fs.readFileSync(
+  path.resolve(__dirname, "services", "campaignEmail.ts"),
+  "utf-8",
+);
+const SCHEMA_SRC = fs.readFileSync(
+  path.resolve(__dirname, "..", "shared", "schema.ts"),
+  "utf-8",
+);
+
+function extractStatusList(label: string): string[] {
+  const re = new RegExp(`${label}\\s*=\\s*\\[([^\\]]+)\\]`);
+  const m = CAMPAIGN_EMAIL_SRC.match(re);
+  if (!m) throw new Error(`failed to extract ${label} from campaignEmail.ts`);
+  return Array.from(m[1].matchAll(/"([^"]+)"/g)).map((mm) => mm[1]);
+}
+
+const TERMINAL_RECIPIENT_STATUSES = extractStatusList(
+  "TERMINAL_RECIPIENT_STATUSES",
+);
+// ACTIVE = ["pending", ...TERMINAL]
+const ACTIVE_RECIPIENT_STATUSES = ["pending", ...TERMINAL_RECIPIENT_STATUSES];
+
+describe("campaign_recipients_active_user_idx predicate matches ACTIVE_RECIPIENT_STATUSES", () => {
+  // Extract the `.where(sql\`…\`)` clause of the activeUserCampaignIdx entry.
+  const indexBlock = SCHEMA_SRC.match(
+    /activeUserCampaignIdx[\s\S]*?\.where\(sql`([^`]+)`\)/,
+  );
+
+  it("finds the activeUserCampaignIdx definition", () => {
+    expect(indexBlock).not.toBeNull();
+  });
+
+  it("predicate references every status in ACTIVE_RECIPIENT_STATUSES", () => {
+    const predicate = indexBlock![1];
+    for (const status of ACTIVE_RECIPIENT_STATUSES) {
+      expect(predicate).toContain(`'${status}'`);
+    }
+  });
+
+  it("predicate does not reference any terminal status outside ACTIVE_RECIPIENT_STATUSES", () => {
+    const predicate = indexBlock![1];
+    const known = new Set<string>([...ACTIVE_RECIPIENT_STATUSES]);
+    // These statuses exist in the schema but must NOT be in the active set.
+    for (const status of ["bounced", "complained"]) {
+      expect(known.has(status)).toBe(false);
+      // Status either appears inside `'...'` in the predicate (bad) or not (good).
+      expect(predicate).not.toContain(`'${status}'`);
+    }
+  });
+});
+
+describe("TERMINAL_RECIPIENT_STATUSES is a subset of ACTIVE_RECIPIENT_STATUSES", () => {
+  // The anti-join excludes terminal sends — that membership relationship
+  // is load-bearing for the welcome-exclusion logic.
+  it("every terminal status is active", () => {
+    const active = new Set<string>([...ACTIVE_RECIPIENT_STATUSES]);
+    for (const status of TERMINAL_RECIPIENT_STATUSES) {
+      expect(active.has(status)).toBe(true);
+    }
+  });
+});

--- a/server/partial-index-invariants.test.ts
+++ b/server/partial-index-invariants.test.ts
@@ -34,30 +34,42 @@ const TERMINAL_RECIPIENT_STATUSES = extractStatusList(
 // ACTIVE = ["pending", ...TERMINAL]
 const ACTIVE_RECIPIENT_STATUSES = ["pending", ...TERMINAL_RECIPIENT_STATUSES];
 
-describe("campaign_recipients_active_user_idx predicate matches ACTIVE_RECIPIENT_STATUSES", () => {
+function extractActiveUserIdxPredicate(): string {
   // Extract the `.where(sql\`…\`)` clause of the activeUserCampaignIdx entry.
-  const indexBlock = SCHEMA_SRC.match(
+  const match = SCHEMA_SRC.match(
     /activeUserCampaignIdx[\s\S]*?\.where\(sql`([^`]+)`\)/,
   );
+  if (!match) {
+    throw new Error(
+      "failed to extract activeUserCampaignIdx predicate from shared/schema.ts — " +
+        "did the index definition move, split across multiple sql`` fragments, " +
+        "or introduce an escaped backtick? The invariant test cannot validate " +
+        "the predicate until this regex matches the index shape again.",
+    );
+  }
+  return match[1];
+}
 
-  it("finds the activeUserCampaignIdx definition", () => {
-    expect(indexBlock).not.toBeNull();
-  });
+// Known non-active recipient statuses per the column comment in
+// shared/schema.ts:170. Kept in lockstep there — if a new terminal status is
+// added to the schema but the partial-index predicate isn't updated, this
+// list catches the leak before the planner regresses silently.
+const NON_ACTIVE_RECIPIENT_STATUSES = ["bounced", "complained"] as const;
 
+describe("campaign_recipients_active_user_idx predicate matches ACTIVE_RECIPIENT_STATUSES", () => {
   it("predicate references every status in ACTIVE_RECIPIENT_STATUSES", () => {
-    const predicate = indexBlock![1];
+    const predicate = extractActiveUserIdxPredicate();
     for (const status of ACTIVE_RECIPIENT_STATUSES) {
       expect(predicate).toContain(`'${status}'`);
     }
   });
 
-  it("predicate does not reference any terminal status outside ACTIVE_RECIPIENT_STATUSES", () => {
-    const predicate = indexBlock![1];
-    const known = new Set<string>([...ACTIVE_RECIPIENT_STATUSES]);
-    // These statuses exist in the schema but must NOT be in the active set.
-    for (const status of ["bounced", "complained"]) {
-      expect(known.has(status)).toBe(false);
-      // Status either appears inside `'...'` in the predicate (bad) or not (good).
+  it("predicate does not reference known non-active recipient statuses (bounced, complained)", () => {
+    const predicate = extractActiveUserIdxPredicate();
+    const active = new Set<string>([...ACTIVE_RECIPIENT_STATUSES]);
+    for (const status of NON_ACTIVE_RECIPIENT_STATUSES) {
+      // Safety: our exclusion list must actually be outside the active set.
+      expect(active.has(status)).toBe(false);
       expect(predicate).not.toContain(`'${status}'`);
     }
   });

--- a/server/services/campaignEmail.test.ts
+++ b/server/services/campaignEmail.test.ts
@@ -420,6 +420,26 @@ describe("cancelCampaign", () => {
     expect(result.cancelled).toBe(75);
   });
 
+  it("COUNT query for sentCount uses TERMINAL_RECIPIENT_STATUSES (issue #434)", async () => {
+    mockDbExecute.mockResolvedValueOnce({ rows: [{ sentCount: 0, pendingCount: 0 }] });
+    setupTransactionMock([
+      { rows: [{ status: "sending" }] },
+      { rows: [] },
+      { rows: [] },
+    ]);
+
+    await cancelCampaign(77);
+
+    // First execute call is the pre-transaction COUNT with the terminal IN list
+    const serialized = JSON.stringify(mockDbExecute.mock.calls[0][0]);
+    // All four terminal statuses are injected as bound values (not hardcoded literals)
+    for (const status of ["sent", "delivered", "opened", "clicked"]) {
+      expect(serialized).toContain(status);
+    }
+    // And the literal old-style inline list should no longer appear
+    expect(serialized).not.toContain("'sent', 'delivered', 'opened', 'clicked'");
+  });
+
   it("returns actual transaction cancelled count, not stale pendingCount", async () => {
     // Simulate race condition: pre-transaction COUNT sees 75 pending,
     // but batch sender processes 10 between COUNT and UPDATE, so only 65 are cancelled
@@ -882,6 +902,24 @@ describe("reconcileCampaignCounters", () => {
     expect(result.after).toEqual({
       totalRecipients: 0, sentCount: 0, failedCount: 0, deliveredCount: 0, openedCount: 0, clickedCount: 0,
     });
+  });
+
+  it("sentCount COUNT(*) FILTER uses TERMINAL_RECIPIENT_STATUSES (issue #434)", async () => {
+    mockDbLimit.mockResolvedValueOnce([{
+      id: 1, totalRecipients: 0, sentCount: 0, failedCount: 0, deliveredCount: 0, openedCount: 0, clickedCount: 0,
+    }]);
+    mockDbExecute.mockResolvedValueOnce({
+      rows: [{ totalRecipients: 0, sentCount: 0, failedCount: 0, deliveredCount: 0, openedCount: 0, clickedCount: 0 }],
+    });
+
+    await reconcileCampaignCounters(1);
+
+    const serialized = JSON.stringify(mockDbExecute.mock.calls[0][0]);
+    // Terminal statuses are bound, not hardcoded literals
+    for (const status of ["sent", "delivered", "opened", "clicked"]) {
+      expect(serialized).toContain(status);
+    }
+    expect(serialized).not.toContain("'sent', 'delivered', 'opened', 'clicked'");
   });
 });
 

--- a/server/services/campaignEmail.ts
+++ b/server/services/campaignEmail.ts
@@ -553,10 +553,12 @@ export async function cancelCampaign(campaignId: number): Promise<{ sentSoFar: n
     control.cancelled = true;
   }
 
-  // Count current state
+  // Count current state — build the IN list from TERMINAL_RECIPIENT_STATUSES so
+  // changes to the constant flow through automatically. See GitHub issue #434.
+  const terminalPlaceholders = TERMINAL_RECIPIENT_STATUSES.map((s) => sql`${s}`);
   const sentResult = await db.execute(sql`
     SELECT
-      COUNT(*) FILTER (WHERE status IN ('sent', 'delivered', 'opened', 'clicked'))::int as "sentCount",
+      COUNT(*) FILTER (WHERE status IN (${sql.join(terminalPlaceholders, sql`, `)}))::int as "sentCount",
       COUNT(*) FILTER (WHERE status = 'pending')::int as "pendingCount"
     FROM campaign_recipients
     WHERE campaign_id = ${campaignId}
@@ -671,11 +673,14 @@ export async function reconcileCampaignCounters(campaignId: number): Promise<{
     clickedCount: campaign.clickedCount,
   };
 
-  // Compute actual counts from recipient rows
+  // Compute actual counts from recipient rows. Terminal "sent"-class statuses
+  // are driven by TERMINAL_RECIPIENT_STATUSES so the reconciler stays in sync
+  // with the rest of the code if the constant ever changes (GitHub #434).
+  const terminalFilterPlaceholders = TERMINAL_RECIPIENT_STATUSES.map((s) => sql`${s}`);
   const result = await db.execute(sql`
     SELECT
       COUNT(*)::int AS "totalRecipients",
-      COUNT(*) FILTER (WHERE status IN ('sent', 'delivered', 'opened', 'clicked'))::int AS "sentCount",
+      COUNT(*) FILTER (WHERE status IN (${sql.join(terminalFilterPlaceholders, sql`, `)}))::int AS "sentCount",
       COUNT(*) FILTER (WHERE status IN ('failed', 'bounced', 'complained'))::int AS "failedCount",
       COUNT(*) FILTER (WHERE status IN ('delivered', 'opened', 'clicked'))::int AS "deliveredCount",
       COUNT(*) FILTER (WHERE status IN ('opened', 'clicked'))::int AS "openedCount",

--- a/server/static.ts
+++ b/server/static.ts
@@ -26,6 +26,14 @@ export function serveStatic(app: Express) {
     return cachedTemplate;
   };
 
+  // Cache the rewritten HTML per-path so a crawler flood against many paths
+  // doesn't redo the regex work on every hit. Bounded by the number of
+  // PAGE_METADATA entries plus some unknown paths; evict on size > 200 so a
+  // UA-spoofed crawl of thousands of distinct paths can't grow it unbounded.
+  // See Phase 5 skeptic Concern 4.
+  const rewriteCache = new Map<string, string>();
+  const REWRITE_CACHE_MAX = 200;
+
   // fall through to index.html if the file doesn't exist
   app.use("/{*path}", (req, res) => {
     // Bots that don't execute JS need per-route OG/Twitter meta in the
@@ -33,15 +41,22 @@ export function serveStatic(app: Express) {
     // See GitHub issue #440.
     if (isCrawlerUserAgent(req.get("user-agent"))) {
       try {
-        // Use the pinned canonical origin from REPLIT_DOMAINS, not the
-        // request's Host header. A crafted Host would otherwise be reflected
-        // into og:url / canonical for crawlers and could be cached as SEO
-        // poisoning or fake unfurl previews.
-        const html = rewriteIndexHtmlForCrawler(
-          getCachedTemplate(),
-          req.path,
-          getAppUrl(),
-        );
+        const baseUrl = getAppUrl();
+        const cacheKey = `${baseUrl}${req.path}`;
+        let html = rewriteCache.get(cacheKey);
+        if (html === undefined) {
+          // Use the pinned canonical origin from REPLIT_DOMAINS, not the
+          // request's Host header. A crafted Host would otherwise be reflected
+          // into og:url / canonical for crawlers and could be cached as SEO
+          // poisoning or fake unfurl previews.
+          html = rewriteIndexHtmlForCrawler(
+            getCachedTemplate(),
+            req.path,
+            baseUrl,
+          );
+          if (rewriteCache.size >= REWRITE_CACHE_MAX) rewriteCache.clear();
+          rewriteCache.set(cacheKey, html);
+        }
         res.status(200).set({ "Content-Type": "text/html" }).send(html);
         return;
       } catch {

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import { isCrawlerUserAgent, rewriteIndexHtmlForCrawler } from "./crawlerMeta";
 
 export function serveStatic(app: Express) {
   const distPath = path.resolve(__dirname, "public");
@@ -13,7 +14,23 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("/{*path}", (_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
+  app.use("/{*path}", (req, res) => {
+    const indexPath = path.resolve(distPath, "index.html");
+    // Bots that don't execute JS need per-route OG/Twitter meta in the
+    // initial HTML to unfurl correctly. Humans get the normal SPA bootstrap.
+    // See GitHub issue #440.
+    if (isCrawlerUserAgent(req.get("user-agent"))) {
+      try {
+        const template = fs.readFileSync(indexPath, "utf-8");
+        const baseUrl = `${req.protocol}://${req.get("host")}`;
+        const html = rewriteIndexHtmlForCrawler(template, req.path, baseUrl);
+        res.status(200).set({ "Content-Type": "text/html" }).send(html);
+        return;
+      } catch {
+        // Fall through to sendFile if anything goes wrong — the human-facing
+        // SPA path must never break for a bot.
+      }
+    }
+    res.sendFile(indexPath);
   });
 }

--- a/server/static.ts
+++ b/server/static.ts
@@ -15,9 +15,12 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   const indexPath = path.resolve(distPath, "index.html");
-  // Cache the template once at startup — it's built in, so it does not change
-  // between deploys. Avoids a per-request fs.readFileSync on the crawler path
-  // that could otherwise be amplified by a UA-spoofed flood.
+  // Lazy cache: the template is read on the first crawler hit and reused for
+  // the life of the process (index.html doesn't change between deploys —
+  // Replit restarts the process on deploy, which is the invalidation point).
+  // Avoids a per-request fs.readFileSync on the crawler path that would
+  // otherwise be amplifiable by a UA-spoofed flood. Trade-off: a
+  // missing/corrupt index.html surfaces on first-unfurl rather than at boot.
   let cachedTemplate: string | null = null;
   const getCachedTemplate = (): string => {
     if (cachedTemplate === null) {

--- a/server/static.ts
+++ b/server/static.ts
@@ -2,6 +2,7 @@ import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
 import { isCrawlerUserAgent, rewriteIndexHtmlForCrawler } from "./crawlerMeta";
+import { getAppUrl } from "./utils/appUrl";
 
 export function serveStatic(app: Express) {
   const distPath = path.resolve(__dirname, "public");
@@ -13,17 +14,34 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  const indexPath = path.resolve(distPath, "index.html");
+  // Cache the template once at startup — it's built in, so it does not change
+  // between deploys. Avoids a per-request fs.readFileSync on the crawler path
+  // that could otherwise be amplified by a UA-spoofed flood.
+  let cachedTemplate: string | null = null;
+  const getCachedTemplate = (): string => {
+    if (cachedTemplate === null) {
+      cachedTemplate = fs.readFileSync(indexPath, "utf-8");
+    }
+    return cachedTemplate;
+  };
+
   // fall through to index.html if the file doesn't exist
   app.use("/{*path}", (req, res) => {
-    const indexPath = path.resolve(distPath, "index.html");
     // Bots that don't execute JS need per-route OG/Twitter meta in the
     // initial HTML to unfurl correctly. Humans get the normal SPA bootstrap.
     // See GitHub issue #440.
     if (isCrawlerUserAgent(req.get("user-agent"))) {
       try {
-        const template = fs.readFileSync(indexPath, "utf-8");
-        const baseUrl = `${req.protocol}://${req.get("host")}`;
-        const html = rewriteIndexHtmlForCrawler(template, req.path, baseUrl);
+        // Use the pinned canonical origin from REPLIT_DOMAINS, not the
+        // request's Host header. A crafted Host would otherwise be reflected
+        // into og:url / canonical for crawlers and could be cached as SEO
+        // poisoning or fake unfurl previews.
+        const html = rewriteIndexHtmlForCrawler(
+          getCachedTemplate(),
+          req.path,
+          getAppUrl(),
+        );
         res.status(200).set({ "Content-Type": "text/html" }).send(html);
         return;
       } catch {

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import path from "path";
 import { nanoid } from "nanoid";
 import { isCrawlerUserAgent, rewriteIndexHtmlForCrawler } from "./crawlerMeta";
+import { getAppUrl } from "./utils/appUrl";
 
 const viteLogger = createLogger();
 
@@ -52,9 +53,10 @@ export async function setupVite(server: Server, app: Express) {
       let page = await vite.transformIndexHtml(url, template);
       // Bots that can't execute JS (Facebook/X/Slack/LinkedIn/Discord/…)
       // need per-route OG/Twitter meta in the initial HTML. See issue #440.
+      // Use the pinned canonical origin (not req.get("host")) to prevent a
+      // spoofed Host header from being reflected into og:url / canonical.
       if (isCrawlerUserAgent(req.get("user-agent"))) {
-        const baseUrl = `${req.protocol}://${req.get("host")}`;
-        page = rewriteIndexHtmlForCrawler(page, req.path, baseUrl);
+        page = rewriteIndexHtmlForCrawler(page, req.path, getAppUrl());
       }
       res.status(200).set({ "Content-Type": "text/html" }).end(page);
     } catch (e) {

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -5,6 +5,7 @@ import viteConfig from "../vite.config";
 import fs from "fs";
 import path from "path";
 import { nanoid } from "nanoid";
+import { isCrawlerUserAgent, rewriteIndexHtmlForCrawler } from "./crawlerMeta";
 
 const viteLogger = createLogger();
 
@@ -48,7 +49,13 @@ export async function setupVite(server: Server, app: Express) {
         `src="/src/main.tsx"`,
         `src="/src/main.tsx?v=${nanoid()}"`,
       );
-      const page = await vite.transformIndexHtml(url, template);
+      let page = await vite.transformIndexHtml(url, template);
+      // Bots that can't execute JS (Facebook/X/Slack/LinkedIn/Discord/…)
+      // need per-route OG/Twitter meta in the initial HTML. See issue #440.
+      if (isCrawlerUserAgent(req.get("user-agent"))) {
+        const baseUrl = `${req.protocol}://${req.get("host")}`;
+        page = rewriteIndexHtmlForCrawler(page, req.path, baseUrl);
+      }
       res.status(200).set({ "Content-Type": "text/html" }).end(page);
     } catch (e) {
       vite.ssrFixStacktrace(e as Error);

--- a/shared/pageMetadata.ts
+++ b/shared/pageMetadata.ts
@@ -1,0 +1,134 @@
+/**
+ * Per-route social metadata consumed by the crawler-UA middleware (see
+ * server/crawlerMeta.ts). When a known bot UA (Facebook, X, Slack, LinkedIn,
+ * Discord, iMessage, …) requests a page, the server rewrites index.html's
+ * <head> with the entry from here so link previews unfurl with the correct
+ * title/description/image instead of the landing page's.
+ *
+ * SEOHead on the client still owns the SPA-rendered head for human visitors —
+ * these entries need to stay in rough sync with the corresponding page's
+ * SEOHead props, but the authoritative copy for humans is the SEOHead call.
+ *
+ * Blog/doc URLs omit the `image` field on purpose: they inherit the default
+ * OG image from client/index.html.
+ *
+ * See GitHub issue #440.
+ */
+export interface PageMeta {
+  title: string;
+  description: string;
+  ogType?: "website" | "article";
+  image?: string;
+}
+
+const SITE_TITLE =
+  "FetchTheChange — Monitor any web value. Get alerted when it changes.";
+
+export const PAGE_METADATA: Record<string, PageMeta> = {
+  "/": {
+    title: SITE_TITLE,
+    description:
+      "Website change monitoring that works on modern, JavaScript-heavy sites. Track prices, availability, text, and any DOM value — and get told when tracking breaks, not just when values change.",
+    ogType: "website",
+  },
+  "/pricing": {
+    title: "Pricing — FetchTheChange",
+    description:
+      "Simple, transparent pricing for website change monitoring. Free for hobbyists, Pro for teams, Power for heavy users.",
+    ogType: "website",
+  },
+  "/support": {
+    title: "Support — FetchTheChange",
+    description:
+      "Get help with FetchTheChange: contact support, browse FAQs, and learn how to troubleshoot broken monitors.",
+    ogType: "website",
+  },
+  "/privacy": {
+    title: "Privacy Policy — FetchTheChange",
+    description:
+      "How FetchTheChange handles your data: what we collect, how we use it, and your rights.",
+    ogType: "website",
+  },
+  "/changelog": {
+    title: "Changelog — FetchTheChange",
+    description:
+      "Release notes for FetchTheChange — new features, bug fixes, and platform improvements.",
+    ogType: "website",
+  },
+  "/blog": {
+    title: "Blog — FetchTheChange",
+    description:
+      "Guides on website change monitoring: selector stability, price tracking, competitor intelligence, and integrations.",
+    ogType: "website",
+  },
+  "/blog/why-website-change-monitors-fail-silently": {
+    title:
+      "Why Website Change Monitors Fail Silently | FetchTheChange",
+    description:
+      "Most website change monitors go silent when selectors break, sites add bot protection, or JavaScript rewrites the DOM. Here is how to catch those failures.",
+    ogType: "article",
+  },
+  "/blog/fetchthechange-vs-distill-visualping-hexowatch": {
+    title:
+      "FetchTheChange vs. Distill, Visualping, Hexowatch | FetchTheChange",
+    description:
+      "How FetchTheChange compares on selector stability, JS rendering, failure reporting, and pricing against the main website change monitoring tools.",
+    ogType: "article",
+  },
+  "/blog/monitor-competitor-prices-without-getting-blocked": {
+    title:
+      "How to Monitor Competitor Prices Without Getting Blocked | FetchTheChange",
+    description:
+      "Practical guide to scraping competitor prices reliably: rendering JS pages, rotating through selectors, and handling bot-protection gracefully.",
+    ogType: "article",
+  },
+  "/blog/css-selectors-keep-breaking-why-and-how-to-fix": {
+    title:
+      "Why CSS Selectors Keep Breaking (and How to Fix Them) | FetchTheChange",
+    description:
+      "Why generated class names and nested indexes break your scraper every deploy, and concrete patterns that survive UI changes.",
+    ogType: "article",
+  },
+  "/blog/website-change-monitoring-use-cases-beyond-price-tracking": {
+    title:
+      "Website Change Monitoring Use Cases Beyond Price Tracking | FetchTheChange",
+    description:
+      "From policy pages and job boards to release notes and SEO audits — the web change monitoring use cases teams actually ship with.",
+    ogType: "article",
+  },
+  "/blog/monitor-website-changes-without-writing-code": {
+    title:
+      "Monitor Website Changes Without Writing Code | FetchTheChange",
+    description:
+      "A no-code walkthrough for setting up website change monitors with selectors, conditions, and notifications — no scripts, no servers.",
+    ogType: "article",
+  },
+  "/blog/slack-webpage-change-alerts": {
+    title:
+      "How to Get a Slack Alert When Any Webpage Changes | FetchTheChange",
+    description:
+      "Set up Slack notifications for webpage changes in minutes. Monitor prices, stock levels, competitor pages, or any site element — alerts go straight to your Slack channel.",
+    ogType: "article",
+  },
+  "/docs/webhooks": {
+    title: "Webhooks — FetchTheChange Docs",
+    description:
+      "Send monitor events to your own HTTP endpoint with signed webhook requests. Payload schema, retry behavior, and signature verification.",
+    ogType: "article",
+  },
+  "/docs/zapier": {
+    title: "Zapier Integration — FetchTheChange Docs",
+    description:
+      "Connect FetchTheChange to 6000+ apps via Zapier. Trigger Zaps when a monitor detects a change.",
+    ogType: "article",
+  },
+  "/docs/make": {
+    title: "Make Integration — FetchTheChange Docs",
+    description:
+      "Integrate FetchTheChange with Make (formerly Integromat) to automate workflows when web content changes.",
+    ogType: "article",
+  },
+};
+
+/** Fallback entry used when no per-path metadata exists. */
+export const DEFAULT_PAGE_METADATA: PageMeta = PAGE_METADATA["/"]!;

--- a/shared/pageMetadata.ts
+++ b/shared/pageMetadata.ts
@@ -139,10 +139,17 @@ export const PAGE_METADATA: Record<string, PageMeta> = {
 };
 
 /**
- * Fallback entry used when no per-path metadata exists. Frozen because
- * getPageMetadata returns this reference directly on cache-miss — mutating
- * it would corrupt the landing metadata for every subsequent request.
+ * Freeze every entry so a consumer that mutates a returned PageMeta (e.g.,
+ * `meta.title = "..."` in a future rewrite helper) trips an error in strict
+ * mode instead of silently corrupting the map for every subsequent crawler
+ * request. getPageMetadata returns references directly — no clone-on-read —
+ * so this freeze is what keeps the map immutable at the callsite boundary.
  */
+for (const key of Object.keys(PAGE_METADATA)) {
+  Object.freeze(PAGE_METADATA[key]);
+}
+
+/** Fallback entry used when no per-path metadata exists. */
 export const DEFAULT_PAGE_METADATA: PageMeta = Object.freeze({
   ...PAGE_METADATA["/"]!,
 });

--- a/shared/pageMetadata.ts
+++ b/shared/pageMetadata.ts
@@ -5,9 +5,10 @@
  * <head> with the entry from here so link previews unfurl with the correct
  * title/description/image instead of the landing page's.
  *
- * SEOHead on the client still owns the SPA-rendered head for human visitors —
- * these entries need to stay in rough sync with the corresponding page's
- * SEOHead props, but the authoritative copy for humans is the SEOHead call.
+ * SEOHead on the client still owns the SPA-rendered head for human visitors.
+ * `client/src/pages/page-metadata-parity.test.ts` enforces that every
+ * `<SEOHead path="X" title="Y" description="Z" />` matches PAGE_METADATA["X"],
+ * so editing one side without the other fails the test suite.
  *
  * Blog/doc URLs omit the `image` field on purpose: they inherit the default
  * OG image from client/index.html.
@@ -32,75 +33,76 @@ export const PAGE_METADATA: Record<string, PageMeta> = {
     ogType: "website",
   },
   "/pricing": {
-    title: "Pricing — FetchTheChange",
+    title: "Pricing — Free, Pro, and Power plans | FetchTheChange",
     description:
-      "Simple, transparent pricing for website change monitoring. Free for hobbyists, Pro for teams, Power for heavy users.",
+      "Simple, transparent pricing for website change monitoring. Start free with 3 monitors, or upgrade to Pro ($9/mo, 100 monitors) or Power ($29/mo, unlimited) for hourly checks, Slack, webhooks, and the REST API.",
     ogType: "website",
   },
   "/support": {
-    title: "Support — FetchTheChange",
+    title: "Support & Help | FetchTheChange",
     description:
-      "Get help with FetchTheChange: contact support, browse FAQs, and learn how to troubleshoot broken monitors.",
+      "Get help with FetchTheChange. Browse frequently asked questions about website monitoring, troubleshooting, and billing, or contact our support team.",
     ogType: "website",
   },
   "/privacy": {
-    title: "Privacy Policy — FetchTheChange",
+    title: "Privacy Policy | FetchTheChange",
     description:
-      "How FetchTheChange handles your data: what we collect, how we use it, and your rights.",
+      "FetchTheChange Privacy Policy. Learn how we collect, use, and protect your personal data in compliance with GDPR.",
     ogType: "website",
   },
   "/changelog": {
-    title: "Changelog — FetchTheChange",
+    title: "What's New | FetchTheChange",
     description:
-      "Release notes for FetchTheChange — new features, bug fixes, and platform improvements.",
+      "See what's new in FetchTheChange — latest features, bug fixes, and improvements.",
     ogType: "website",
   },
   "/blog": {
-    title: "Blog — FetchTheChange",
+    title:
+      "Blog — Website monitoring, change detection, and integrations | FetchTheChange",
     description:
-      "Guides on website change monitoring: selector stability, price tracking, competitor intelligence, and integrations.",
+      "Insights on web monitoring, change detection, CSS selector resilience, and integrations with Slack, webhooks, and Zapier. Read the FetchTheChange blog.",
     ogType: "website",
   },
   "/blog/why-website-change-monitors-fail-silently": {
     title:
-      "Why Website Change Monitors Fail Silently | FetchTheChange",
+      "Why Website Change Monitors Fail Silently on JavaScript-Heavy Sites | FetchTheChange",
     description:
-      "Most website change monitors go silent when selectors break, sites add bot protection, or JavaScript rewrites the DOM. Here is how to catch those failures.",
+      "Most website change monitors fail silently when JavaScript or CSS selectors break. Learn why this happens and how to detect it before you miss important changes.",
     ogType: "article",
   },
   "/blog/fetchthechange-vs-distill-visualping-hexowatch": {
     title:
-      "FetchTheChange vs. Distill, Visualping, Hexowatch | FetchTheChange",
+      "FetchTheChange vs Distill vs Visualping vs Hexowatch | Website Change Monitor Comparison",
     description:
-      "How FetchTheChange compares on selector stability, JS rendering, failure reporting, and pricing against the main website change monitoring tools.",
+      "A neutral comparison of website change monitoring tools for JavaScript-heavy sites, selector breakage detection, and value-level monitoring.",
     ogType: "article",
   },
   "/blog/monitor-competitor-prices-without-getting-blocked": {
     title:
-      "How to Monitor Competitor Prices Without Getting Blocked | FetchTheChange",
+      "How to Monitor Competitor Prices Without Getting Blocked (2026 Guide)",
     description:
-      "Practical guide to scraping competitor prices reliably: rendering JS pages, rotating through selectors, and handling bot-protection gracefully.",
+      "Learn how to monitor competitor prices on modern JavaScript-heavy websites without getting blocked — and how to avoid silent monitoring failures.",
     ogType: "article",
   },
   "/blog/css-selectors-keep-breaking-why-and-how-to-fix": {
     title:
-      "Why CSS Selectors Keep Breaking (and How to Fix Them) | FetchTheChange",
+      "CSS Selectors Keep Breaking? Why It Happens and How to Fix It | FetchTheChange",
     description:
-      "Why generated class names and nested indexes break your scraper every deploy, and concrete patterns that survive UI changes.",
+      "CSS selectors in website monitors break constantly due to hashed class names, DOM restructuring, and framework re-renders. Learn why it happens and how to build resilient selectors that survive site updates.",
     ogType: "article",
   },
   "/blog/website-change-monitoring-use-cases-beyond-price-tracking": {
     title:
-      "Website Change Monitoring Use Cases Beyond Price Tracking | FetchTheChange",
+      "5 Real-World Use Cases for Website Change Monitoring (Beyond Price Tracking) | FetchTheChange",
     description:
-      "From policy pages and job boards to release notes and SEO audits — the web change monitoring use cases teams actually ship with.",
+      "Website change monitoring isn't just for tracking prices. Learn five practical use cases — from regulatory compliance to job postings — with concrete examples and selector strategies for each.",
     ogType: "article",
   },
   "/blog/monitor-website-changes-without-writing-code": {
     title:
-      "Monitor Website Changes Without Writing Code | FetchTheChange",
+      "How to Monitor Website Changes Without Writing Code (Step-by-Step) | FetchTheChange",
     description:
-      "A no-code walkthrough for setting up website change monitors with selectors, conditions, and notifications — no scripts, no servers.",
+      "You don't need to be a developer to track changes on a website. Learn how to monitor any webpage — prices, availability, text, job postings — using a point-and-click browser extension. No coding required.",
     ogType: "article",
   },
   "/blog/slack-webpage-change-alerts": {
@@ -111,21 +113,27 @@ export const PAGE_METADATA: Record<string, PageMeta> = {
     ogType: "article",
   },
   "/docs/webhooks": {
-    title: "Webhooks — FetchTheChange Docs",
+    title: "Webhook Integration | FetchTheChange Developer Docs",
     description:
-      "Send monitor events to your own HTTP endpoint with signed webhook requests. Payload schema, retry behavior, and signature verification.",
+      "Learn how to receive FetchTheChange change alerts via webhooks. Covers payload format, HMAC signature verification, retries, and testing.",
     ogType: "article",
   },
   "/docs/zapier": {
-    title: "Zapier Integration — FetchTheChange Docs",
+    title: "Zapier Integration | FetchTheChange",
     description:
-      "Connect FetchTheChange to 6000+ apps via Zapier. Trigger Zaps when a monitor detects a change.",
+      "Connect FetchTheChange to 7,000+ apps via Zapier. Trigger Zaps when any monitored value changes — no server required. Power plan.",
     ogType: "article",
   },
   "/docs/make": {
-    title: "Make Integration — FetchTheChange Docs",
+    title: "Make Integration | FetchTheChange",
     description:
-      "Integrate FetchTheChange with Make (formerly Integromat) to automate workflows when web content changes.",
+      "Connect FetchTheChange to Make (Integromat) using webhooks. Receive change alerts in any Make scenario — no server required.",
+    ogType: "article",
+  },
+  "/developer": {
+    title: "REST API Documentation | FetchTheChange Developer Docs",
+    description:
+      "FetchTheChange REST API documentation. Create monitors, pull change history, and integrate website monitoring into your CI/CD pipelines. Power plan required.",
     ogType: "article",
   },
 };

--- a/shared/pageMetadata.ts
+++ b/shared/pageMetadata.ts
@@ -138,5 +138,11 @@ export const PAGE_METADATA: Record<string, PageMeta> = {
   },
 };
 
-/** Fallback entry used when no per-path metadata exists. */
-export const DEFAULT_PAGE_METADATA: PageMeta = PAGE_METADATA["/"]!;
+/**
+ * Fallback entry used when no per-path metadata exists. Frozen because
+ * getPageMetadata returns this reference directly on cache-miss — mutating
+ * it would corrupt the landing metadata for every subsequent request.
+ */
+export const DEFAULT_PAGE_METADATA: PageMeta = Object.freeze({
+  ...PAGE_METADATA["/"]!,
+});

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -160,6 +160,13 @@ export const campaigns = pgTable("campaigns", {
 }, (table) => ({
   statusIdx: index("campaigns_status_idx").on(table.status),
   createdAtIdx: index("campaigns_created_at_idx").on(table.createdAt),
+  // Partial index on type='automated' so the welcome-exclusion anti-join in
+  // resolveRecipients can satisfy `c.type = 'automated'` via an index scan
+  // instead of a sequential scan over all campaigns. Partial because the
+  // automated set is small and stable. See GitHub issue #433.
+  typeAutomatedIdx: index("campaigns_type_automated_idx")
+    .on(table.id)
+    .where(sql`type = 'automated'`),
 }));
 
 export const campaignRecipients = pgTable("campaign_recipients", {
@@ -183,6 +190,13 @@ export const campaignRecipients = pgTable("campaign_recipients", {
     .where(sql`resend_id IS NOT NULL`),
   statusIdx: index("campaign_recipients_status_idx").on(table.status),
   campaignUserUniq: uniqueIndex("campaign_recipients_campaign_user_uniq").on(table.campaignId, table.userId),
+  // Partial composite index scoped to the active-status set used by the
+  // welcome-exclusion anti-join in resolveRecipients. Lets the planner answer
+  // the per-user probe from just the active subset instead of every historical
+  // recipient row for the user. See GitHub issue #436.
+  activeUserCampaignIdx: index("campaign_recipients_active_user_idx")
+    .on(table.userId, table.campaignId)
+    .where(sql`status IN ('pending', 'sent', 'delivered', 'opened', 'clicked')`),
 }));
 
 export const campaignsRelations = relations(campaigns, ({ many }) => ({


### PR DESCRIPTION
## Summary

Bundles fixes for 11 open bug issues (#433–#444) and a full magicwand pipeline pass on top (tests, security, architecture, code review, skeptic review). All 2454 tests pass, `npm run check` clean, production build succeeds.

Issues #428, #429, #431, #432 were already resolved in commit ed68bd2 on main — this branch does not revisit them.

## Changes

**Campaign / DB hardening**
- **#434**: `cancelCampaign` and `reconcileCampaignCounters` raw SQL now build terminal-status IN-lists from `TERMINAL_RECIPIENT_STATUSES` via `sql.join`, eliminating the dual-source-of-truth drift against `resolveRecipients`.
- **#433**: Added partial index `campaigns_type_automated_idx ON campaigns(id) WHERE type = 'automated'` so the welcome-exclusion anti-join probes via index scan rather than seq scan.
- **#436**: Added partial composite index `campaign_recipients_active_user_idx ON (user_id, campaign_id) WHERE status IN (active-set)` so the per-user probe hits only the active-status subset.

**Client / UX**
- **#435**: Dashboard `handleRefresh` now inspects `refetch()`'s `error` field and surfaces a destructive toast for real network/HTTP failures instead of bucketing them as "No monitors".
- **#437**: New `useAbortableFetchers` hook — tracks a `Set<AbortController>` in `useRef` and aborts all in-flight fetches on component unmount. Applied to `useCheckMonitor` and `useCheckMonitorSilent` so browserless/Resend quota isn't burnt on orphaned work. StrictMode-safe via `mountedRef` re-init.
- **#441**: New `usePageTitle` hook sets `document.title` on authenticated pages (Dashboard, MonitorDetails, AdminErrors, AdminCampaigns, AdminCampaignDetail, ExtensionAuth) so browser tab labels don't stay stuck on the previous public page.

**SEO / head**
- **#439**: `LandingPage` accepts an optional `path` prop; `ProtectedRoute` passes `window.location.pathname` when rendering it as the unauthed fallback on `/dashboard` or `/monitors/:id`, so canonical / og:url / JSON-LD `@id` reflect the actual URL instead of lying about it being `/`.
- **#440**: New server-side crawler-UA middleware (`server/crawlerMeta.ts` + `shared/pageMetadata.ts`) rewrites `index.html` `<head>` for known bot UAs (Facebook, X, Slack, LinkedIn, Discord, Google, Bing, etc.) with per-route title/description/canonical/og/twitter tags. Hooked into both the prod static handler (`server/static.ts`) and the dev Vite middleware (`server/vite.ts`). Template cached at module scope; rewrite cached per path (bounded, max 200 entries). Host header is NOT reflected into `baseUrl` — uses pinned `getAppUrl()` from `REPLIT_DOMAINS` to prevent SEO poisoning. Unknown paths inject `<meta name="robots" content="noindex">` to prevent soft-404 indexation. Trailing-slash paths normalize to the canonical form.
- **#442**: Defined `--font-sans`, `--font-serif`, `--font-mono` in `:root` so the Tailwind `font-mono` class actually resolves to a monospace stack instead of inheriting Inter — matters for API keys, CSS selectors, error codes, stack traces.
- **#443**: Moved Google Fonts from CSS `@import` (render-blocking, serial) to `<link rel="stylesheet">` in `client/index.html`, parallelizing the font fetch with `index.css`.
- **#444**: Dropped `maximum-scale=1` from the viewport meta to restore pinch-zoom on mobile (WCAG 2.1 SC 1.4.4 Level AA compliance).

**Test coverage**
- `client/src/hooks/use-page-title.test.ts` — 5 tests (set-on-mount, restore-on-unmount, undefined no-op, prop change, nested mount).
- `client/src/hooks/use-monitors.test.ts` — 2 tests asserting `useCheckMonitor`/`useCheckMonitorSilent` abort in-flight fetches on unmount.
- `server/services/campaignEmail.test.ts` — 2 tests asserting `cancelCampaign` and `reconcileCampaignCounters` bind terminal statuses from the constant.
- `server/crawlerMeta.test.ts` — 29 tests (bot-UA detection, real-template integration, noindex for unknown paths, trailing-slash normalization, multi-line attribute tolerance, exact-one-of-each-tag invariant).
- `client/src/pages/page-metadata-parity.test.ts` — 49 tests enforcing `PAGE_METADATA ↔ <SEOHead>` agreement; resolves one-level `const BLOG_PATH = "..."` indirection so all blog posts are covered.
- `server/partial-index-invariants.test.ts` — 4 tests asserting the `campaign_recipients_active_user_idx` predicate contains every status in `ACTIVE_RECIPIENT_STATUSES`.

**Magicwand pipeline findings**
- Phase 2 security: fixed a Medium Host-header reflection in the crawler middleware (was using `req.get("host")`, now uses pinned `getAppUrl()`) and added a per-path rewrite cache to cap UA-spoofed flood amplification.
- Phase 3 architecture: added the `PAGE_METADATA ↔ SEOHead` parity test and a real-template crawler test so the two sources-of-truth can't silently drift.
- Phase 4 code review: 7 minor-to-important fixes, 1 finding filed as #446 (Dashboard bulk-refresh still lacks AbortController plumbing — pre-existing from #438, out-of-scope here).
- Phase 5 skeptic: 7 discoveries remediated (blog parity, unknown-path noindex, partial-index invariant, rewrite cache, StrictMode safety, trailing-slash normalization, duplicate-tag invariant).

## How to test

- [ ] **Social unfurl:** in incognito, paste `https://<your-deploy>/blog/slack-webpage-change-alerts` into a Slack DM or Facebook Sharing Debugger. Preview should show the blog post title/description, not the landing page.
- [ ] **Pinch-zoom:** on a mobile device (or Chrome DevTools device emulation), open any page and confirm you can pinch-zoom.
- [ ] **Font-mono:** DevTools → inspect an API key card on `/dashboard` or an error code on `/admin/errors`. Computed `font-family` should start with `ui-monospace`.
- [ ] **Dashboard refresh error:** in DevTools throttle or block `GET /api/monitors`, click the refresh button, confirm you see a destructive "Refresh failed" toast (not "No monitors").
- [ ] **Dashboard refresh abort:** with 10+ monitors, click refresh and immediately navigate away. DevTools Network panel: the in-flight `/api/monitors/:id/check` requests started from the hook-based paths should show as `(cancelled)`.
- [ ] **Tab titles:** click between `/pricing` → `/dashboard` → `/monitors/X` → `/admin/errors`. Each should update the tab label to something descriptive.
- [ ] **Canonical on unauthed dashboard:** in incognito, visit `/dashboard`. View source — canonical link and og:url should point to `/dashboard`, not `/`.
- [ ] **Unknown-path noindex:** `curl -H "User-Agent: Googlebot" https://<deploy>/no-such-route | grep robots` — expect `<meta name="robots" content="noindex">`.

https://claude.ai/code/session_04BM7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dynamic page titles now update for each route
  * Social media link previews now display correctly when sharing
  * Improved crawler and bot support for better link unfurling

* **Bug Fixes**
  * Fixed canonical URLs in social metadata
  * Better error messaging on data refresh failures
  * Prevented orphaned network requests during navigation

* **Performance**
  * Faster font loading via optimized asset delivery
  * Improved database query efficiency

* **UX Improvements**
  * Enabled pinch-zoom on mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->