### PR TITLE
chore: compact admin /errors warnings — aggregate infra, trim verbose tails

### DIFF
--- a/server/services/logger.test.ts
+++ b/server/services/logger.test.ts
@@ -204,20 +204,18 @@ describe("ErrorLogger deduplication", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("Browserless graceful degradation logs a single warning with preservation note", async () => {
-    // Contract test: when monitor has currentValue, the warning message includes
-    // "preserving last known value" so no separate Info entry is created.
-    const classified = "Rendered page extraction failed — the site may block automated browsers";
-    const withCurrentValue = ", preserving last known value. Will retry shortly.";
-    const withoutCurrentValue = ".";
+  it("Browserless warnings use monitor-agnostic message for infra failures so dedup aggregates across monitors", async () => {
+    // Contract test: infra-wide failures (service unavailable, circuit breaker open)
+    // emit a monitor-agnostic message so every affected monitor dedups into a single
+    // row in the admin UI. Site-specific failures still name the monitor.
+    const infraMsg = "Browserless service unavailable — preserving last known values";
+    const circuitMsg = "Browserless circuit breaker open — preserving last known values";
+    const siteSpecificMsg = `"My Monitor" — site blocking automated access`;
 
-    const msgWithValue = `"My Monitor" — rendered page extraction failed: ${classified}${withCurrentValue}`;
-    const msgWithoutValue = `"My Monitor" — rendered page extraction failed: ${classified}${withoutCurrentValue}`;
-
-    expect(msgWithValue).toMatch(/preserving last known value/);
-    expect(msgWithValue).not.toMatch(/Browserless temporarily unavailable/);
-    expect(msgWithoutValue).not.toMatch(/preserving last known value/);
-    expect(msgWithoutValue).toMatch(/\.$/);
+    expect(infraMsg).not.toMatch(/"My Monitor"/);
+    expect(circuitMsg).not.toMatch(/"My Monitor"/);
+    expect(siteSpecificMsg).toMatch(/"My Monitor"/);
+    expect(siteSpecificMsg).not.toMatch(/preserving last known value/);
   });
 
   it("convenience methods call log with correct level", async () => {

--- a/server/services/scheduler.test.ts
+++ b/server/services/scheduler.test.ts
@@ -781,7 +781,7 @@ describe("daily metrics cleanup", () => {
 
     expect(ErrorLogger.warning).toHaveBeenCalledWith(
       "scheduler",
-      "monitor_metrics cleanup failed (transient, will retry)",
+      "monitor_metrics cleanup failed",
       expect.objectContaining({
         errorMessage: "Connection terminated",
         retentionDays: 90,
@@ -949,7 +949,7 @@ describe("notification queue and digest cron (*/1 * * * *)", () => {
 
     expect(ErrorLogger.warning).toHaveBeenCalledWith(
       "scheduler",
-      expect.stringContaining("Queued notification processing failed (transient, will retry)"),
+      "Queued notification processing failed",
       expect.objectContaining({
         errorMessage: "Connection terminated",
       })
@@ -966,7 +966,7 @@ describe("notification queue and digest cron (*/1 * * * *)", () => {
 
     expect(ErrorLogger.warning).toHaveBeenCalledWith(
       "scheduler",
-      expect.stringContaining("Digest processing failed (transient, will retry)"),
+      "Digest processing failed",
       expect.objectContaining({
         errorMessage: "Connection terminated",
       })
@@ -1098,7 +1098,7 @@ describe("withDbRetry and re-entrancy guards", () => {
     // Transient DB errors are downgraded to warnings via logSchedulerError helper
     expect(ErrorLogger.warning).toHaveBeenCalledWith(
       "scheduler",
-      expect.stringContaining("Scheduler iteration failed (transient, will retry)"),
+      "Scheduler iteration failed",
       expect.objectContaining({ activeChecks: 0 })
     );
   });
@@ -1214,7 +1214,7 @@ describe("withDbRetry and re-entrancy guards", () => {
 
     expect(ErrorLogger.warning).toHaveBeenCalledWith(
       "scheduler",
-      expect.stringContaining("Webhook retry processing failed (transient, will retry)"),
+      "Webhook retry processing failed",
       expect.objectContaining({
         errorMessage: "Connection terminated",
       })

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -49,7 +49,7 @@ async function logSchedulerError(
 ): Promise<void> {
   try {
     if (isTransientDbError(error)) {
-      await ErrorLogger.warning("scheduler", `${message} (transient, will retry)`, {
+      await ErrorLogger.warning("scheduler", message, {
         errorMessage: error instanceof Error ? error.message : String(error),
         ...context,
       });

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -5513,27 +5513,27 @@ describe("human-like delay before selector access", () => {
 // ---------------------------------------------------------------------------
 describe("classifyBrowserlessError", () => {
   it("classifies timeout errors", () => {
-    expect(classifyBrowserlessError("Navigation timeout of 30000ms exceeded")).toContain("took too long");
+    expect(classifyBrowserlessError("Navigation timeout of 30000ms exceeded")).toContain("timeout");
   });
 
   it("classifies timed out errors", () => {
-    expect(classifyBrowserlessError("page timed out waiting for selector")).toContain("took too long");
+    expect(classifyBrowserlessError("page timed out waiting for selector")).toContain("timeout");
   });
 
   it("classifies ENOTFOUND errors", () => {
-    expect(classifyBrowserlessError("getaddrinfo ENOTFOUND example.com")).toContain("domain could not be resolved");
+    expect(classifyBrowserlessError("getaddrinfo ENOTFOUND example.com")).toContain("DNS resolution failed");
   });
 
   it("classifies ECONNREFUSED errors", () => {
-    expect(classifyBrowserlessError("connect ECONNREFUSED 127.0.0.1:443")).toContain("refused the connection");
+    expect(classifyBrowserlessError("connect ECONNREFUSED 127.0.0.1:443")).toContain("connection refused");
   });
 
   it("classifies net::ERR_CONNECTION_REFUSED errors", () => {
-    expect(classifyBrowserlessError("net::ERR_CONNECTION_REFUSED at page.goto")).toContain("refused the connection");
+    expect(classifyBrowserlessError("net::ERR_CONNECTION_REFUSED at page.goto")).toContain("connection refused");
   });
 
   it("classifies ERR_TOO_MANY_REDIRECTS errors", () => {
-    expect(classifyBrowserlessError("net::ERR_TOO_MANY_REDIRECTS")).toContain("Too many redirects");
+    expect(classifyBrowserlessError("net::ERR_TOO_MANY_REDIRECTS")).toContain("too many redirects");
   });
 
   it("classifies 403 Forbidden errors", () => {
@@ -5553,11 +5553,11 @@ describe("classifyBrowserlessError", () => {
   });
 
   it("returns default message for unknown errors", () => {
-    expect(classifyBrowserlessError("some random error")).toContain("Rendered page extraction failed");
+    expect(classifyBrowserlessError("some random error")).toContain("extraction failed");
   });
 
   it("classifies ERR_NAME_NOT_RESOLVED errors", () => {
-    expect(classifyBrowserlessError("net::ERR_NAME_NOT_RESOLVED")).toContain("domain could not be resolved");
+    expect(classifyBrowserlessError("net::ERR_NAME_NOT_RESOLVED")).toContain("DNS resolution failed");
   });
 });
 

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -1966,7 +1966,7 @@ describe("failure tracking and auto-pause", () => {
       expect.objectContaining({
         monitorId: 1,
         monitorName: "My Watch",
-        classifiedReason: expect.any(String),
+        classifiedReason: expect.stringContaining("connection refused"),
       }),
     );
     // Every infra-warning call must omit the monitor name so dedup aggregates across monitors.
@@ -2008,7 +2008,12 @@ describe("failure tracking and auto-pause", () => {
     expect(ErrorLogger.warning).toHaveBeenCalledWith(
       "scraper",
       `"My Watch" — page timeout`,
-      expect.objectContaining({ monitorId: 1, monitorName: "My Watch" }),
+      expect.objectContaining({
+        monitorId: 1,
+        monitorName: "My Watch",
+        classifiedReason: "page timeout",
+        rawBrowserlessMsg: expect.stringContaining("Navigation timeout"),
+      }),
     );
 
     delete process.env.BROWSERLESS_TOKEN;

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -1998,10 +1998,11 @@ describe("failure tracking and auto-pause", () => {
     mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
 
     const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
-    // Non-infra failures retry once with BASE_RETRY_MS + jitter (up to ~3.5s), so
-    // drain all pending timers rather than advancing a fixed amount.
+    // Non-infra failures retry once with BASE_RETRY_MS + jitter (up to ~3.5s).
+    // Bound to 10s so future refactors adding recursive setTimeout in this path
+    // produce a test timeout rather than an infinite loop.
     const promise = checkMonitor(monitor);
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(10000);
     await promise;
 
     expect(ErrorLogger.warning).toHaveBeenCalledWith(

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -1942,6 +1942,106 @@ describe("failure tracking and auto-pause", () => {
     delete process.env.BROWSERLESS_TOKEN;
   });
 
+  it("Browserless infrastructure failures emit a monitor-agnostic warning so affected monitors dedup into one row", async () => {
+    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
+
+    process.env.BROWSERLESS_TOKEN = "test-token";
+    const { BrowserlessUsageTracker } = await import("./browserlessTracker");
+    (BrowserlessUsageTracker.canUseBrowserless as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ allowed: true });
+    mockConnectOverCDP.mockRejectedValue(new Error("connectOverCDP failed: ECONNREFUSED"));
+
+    mockDbUpdate(1, true);
+    mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
+
+    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+    await runWithTimers(monitor);
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      "Browserless service unavailable — preserving last known values",
+      expect.objectContaining({
+        monitorId: 1,
+        monitorName: "My Watch",
+        classifiedReason: expect.any(String),
+      }),
+    );
+    // Every infra-warning call must omit the monitor name so dedup aggregates across monitors.
+    const infraCalls = (ErrorLogger.warning as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c) => c[0] === "scraper" && String(c[1]).includes("Browserless service unavailable"));
+    expect(infraCalls.length).toBeGreaterThanOrEqual(1);
+    for (const c of infraCalls) {
+      expect(c[1]).not.toContain("My Watch");
+    }
+
+    delete process.env.BROWSERLESS_TOKEN;
+  });
+
+  it("Browserless site-specific failures include the monitor name for per-site drill-down", async () => {
+    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
+
+    process.env.BROWSERLESS_TOKEN = "test-token";
+    const { BrowserlessUsageTracker } = await import("./browserlessTracker");
+    (BrowserlessUsageTracker.canUseBrowserless as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ allowed: true });
+    // Timeout message matches classifyBrowserlessError's "timeout" branch but not
+    // any isInfra pattern — so the site-specific warning path fires.
+    mockConnectOverCDP.mockRejectedValue(new Error("Navigation timeout of 30000ms exceeded"));
+
+    mockDbUpdate(1, true);
+    mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
+
+    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+    // Non-infra failures retry once with BASE_RETRY_MS + jitter (up to ~3.5s), so
+    // drain all pending timers rather than advancing a fixed amount.
+    const promise = checkMonitor(monitor);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      `"My Watch" — page timeout`,
+      expect.objectContaining({ monitorId: 1, monitorName: "My Watch" }),
+    );
+
+    delete process.env.BROWSERLESS_TOKEN;
+  });
+
+  it("Browserless circuit-breaker-open warning is monitor-agnostic", async () => {
+    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
+
+    process.env.BROWSERLESS_TOKEN = "test-token";
+    (browserlessCircuitBreaker.isAvailable as ReturnType<typeof vi.fn>).mockReturnValueOnce(false);
+
+    mockDbUpdate(1, true);
+    mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
+
+    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+    await runWithTimers(monitor);
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      "Browserless circuit breaker open — preserving last known values",
+      expect.objectContaining({ monitorId: 1, monitorName: "My Watch" }),
+    );
+    const circuitCalls = (ErrorLogger.warning as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c) => c[0] === "scraper" && String(c[1]).includes("circuit breaker open"));
+    for (const c of circuitCalls) {
+      expect(c[1]).not.toContain("My Watch");
+    }
+
+    delete process.env.BROWSERLESS_TOKEN;
+  });
+
   it("falls back to free tier threshold when user tier is unknown", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("timeout"));
     // free threshold: DB returns active=false to indicate SQL CASE triggered

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -921,21 +921,21 @@ async function tryDismissConsent(page: any): Promise<boolean> {
  */
 export function classifyBrowserlessError(errMsg: string): string {
   if (/timeout|Timeout|timed out/.test(errMsg)) {
-    return "Page took too long to load — the site may be slow or blocking headless browsers";
+    return "page timeout";
   }
   if (/net::ERR_NAME_NOT_RESOLVED|getaddrinfo|ENOTFOUND/.test(errMsg)) {
-    return "The domain could not be resolved — check the URL is correct";
+    return "DNS resolution failed";
   }
   if (/net::ERR_CONNECTION_REFUSED|ECONNREFUSED/.test(errMsg)) {
-    return "The site refused the connection — it may be down";
+    return "connection refused (site down?)";
   }
   if (/net::ERR_TOO_MANY_REDIRECTS/.test(errMsg)) {
-    return "Too many redirects — the page may require a login or cookie";
+    return "too many redirects";
   }
   if (/403|Forbidden|access denied|bot detection|challenge/i.test(errMsg)) {
-    return "The site is actively blocking automated access — try a less frequent check interval";
+    return "site blocking automated access";
   }
-  return "Rendered page extraction failed — the site may block automated browsers";
+  return "extraction failed";
 }
 
 /**
@@ -1262,19 +1262,14 @@ export async function checkMonitor(monitor: Monitor): Promise<{
               lastBrowserlessErr instanceof Error ? lastBrowserlessErr : null,
               { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector },
             ).catch(() => {});
+          } else if (browserlessInfraFailure) {
+            // Infra-wide outage: monitor-agnostic message so every affected monitor
+            // dedups into a single row in the admin UI. Per-monitor details stay
+            // in context for drill-down (last-writer-wins; occurrenceCount conveys scale).
+            await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() });
           } else {
-            // Downgrade to warning: Browserless failures are expected for sites that
-            // block headless browsers. The circuit breaker and retry logic handle recovery.
-            const classified = browserlessInfraFailure
-              ? "Browserless service connection refused (infrastructure issue)"
-              : classifyBrowserlessError(rawBrowserlessMsg);
-            // Suffix varies by cached-value state — intentionally creates two dedup
-            // buckets in error_logs so the admin UI distinguishes first-check failures
-            // from degraded-but-cached monitors.
-            const degradationNote = monitor.currentValue
-              ? ", preserving last known value. Will retry shortly."
-              : ".";
-            await ErrorLogger.warning("scraper", `"${monitor.name}" — rendered page extraction failed: ${classified}${degradationNote}`, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() });
+            // Site-specific failure: keep the monitor name because the site itself is the problem.
+            await ErrorLogger.warning("scraper", `"${monitor.name}" — ${classifyBrowserlessError(rawBrowserlessMsg)}`, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() });
           }
         }
 
@@ -1309,7 +1304,7 @@ export async function checkMonitor(monitor: Monitor): Promise<{
         if (skippedDueToOpenCircuit) {
           await ErrorLogger.warning(
             "scraper",
-            `"${monitor.name}" — rendered page extraction failed: Browserless circuit breaker open, preserving last known value. Will retry shortly.`,
+            "Browserless circuit breaker open — preserving last known values",
             { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
           );
         }

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -1266,7 +1266,9 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             // Infra-wide outage: monitor-agnostic message so every affected monitor
             // dedups into a single row in the admin UI. Per-monitor details stay
             // in context for drill-down (last-writer-wins; occurrenceCount conveys scale).
-            await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() });
+            // classifiedReason preserves the specific failure type (timeout/DNS/ECONNREFUSED)
+            // since the message itself is now constant across monitors.
+            await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
           } else {
             // Site-specific failure: keep the monitor name because the site itself is the problem.
             await ErrorLogger.warning("scraper", `"${monitor.name}" — ${classifyBrowserlessError(rawBrowserlessMsg)}`, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() });

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -1273,7 +1273,24 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
           } else {
             // Site-specific failure: keep the monitor name because the site itself is the problem.
-            await ErrorLogger.warning("scraper", `"${monitor.name}" — ${classifyBrowserlessError(rawBrowserlessMsg)}`, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() });
+            // Mirror the infra branch's drill-down fields (classifiedReason + truncated raw
+            // error) so the admin UI has enough detail when the catchall "extraction failed"
+            // string fires. Logger sanitization (server/services/logger.ts:29-53) strips
+            // secrets from the raw error before persistence.
+            const classifiedReason = classifyBrowserlessError(rawBrowserlessMsg);
+            await ErrorLogger.warning(
+              "scraper",
+              `"${monitor.name}" — ${classifiedReason}`,
+              {
+                monitorId: monitor.id,
+                monitorName: monitor.name,
+                url: monitor.url,
+                selector: monitor.selector,
+                circuitState: browserlessCircuitBreaker.getState(),
+                classifiedReason,
+                rawBrowserlessMsg: rawBrowserlessMsg.slice(0, 500),
+              },
+            );
           }
         }
 

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -1265,9 +1265,11 @@ export async function checkMonitor(monitor: Monitor): Promise<{
           } else if (browserlessInfraFailure) {
             // Infra-wide outage: monitor-agnostic message so every affected monitor
             // dedups into a single row in the admin UI. Per-monitor details stay
-            // in context for drill-down (last-writer-wins; occurrenceCount conveys scale).
-            // classifiedReason preserves the specific failure type (timeout/DNS/ECONNREFUSED)
-            // since the message itself is now constant across monitors.
+            // in context for drill-down. NOTE: context is last-writer-wins
+            // (server/services/logger.ts:99), so during a mixed-mode outage
+            // monitorId/monitorName/url/classifiedReason reflect only the most
+            // recent writer, not an aggregate across affected monitors.
+            // occurrenceCount is the only signal of outage scope.
             await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
           } else {
             // Site-specific failure: keep the monitor name because the site itself is the problem.


### PR DESCRIPTION
## Summary

The admin `/admin/errors` warnings list was dominated by near-duplicate rows — every monitor hit by a Browserless infrastructure outage produced its own row because the monitor name was baked into the dedup key. Messages also carried redundant prefixes/suffixes that the level+source badges already convey. This PR trims messages and aggregates infra-wide failures so a typical outage collapses from ~8 rows into ~2.

## Changes

**Scraper warnings (`server/services/scraper.ts`)**
- Split Browserless warning emission: infra-wide failures (service unreachable, circuit breaker open) now use a monitor-agnostic message so every affected monitor dedups into a single row; site-specific failures still name the monitor.
- Shortened `classifyBrowserlessError` outputs (e.g. `"The site is actively blocking automated access — try a less frequent check interval"` → `"site blocking automated access"`).
- Dropped the `"rendered page extraction failed:"` prefix and `", preserving last known value. Will retry shortly."` suffix — the level + source badges convey this.
- Preserved the specific failure type (timeout/DNS/ECONNREFUSED) in `context.classifiedReason` on the aggregated infra path.

**Scheduler warnings (`server/services/scheduler.ts`)**
- Dropped `(transient, will retry)` suffix from `logSchedulerError` — a `warning`-level row already communicates transient.

**Tests**
- Added 3 behavior tests in `scraper.test.ts` asserting the new emission contract (infra-agnostic, site-specific-named, circuit-breaker-agnostic) — they drive `checkMonitor` and assert on `ErrorLogger.warning` call arguments.
- Updated existing string assertions in `scraper.test.ts`, `scheduler.test.ts`, and `logger.test.ts`.
- Total test count: 2365 → 2368.

## Known tradeoffs (reviewed in magicwand skeptic pass)

- **Context last-writer-wins on aggregated rows.** During a mixed-mode Browserless outage, `monitorId`/`monitorName`/`classifiedReason` in `context` reflect only the most recent writer, not an aggregate. `occurrenceCount` is the only signal of outage scope. Documented inline at `scraper.ts:1266-1272`.
- **Scheduler warning and error rows now share identical message text** (e.g. `"monitor_metrics cleanup failed"`) — distinguished only by the level badge in the admin UI rather than the previous `(transient, will retry)` suffix.
- **Pre-deploy unresolved rows won't dedup with new short-form messages.** Operators may want to bulk-resolve pre-existing unresolved scraper warnings after this ships so the admin UI doesn't show both old and new variants simultaneously.

## Related follow-ups filed during review

- #448 — ErrorLogger dedup race (non-atomic SELECT-then-INSERT, no unique constraint). Pre-existing but newly reachable because this PR introduces shared message strings.
- #449 — First-check monitor during circuit-open produces no admin warning. Pre-existing; worth hoisting the warning out of the `currentValue` guard.

## How to test

1. `npm run check && npm run test` — both pass (2368 tests).
2. Manual, in dev:
   - Set `BROWSERLESS_URL` to an invalid host to simulate an infra outage.
   - Trigger several monitor checks (via dashboard refresh or scheduler tick).
   - Open `/admin/errors`. Confirm one `Browserless service unavailable — preserving last known values` row with `occurrenceCount` climbing, instead of one row per monitor name.
   - Restore `BROWSERLESS_URL` and verify site-specific failures (e.g. for a known bot-blocking URL) still include the monitor name in the message.
3. Visually compare `/admin/errors` before/after — the 10-row screenshot from the originating request should collapse to ~4-5 rows with higher occurrence counts.

https://claude.ai/code/session_01NVUxNV8Q5gxoDeLsRANR2Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made error and warning messages for the scraping/browserless service shorter and more consistent.
  * Split warnings into infrastructure-wide versus site-specific variants to reduce duplicate alerts.
  * Standardized circuit-breaker and transient-error logging wording.
  * Improved error classification labels for clearer root-cause indications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->