### PR TITLE
fix: resolve open bugs #446, #448, #449 with deploy-time hardening

### DIFF
--- a/client/src/hooks/use-monitors.ts
+++ b/client/src/hooks/use-monitors.ts
@@ -10,9 +10,12 @@ import { useToast } from "@/hooks/use-toast";
  * cancellation signal (unlike `queryFn`), so we plumb one in ourselves. Used
  * by useCheckMonitor / useCheckMonitorSilent so an in-flight monitor check
  * stops burning browserless/scraper quota once the user navigates away.
- * See GitHub issue #437.
+ * Also reused by Dashboard's bulk-refresh direct-fetch path (#446), which
+ * intentionally bypasses these hooks to avoid an N-way query invalidation
+ * storm but still needs the same abort-on-unmount guarantee.
+ * See GitHub issues #437 and #446.
  */
-function useAbortableFetchers() {
+export function useAbortableFetchers() {
   const controllersRef = useRef<Set<AbortController>>(new Set());
   useEffect(() => {
     // Capture the Set reference so the cleanup aborts the same object the

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -40,12 +40,13 @@ export default function Dashboard() {
   // stays false for the rest of the component's life and handleRefresh bails
   // out immediately.
   const mountedRef = useRef(true);
-  // Shared with the hook-path fetchers (useCheckMonitor / useCheckMonitorSilent)
-  // so the Dashboard's bulk-refresh direct-fetch path gets the same
-  // abort-on-unmount guarantee without duplicating the Set bookkeeping. The
-  // direct fetch bypasses the typed hooks to avoid an N-way query
-  // invalidation storm; this keeps the abort semantics aligned. See GitHub
-  // issue #446.
+  // Uses the same abort-on-unmount abstraction as the hook-path fetchers
+  // (useCheckMonitor / useCheckMonitorSilent); each hook call returns its
+  // own Set, so Dashboard's direct-fetch controllers are tracked separately
+  // from any concurrent hook-path mutations (MonitorCard etc). Dashboard
+  // bypasses the typed hooks on the bulk path to avoid an N-way query
+  // invalidation storm; reusing the helper keeps the abort semantics
+  // aligned. See GitHub issue #446.
   const bulkAbortControllers = useAbortableFetchers();
   useEffect(() => {
     mountedRef.current = true;

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from "@/hooks/use-auth";
 import { usePageTitle } from "@/hooks/use-page-title";
-import { useMonitors, useCheckMonitor } from "@/hooks/use-monitors";
+import { useMonitors, useCheckMonitor, useAbortableFetchers } from "@/hooks/use-monitors";
 import { useQueryClient } from "@tanstack/react-query";
 import { api, buildUrl } from "@shared/routes";
 import { CreateMonitorDialog } from "@/components/CreateMonitorDialog";
@@ -40,20 +40,16 @@ export default function Dashboard() {
   // stays false for the rest of the component's life and handleRefresh bails
   // out immediately.
   const mountedRef = useRef(true);
-  // Tracks AbortControllers for in-flight bulk-refresh fetches so we can abort
-  // them on unmount. Without this, the direct-fetch path bypasses
-  // useAbortableFetchers (the hook path the typed mutations use) and the
-  // browser keeps in-flight requests running on the server, burning
-  // Browserless / Resend quota after the user has navigated away. See GitHub
+  // Shared with the hook-path fetchers (useCheckMonitor / useCheckMonitorSilent)
+  // so the Dashboard's bulk-refresh direct-fetch path gets the same
+  // abort-on-unmount guarantee without duplicating the Set bookkeeping. The
+  // direct fetch bypasses the typed hooks to avoid an N-way query
+  // invalidation storm; this keeps the abort semantics aligned. See GitHub
   // issue #446.
-  const bulkAbortControllers = useRef<Set<AbortController>>(new Set());
+  const bulkAbortControllers = useAbortableFetchers();
   useEffect(() => {
     mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-      bulkAbortControllers.current.forEach(c => c.abort());
-      bulkAbortControllers.current.clear();
-    };
+    return () => { mountedRef.current = false; };
   }, []);
   const { toast } = useToast();
   const searchString = useSearch();

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -212,9 +212,9 @@ export default function Dashboard() {
     try {
       for (let i = 0; i < activeMonitors.length; i += REFRESH_CONCURRENCY) {
         // If the user navigated away mid-refresh, stop issuing new batches.
-        // In-flight requests continue (no AbortController plumbing yet) but
-        // the orphaned-work blast radius is capped at one batch rather than
-        // the full N monitors.
+        // In-flight requests from prior batches are aborted by
+        // `useAbortableFetchers`' unmount cleanup (#446); this early-return
+        // just stops queuing additional work.
         if (!mountedRef.current) return;
         const batch = activeMonitors.slice(i, i + REFRESH_CONCURRENCY);
         const results = await Promise.allSettled(batch.map(m => bulkCheckOne(m.id)));
@@ -222,8 +222,16 @@ export default function Dashboard() {
           if (r.status === "fulfilled") {
             if (r.value.changed) changed += 1; else unchanged += 1;
           } else {
-            const status = (r.reason as { status?: number } | undefined)?.status;
-            if (status === 429) rateLimited += 1; else failed += 1;
+            // AbortError rejections come from the unmount cleanup, not a real
+            // check failure — they should never inflate the `failed` tally.
+            // Today the summary toast is suppressed below by the `return`
+            // guarded on `!mountedRef.current`, but filtering here keeps the
+            // tally correct even if a future refactor hoists the toast above
+            // that guard, or aborts controllers for non-unmount reasons
+            // (e.g. a "cancel refresh" button).
+            const reason = r.reason as { status?: number; name?: string } | undefined;
+            if (reason?.name === "AbortError") continue;
+            if (reason?.status === 429) rateLimited += 1; else failed += 1;
           }
         }
       }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -40,9 +40,20 @@ export default function Dashboard() {
   // stays false for the rest of the component's life and handleRefresh bails
   // out immediately.
   const mountedRef = useRef(true);
+  // Tracks AbortControllers for in-flight bulk-refresh fetches so we can abort
+  // them on unmount. Without this, the direct-fetch path bypasses
+  // useAbortableFetchers (the hook path the typed mutations use) and the
+  // browser keeps in-flight requests running on the server, burning
+  // Browserless / Resend quota after the user has navigated away. See GitHub
+  // issue #446.
+  const bulkAbortControllers = useRef<Set<AbortController>>(new Set());
   useEffect(() => {
     mountedRef.current = true;
-    return () => { mountedRef.current = false; };
+    return () => {
+      mountedRef.current = false;
+      bulkAbortControllers.current.forEach(c => c.abort());
+      bulkAbortControllers.current.clear();
+    };
   }, []);
   const { toast } = useToast();
   const searchString = useSearch();
@@ -179,19 +190,26 @@ export default function Dashboard() {
     // approach failed because the 429 body ("Free tier: You can check…")
     // doesn't contain "rate limit".
     const bulkCheckOne = async (id: number): Promise<{ changed: boolean }> => {
-      const res = await fetch(buildUrl(api.monitors.check.path, { id }), {
-        method: api.monitors.check.method,
-        credentials: "include",
-      });
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}));
-        const err = new Error(errorData.message || "Failed to check monitor") as Error & { status: number };
-        err.status = res.status;
-        throw err;
+      const controller = new AbortController();
+      bulkAbortControllers.current.add(controller);
+      try {
+        const res = await fetch(buildUrl(api.monitors.check.path, { id }), {
+          method: api.monitors.check.method,
+          credentials: "include",
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          const errorData = await res.json().catch(() => ({}));
+          const err = new Error(errorData.message || "Failed to check monitor") as Error & { status: number };
+          err.status = res.status;
+          throw err;
+        }
+        return api.monitors.check.responses[200].parse(await res.json().catch(() => {
+          throw new Error("Unexpected response format from server");
+        }));
+      } finally {
+        bulkAbortControllers.current.delete(controller);
       }
-      return api.monitors.check.responses[200].parse(await res.json().catch(() => {
-        throw new Error("Unexpected response format from server");
-      }));
     };
 
     try {

--- a/server/partial-index-invariants.test.ts
+++ b/server/partial-index-invariants.test.ts
@@ -4,9 +4,9 @@
  * causes the planner to regress because the index no longer covers the new
  * status values. See Phase 5 skeptic Concern 3.
  *
- * Reads the campaignEmail.ts and schema.ts source as text rather than
- * importing them — the service module pulls in db.ts which requires a live
- * DATABASE_URL, and this test only needs to compare string predicates.
+ * Reads the campaignEmail.ts / logger.ts / schema.ts source as text rather
+ * than importing them — the service modules pull in db.ts which requires a
+ * live DATABASE_URL, and these tests only compare string predicates.
  */
 import { describe, it, expect } from "vitest";
 import fs from "fs";
@@ -18,6 +18,10 @@ const CAMPAIGN_EMAIL_SRC = fs.readFileSync(
 );
 const SCHEMA_SRC = fs.readFileSync(
   path.resolve(__dirname, "..", "shared", "schema.ts"),
+  "utf-8",
+);
+const LOGGER_SRC = fs.readFileSync(
+  path.resolve(__dirname, "services", "logger.ts"),
   "utf-8",
 );
 
@@ -83,5 +87,58 @@ describe("TERMINAL_RECIPIENT_STATUSES is a subset of ACTIVE_RECIPIENT_STATUSES",
     for (const status of TERMINAL_RECIPIENT_STATUSES) {
       expect(active.has(status)).toBe(true);
     }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// error_logs_unresolved_dedup_idx — the ErrorLogger upsert's ON CONFLICT
+// partial-index predicate must exactly match the index's WHERE clause.
+// Postgres matches ON CONFLICT inference specs by strict predicate equality;
+// a mismatch produces a runtime error ("there is no unique or exclusion
+// constraint matching the ON CONFLICT specification") that ErrorLogger's
+// catch block swallows, silently disabling logging. See GitHub issue #448.
+// -----------------------------------------------------------------------------
+
+function extractIndexPredicate(indexName: string): string {
+  const re = new RegExp(`${indexName}[\\s\\S]*?\\.where\\(sql\`([^\`]+)\`\\)`);
+  const m = SCHEMA_SRC.match(re);
+  if (!m) throw new Error(`failed to extract ${indexName} predicate from shared/schema.ts`);
+  return m[1].trim();
+}
+
+function extractLoggerTargetWherePredicate(): string {
+  const m = LOGGER_SRC.match(/targetWhere:\s*sql`([^`]+)`/);
+  if (!m) {
+    throw new Error(
+      "failed to extract targetWhere predicate from server/services/logger.ts — " +
+        "did the onConflictDoUpdate call move, split the predicate across " +
+        "fragments, or switch to a non-sql`` expression? The invariant test " +
+        "cannot validate the upsert until this regex matches the call shape again.",
+    );
+  }
+  return m[1].trim();
+}
+
+describe("error_logs_unresolved_dedup_idx predicate matches ErrorLogger upsert targetWhere", () => {
+  it("index WHERE clause and onConflictDoUpdate targetWhere are byte-for-byte equal", () => {
+    const indexPredicate = extractIndexPredicate("unresolvedDedupIdx");
+    const loggerPredicate = extractLoggerTargetWherePredicate();
+    expect(loggerPredicate).toBe(indexPredicate);
+  });
+
+  it("index covers exactly the (level, source, message) tuple", () => {
+    // Match the exact .on(...) column list for the unresolved-dedup index.
+    // If new columns are added or the order changes, the ErrorLogger upsert's
+    // `target: [errorLogs.level, errorLogs.source, errorLogs.message]` tuple
+    // must be updated in lockstep or Postgres rejects the conflict spec.
+    const m = SCHEMA_SRC.match(
+      /unresolvedDedupIdx[\s\S]*?\.on\(([^)]+)\)/,
+    );
+    if (!m) throw new Error("failed to extract unresolvedDedupIdx .on(...) columns");
+    const columns = m[1]
+      .split(",")
+      .map((c) => c.trim().replace(/^table\./, ""))
+      .filter(Boolean);
+    expect(columns).toEqual(["level", "source", "message"]);
   });
 });

--- a/server/partial-index-invariants.test.ts
+++ b/server/partial-index-invariants.test.ts
@@ -119,6 +119,24 @@ function extractLoggerTargetWherePredicate(): string {
   return m[1].trim();
 }
 
+function extractLoggerConflictTargetColumns(): string[] {
+  // Match `target: [errorLogs.level, errorLogs.source, errorLogs.message]` on
+  // the onConflictDoUpdate call. Extracts the column names after the
+  // `errorLogs.` prefix so they can be compared against the schema's .on(...)
+  // tuple directly. If this regex stops matching, the caller-side assertion
+  // throws a descriptive error so the drift is caught rather than silently
+  // skipped.
+  const m = LOGGER_SRC.match(/target:\s*\[([^\]]+)\]/);
+  if (!m) {
+    throw new Error(
+      "failed to extract onConflictDoUpdate target column list from server/services/logger.ts — " +
+        "did the target tuple move, use a spread, or split across lines? The invariant test " +
+        "cannot validate the upsert target until this regex matches the call shape again.",
+    );
+  }
+  return Array.from(m[1].matchAll(/errorLogs\.(\w+)/g)).map((mm) => mm[1]);
+}
+
 describe("error_logs_unresolved_dedup_idx predicate matches ErrorLogger upsert targetWhere", () => {
   it("index WHERE clause and onConflictDoUpdate targetWhere are byte-for-byte equal", () => {
     const indexPredicate = extractIndexPredicate("unresolvedDedupIdx");
@@ -126,19 +144,23 @@ describe("error_logs_unresolved_dedup_idx predicate matches ErrorLogger upsert t
     expect(loggerPredicate).toBe(indexPredicate);
   });
 
-  it("index covers exactly the (level, source, message) tuple", () => {
+  it("schema index .on(...) and ErrorLogger target [...] both list exactly (level, source, message)", () => {
     // Match the exact .on(...) column list for the unresolved-dedup index.
     // If new columns are added or the order changes, the ErrorLogger upsert's
     // `target: [errorLogs.level, errorLogs.source, errorLogs.message]` tuple
-    // must be updated in lockstep or Postgres rejects the conflict spec.
+    // must be updated in lockstep or Postgres rejects the conflict spec. We
+    // assert both sides match the canonical tuple AND each other, so schema-
+    // only or logger-only drift both fail the test.
     const m = SCHEMA_SRC.match(
       /unresolvedDedupIdx[\s\S]*?\.on\(([^)]+)\)/,
     );
     if (!m) throw new Error("failed to extract unresolvedDedupIdx .on(...) columns");
-    const columns = m[1]
+    const schemaColumns = m[1]
       .split(",")
       .map((c) => c.trim().replace(/^table\./, ""))
       .filter(Boolean);
-    expect(columns).toEqual(["level", "source", "message"]);
+    const loggerColumns = extractLoggerConflictTargetColumns();
+    expect(schemaColumns).toEqual(["level", "source", "message"]);
+    expect(loggerColumns).toEqual(schemaColumns);
   });
 });

--- a/server/routes.migration.test.ts
+++ b/server/routes.migration.test.ts
@@ -64,6 +64,17 @@ vi.mock("./db", () => ({
     insert: vi.fn().mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }),
     update: vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }) }),
     execute: (...args: any[]) => mockDbExecute(...args),
+    // Delegate tx.execute back to the same mockDbExecute so the
+    // ensureErrorLogColumns migration's in-transaction SQL (SET LOCAL,
+    // pg_advisory_xact_lock, dedup UPDATE, dedup DELETE) is actually
+    // exercised under the migration mock sequences below. Without this,
+    // db.transaction is undefined and the whole migration falls into its
+    // catch block — silently making the 9-call sequence assertions pass
+    // for the wrong reason.
+    transaction: async (fn: (tx: any) => Promise<any>) => {
+      const tx = { execute: (...args: any[]) => mockDbExecute(...args) };
+      return fn(tx);
+    },
   },
 }));
 

--- a/server/routes.migration.test.ts
+++ b/server/routes.migration.test.ts
@@ -246,7 +246,7 @@ describe("error_logs dedup column migration at startup", () => {
     await registerRoutes(app as any, app as any);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      "Could not ensure error_logs columns:",
+      "Could not ensure error_logs columns/index:",
       migrationError,
     );
     warnSpy.mockRestore();
@@ -403,14 +403,22 @@ describe("error_logs dedup column migration at startup", () => {
   it("logs error and continues when notification channel table creation fails", async () => {
     vi.clearAllMocks();
     const channelError = new Error("permission denied for schema public");
-    // monitor health ALTERs succeed (2), pending_retry_at (1), error_logs ALTERs succeed (3), api_keys succeed (2), then channel tables fail
+    // monitor health ALTERs succeed (2), pending_retry_at (1), error_logs
+    // migration succeeds (3 ALTERs + 1 pg_indexes check + 4 in-tx + 1 CREATE
+    // INDEX CONCURRENTLY = 9), api_keys succeed (2), then channel tables fail
     mockDbExecute
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors health_alert_sent_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors last_healthy_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors pending_retry_at
-      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs 1
-      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs 2
-      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs 3
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs first_occurrence
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs occurrence_count
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs deleted_at
+      .mockResolvedValueOnce({ rows: [] }) // pg_indexes check (no existing idx)
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL lock_timeout
+      .mockResolvedValueOnce({ rows: [] }) // pg_advisory_xact_lock
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE dedup
+      .mockResolvedValueOnce({ rows: [] }) // DELETE dedup
+      .mockResolvedValueOnce({ rows: [] }) // CREATE UNIQUE INDEX CONCURRENTLY
       .mockResolvedValueOnce({ rows: [] }) // CREATE api_keys
       .mockResolvedValueOnce({ rows: [] }) // CREATE INDEX api_keys
       .mockRejectedValueOnce(channelError); // notification_channels fails
@@ -443,14 +451,22 @@ describe("error_logs dedup column migration at startup", () => {
   it("registers channel routes even when notification channel tables fail to create", async () => {
     vi.clearAllMocks();
     const channelError = new Error("connection timeout");
-    // monitor health ALTERs succeed (2), pending_retry_at (1), error_logs and api_keys succeed, channel tables fail
+    // monitor health ALTERs succeed (2), pending_retry_at (1), error_logs
+    // migration succeeds (3 ALTERs + 1 pg_indexes check + 4 in-tx + 1 CREATE
+    // INDEX CONCURRENTLY = 9), api_keys succeed (2), channel tables fail
     mockDbExecute
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors health_alert_sent_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors last_healthy_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors pending_retry_at
-      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs 1
-      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs 2
-      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs 3
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs first_occurrence
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs occurrence_count
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs deleted_at
+      .mockResolvedValueOnce({ rows: [] }) // pg_indexes check (no existing idx)
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL lock_timeout
+      .mockResolvedValueOnce({ rows: [] }) // pg_advisory_xact_lock
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE dedup
+      .mockResolvedValueOnce({ rows: [] }) // DELETE dedup
+      .mockResolvedValueOnce({ rows: [] }) // CREATE UNIQUE INDEX CONCURRENTLY
       .mockResolvedValueOnce({ rows: [] }) // CREATE api_keys
       .mockResolvedValueOnce({ rows: [] }) // CREATE INDEX api_keys
       .mockRejectedValueOnce(channelError); // notification_channels fails

--- a/server/services/ensureTables.test.ts
+++ b/server/services/ensureTables.test.ts
@@ -90,25 +90,78 @@ describe("ensureErrorLogColumns", () => {
     expect(stmts.some((s: string) => s.includes("CREATE UNIQUE INDEX") && s.includes("CONCURRENTLY") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
   });
 
-  it("skips DDL entirely when a valid index already exists", async () => {
-    // pg_indexes check returns a valid row → fast-path return.
+  it("skips DDL entirely when a valid, unique, correctly-shaped index already exists", async () => {
+    // pg_indexes check returns a row that passes all three validity gates
+    // (indisvalid, indisunique, indexdef includes both the expected column
+    // tuple and the partial predicate) → fast-path return.
     mockExecute
       .mockResolvedValueOnce({ rows: [] }) // ALTER first_occurrence
       .mockResolvedValueOnce({ rows: [] }) // ALTER occurrence_count
       .mockResolvedValueOnce({ rows: [] }) // ALTER deleted_at
-      .mockResolvedValueOnce({ rows: [{ indisvalid: true }] }); // pg_indexes check
+      .mockResolvedValueOnce({ rows: [{
+        indisvalid: true,
+        indisunique: true,
+        indexdef: "CREATE UNIQUE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source, message) WHERE (resolved = false)",
+      }] });
     await ensureErrorLogColumns();
     expect(mockExecute).toHaveBeenCalledTimes(4); // ALTERs + pg_indexes only
   });
 
-  it("drops invalid index before rebuilding", async () => {
+  it("drops and rebuilds when existing index is INVALID", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockExecute
       .mockResolvedValueOnce({ rows: [] }) // ALTER first_occurrence
       .mockResolvedValueOnce({ rows: [] }) // ALTER occurrence_count
       .mockResolvedValueOnce({ rows: [] }) // ALTER deleted_at
-      .mockResolvedValueOnce({ rows: [{ indisvalid: false }] }) // pg_indexes check → invalid
+      .mockResolvedValueOnce({ rows: [{
+        indisvalid: false,
+        indisunique: true,
+        indexdef: "CREATE UNIQUE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source, message) WHERE (resolved = false)",
+      }] })
       .mockResolvedValue({ rows: [] }); // DROP + tx statements + CREATE
+    await ensureErrorLogColumns();
+    const stmts = mockExecute.mock.calls.map(([arg]: any) => {
+      try { return JSON.stringify(arg); } catch { return String(arg); }
+    });
+    expect(stmts.some((s: string) => s.includes("DROP INDEX") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("drops and rebuilds when existing index is non-unique (wrong definition)", async () => {
+    // A stale index with the same name but non-unique type would otherwise
+    // pass the old bare `indisvalid` check and silently break ON CONFLICT.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExecute
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{
+        indisvalid: true,
+        indisunique: false, // ← the drift we're guarding against
+        indexdef: "CREATE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source, message) WHERE (resolved = false)",
+      }] })
+      .mockResolvedValue({ rows: [] });
+    await ensureErrorLogColumns();
+    const stmts = mockExecute.mock.calls.map(([arg]: any) => {
+      try { return JSON.stringify(arg); } catch { return String(arg); }
+    });
+    expect(stmts.some((s: string) => s.includes("DROP INDEX") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("drops and rebuilds when existing index has wrong columns or missing predicate", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExecute
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{
+        indisvalid: true,
+        indisunique: true,
+        // Wrong column tuple — missing message, no WHERE predicate.
+        indexdef: "CREATE UNIQUE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source)",
+      }] })
+      .mockResolvedValue({ rows: [] });
     await ensureErrorLogColumns();
     const stmts = mockExecute.mock.calls.map(([arg]: any) => {
       try { return JSON.stringify(arg); } catch { return String(arg); }

--- a/server/services/ensureTables.test.ts
+++ b/server/services/ensureTables.test.ts
@@ -73,10 +73,48 @@ describe("ensureErrorLogColumns", () => {
     mockExecute.mockReset();
   });
 
-  it("executes 3 ALTER TABLE statements without throwing", async () => {
-    mockExecute.mockResolvedValue([]);
+  it("executes ALTERs, pg_indexes check, dedup tx, and CONCURRENTLY index creation without throwing", async () => {
+    // Default empty rows → no existing valid index, proceed to dedup + create.
+    mockExecute.mockResolvedValue({ rows: [] });
     await ensureErrorLogColumns();
-    expect(mockExecute).toHaveBeenCalledTimes(3);
+    // 3 ALTER TABLE + 1 pg_indexes check + 4 in-tx (SET LOCAL, advisory
+    // lock, UPDATE, DELETE) + 1 CREATE UNIQUE INDEX CONCURRENTLY = 9
+    expect(mockExecute).toHaveBeenCalledTimes(9);
+    const stmts = mockExecute.mock.calls.map(([arg]: any) => {
+      try { return JSON.stringify(arg); } catch { return String(arg); }
+    });
+    expect(stmts.some((s: string) => s.includes("first_occurrence"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("occurrence_count"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("pg_indexes"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("pg_advisory_xact_lock"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("CREATE UNIQUE INDEX") && s.includes("CONCURRENTLY") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
+  });
+
+  it("skips DDL entirely when a valid index already exists", async () => {
+    // pg_indexes check returns a valid row → fast-path return.
+    mockExecute
+      .mockResolvedValueOnce({ rows: [] }) // ALTER first_occurrence
+      .mockResolvedValueOnce({ rows: [] }) // ALTER occurrence_count
+      .mockResolvedValueOnce({ rows: [] }) // ALTER deleted_at
+      .mockResolvedValueOnce({ rows: [{ indisvalid: true }] }); // pg_indexes check
+    await ensureErrorLogColumns();
+    expect(mockExecute).toHaveBeenCalledTimes(4); // ALTERs + pg_indexes only
+  });
+
+  it("drops invalid index before rebuilding", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExecute
+      .mockResolvedValueOnce({ rows: [] }) // ALTER first_occurrence
+      .mockResolvedValueOnce({ rows: [] }) // ALTER occurrence_count
+      .mockResolvedValueOnce({ rows: [] }) // ALTER deleted_at
+      .mockResolvedValueOnce({ rows: [{ indisvalid: false }] }) // pg_indexes check → invalid
+      .mockResolvedValue({ rows: [] }); // DROP + tx statements + CREATE
+    await ensureErrorLogColumns();
+    const stmts = mockExecute.mock.calls.map(([arg]: any) => {
+      try { return JSON.stringify(arg); } catch { return String(arg); }
+    });
+    expect(stmts.some((s: string) => s.includes("DROP INDEX") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
+    warnSpy.mockRestore();
   });
 
   it("catches errors and does not throw", async () => {
@@ -89,7 +127,7 @@ describe("ensureErrorLogColumns", () => {
     mockExecute.mockRejectedValue(new Error("permission denied"));
     await ensureErrorLogColumns();
     expect(warnSpy).toHaveBeenCalledWith(
-      "Could not ensure error_logs columns:",
+      "Could not ensure error_logs columns/index:",
       expect.any(Error),
     );
     warnSpy.mockRestore();

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -13,9 +13,19 @@ import { encryptUrl, decryptToken, hashUrl, isValidEncryptedToken, isEncryptionA
  * silently disabling DB-backed error logging for the entire deploy window
  * between code ship and `npm run schema:push`.
  *
- * Pre-existing duplicate unresolved rows (the bug #448 is fixing) would block
- * a naive `CREATE UNIQUE INDEX`, so we dedupe first: keep the newest row per
- * `(level, source, message)` group and sum `occurrence_count` into it.
+ * Migration strategy:
+ * 1. Fast-path idempotency: if a VALID unique index already exists, skip the
+ *    whole migration. If an INVALID one exists (leftover from an interrupted
+ *    CREATE CONCURRENTLY), drop it so we can rebuild.
+ * 2. Dedup pre-existing duplicate unresolved rows (the bug being fixed!) in
+ *    a transaction gated by a pg_advisory_xact_lock so concurrent instances
+ *    in a rolling deploy don't race on overlapping DELETEs. Cap the rolled-
+ *    up `occurrence_count` at INT32_MAX to avoid an overflow-rollback loop
+ *    on busy tables.
+ * 3. CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS — outside the tx so we
+ *    don't take a SHARE lock that would block every ErrorLogger.log caller
+ *    on the entire app during index build. Mirrors the pattern established
+ *    by ensureMonitorChangesIndexes below.
  */
 export async function ensureErrorLogColumns(): Promise<void> {
   try {
@@ -23,22 +33,37 @@ export async function ensureErrorLogColumns(): Promise<void> {
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS occurrence_count INTEGER NOT NULL DEFAULT 1`);
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP`);
 
-    // Skip the dedup + index step if the index already exists (idempotent
-    // across restarts). Check catalog directly so we don't do work on every
-    // boot after the initial migration has landed.
+    // Check if a valid unique index already exists — skip DDL entirely if so.
+    // Uses pg_index.indisvalid so an INVALID index (interrupted build) is
+    // detected and rebuilt, matching the ensureMonitorChangesIndexes pattern.
     const existing = await db.execute(sql`
-      SELECT 1 FROM pg_indexes WHERE indexname = 'error_logs_unresolved_dedup_idx' LIMIT 1
+      SELECT i.indisvalid
+      FROM pg_indexes ix
+      JOIN pg_class c ON c.relname = ix.indexname
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE ix.indexname = 'error_logs_unresolved_dedup_idx'
     `);
-    const alreadyExists = ((existing as any).rows?.length ?? 0) > 0;
-    if (alreadyExists) return;
+    const rows = (existing as any).rows as Array<{ indisvalid: boolean }> | undefined;
+    if (rows && rows.length > 0) {
+      if (rows[0].indisvalid) return; // Valid index — nothing to do
+      console.warn("[ensureTables] Dropping invalid index error_logs_unresolved_dedup_idx");
+      await db.execute(sql`DROP INDEX IF EXISTS error_logs_unresolved_dedup_idx`);
+    }
 
     // Dedupe pre-existing unresolved rows produced by the old racy
     // SELECT-then-INSERT path. Keep the newest row per
     // (level, source, message) group and roll up `occurrence_count` into it
-    // so the dedup bucket's total event count is preserved. Wrapped in a
-    // transaction so concurrent writers don't split the dedup mid-flight.
+    // so the dedup bucket's total event count is preserved. The advisory
+    // xact lock serializes concurrent boots in a rolling deploy so only one
+    // instance performs the dedup at a time; follow-up boots find nothing
+    // to merge and fall through to the idempotent CONCURRENTLY step below.
+    // LEAST(INT32_MAX, SUM) caps the rolled-up count so a site with many
+    // already-huge duplicate rows doesn't blow past integer range and
+    // rollback the whole transaction.
     await db.transaction(async (tx) => {
       await tx.execute(sql`SET LOCAL lock_timeout = '10s'`);
+      // Advisory lock key is a stable 64-bit hash of the migration identifier.
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended('error_logs_unresolved_dedup_migration', 0))`);
       await tx.execute(sql`
         WITH dups AS (
           SELECT id,
@@ -46,9 +71,9 @@ export async function ensureErrorLogColumns(): Promise<void> {
                    PARTITION BY level, source, message
                    ORDER BY timestamp DESC, id DESC
                  ) AS rn,
-                 SUM(occurrence_count) OVER (
+                 LEAST(2147483647, SUM(occurrence_count) OVER (
                    PARTITION BY level, source, message
-                 ) AS total_count
+                 ))::int AS total_count
           FROM error_logs
           WHERE resolved = false
         )
@@ -69,12 +94,16 @@ export async function ensureErrorLogColumns(): Promise<void> {
           ) d WHERE rn > 1
         )
       `);
-      await tx.execute(sql`
-        CREATE UNIQUE INDEX IF NOT EXISTS error_logs_unresolved_dedup_idx
-        ON error_logs(level, source, message)
-        WHERE resolved = false
-      `);
     });
+
+    // CONCURRENTLY cannot run inside a transaction. IF NOT EXISTS makes this
+    // safe if another rolling-deploy instance beat us to it between the
+    // dedup tx above and this statement.
+    await db.execute(sql`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS error_logs_unresolved_dedup_idx
+      ON error_logs(level, source, message)
+      WHERE resolved = false
+    `);
   } catch (e) {
     console.warn("Could not ensure error_logs columns/index:", e);
   }

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -33,20 +33,35 @@ export async function ensureErrorLogColumns(): Promise<void> {
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS occurrence_count INTEGER NOT NULL DEFAULT 1`);
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP`);
 
-    // Check if a valid unique index already exists — skip DDL entirely if so.
-    // Uses pg_index.indisvalid so an INVALID index (interrupted build) is
-    // detected and rebuilt, matching the ensureMonitorChangesIndexes pattern.
+    // Check if a VALID, UNIQUE, correctly-shaped index already exists — skip
+    // DDL entirely if so. Validates four invariants simultaneously:
+    //   1. `indisvalid` — not a leftover INVALID build
+    //   2. `indisunique` — ON CONFLICT inference requires uniqueness
+    //   3. `pg_get_indexdef` exposes the column tuple + predicate so we can
+    //      assert the index covers (level, source, message) with the
+    //      `WHERE resolved = false` partial predicate
+    // A stale index with the same name but a different definition (wrong
+    // columns, non-unique, missing predicate) fails this check and is
+    // dropped and rebuilt. Without the definition check, a drifted index
+    // would pass the fast path and ON CONFLICT would fail silently at
+    // runtime, swallowed by ErrorLogger.log's catch block.
     const existing = await db.execute(sql`
-      SELECT i.indisvalid
+      SELECT i.indisvalid, i.indisunique, pg_get_indexdef(i.indexrelid) AS indexdef
       FROM pg_indexes ix
       JOIN pg_class c ON c.relname = ix.indexname
       JOIN pg_index i ON i.indexrelid = c.oid
       WHERE ix.indexname = 'error_logs_unresolved_dedup_idx'
     `);
-    const rows = (existing as any).rows as Array<{ indisvalid: boolean }> | undefined;
+    const rows = (existing as any).rows as Array<{ indisvalid: boolean; indisunique: boolean; indexdef: string }> | undefined;
     if (rows && rows.length > 0) {
-      if (rows[0].indisvalid) return; // Valid index — nothing to do
-      console.warn("[ensureTables] Dropping invalid index error_logs_unresolved_dedup_idx");
+      const { indisvalid, indisunique, indexdef } = rows[0];
+      const defIsCorrect =
+        indexdef.includes("(level, source, message)") &&
+        /WHERE\s+\(?resolved\s*=\s*false\)?/i.test(indexdef);
+      if (indisvalid && indisunique && defIsCorrect) return;
+      console.warn(
+        `[ensureTables] Dropping existing error_logs_unresolved_dedup_idx (valid=${indisvalid} unique=${indisunique} defMatch=${defIsCorrect}) so it can be rebuilt with the expected shape`,
+      );
       await db.execute(sql`DROP INDEX IF EXISTS error_logs_unresolved_dedup_idx`);
     }
 

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -3,17 +3,80 @@ import { sql } from "drizzle-orm";
 import { encryptUrl, decryptToken, hashUrl, isValidEncryptedToken, isEncryptionAvailable } from "../utils/encryption";
 
 /**
- * Ensures error_logs deduplication columns exist (added in PR #56).
- * Without this, db.select().from(errorLogs) fails when the schema
- * references columns the database doesn't have yet.
+ * Ensures error_logs deduplication columns and the partial unique index used
+ * by ErrorLogger's atomic upsert (see GitHub issue #448) exist.
+ *
+ * Without the index, `INSERT … ON CONFLICT (level, source, message) WHERE
+ * resolved = false` fails at runtime with "there is no unique or exclusion
+ * constraint matching the ON CONFLICT specification", which ErrorLogger's
+ * catch block at server/services/logger.ts swallows to `console.error` —
+ * silently disabling DB-backed error logging for the entire deploy window
+ * between code ship and `npm run schema:push`.
+ *
+ * Pre-existing duplicate unresolved rows (the bug #448 is fixing) would block
+ * a naive `CREATE UNIQUE INDEX`, so we dedupe first: keep the newest row per
+ * `(level, source, message)` group and sum `occurrence_count` into it.
  */
 export async function ensureErrorLogColumns(): Promise<void> {
   try {
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS first_occurrence TIMESTAMP NOT NULL DEFAULT NOW()`);
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS occurrence_count INTEGER NOT NULL DEFAULT 1`);
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP`);
+
+    // Skip the dedup + index step if the index already exists (idempotent
+    // across restarts). Check catalog directly so we don't do work on every
+    // boot after the initial migration has landed.
+    const existing = await db.execute(sql`
+      SELECT 1 FROM pg_indexes WHERE indexname = 'error_logs_unresolved_dedup_idx' LIMIT 1
+    `);
+    const alreadyExists = ((existing as any).rows?.length ?? 0) > 0;
+    if (alreadyExists) return;
+
+    // Dedupe pre-existing unresolved rows produced by the old racy
+    // SELECT-then-INSERT path. Keep the newest row per
+    // (level, source, message) group and roll up `occurrence_count` into it
+    // so the dedup bucket's total event count is preserved. Wrapped in a
+    // transaction so concurrent writers don't split the dedup mid-flight.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL lock_timeout = '10s'`);
+      await tx.execute(sql`
+        WITH dups AS (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY level, source, message
+                   ORDER BY timestamp DESC, id DESC
+                 ) AS rn,
+                 SUM(occurrence_count) OVER (
+                   PARTITION BY level, source, message
+                 ) AS total_count
+          FROM error_logs
+          WHERE resolved = false
+        )
+        UPDATE error_logs
+        SET occurrence_count = dups.total_count
+        FROM dups
+        WHERE error_logs.id = dups.id AND dups.rn = 1
+      `);
+      await tx.execute(sql`
+        DELETE FROM error_logs
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT id, ROW_NUMBER() OVER (
+              PARTITION BY level, source, message
+              ORDER BY timestamp DESC, id DESC
+            ) AS rn
+            FROM error_logs WHERE resolved = false
+          ) d WHERE rn > 1
+        )
+      `);
+      await tx.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS error_logs_unresolved_dedup_idx
+        ON error_logs(level, source, message)
+        WHERE resolved = false
+      `);
+    });
   } catch (e) {
-    console.warn("Could not ensure error_logs columns:", e);
+    console.warn("Could not ensure error_logs columns/index:", e);
   }
 }
 

--- a/server/services/logger.test.ts
+++ b/server/services/logger.test.ts
@@ -73,6 +73,11 @@ describe("ErrorLogger atomic upsert", () => {
     expect(insertedValues.occurrenceCount).toBe(1);
     expect(insertedValues.firstOccurrence).toBeInstanceOf(Date);
     expect(insertedValues.timestamp).toBeInstanceOf(Date);
+    // null error → errorType/stackTrace must be null (not undefined) so the
+    // COALESCE(EXCLUDED.*, current.*) clause in the conflict update keeps
+    // prior non-null values on subsequent racing writes.
+    expect(insertedValues.errorType).toBeNull();
+    expect(insertedValues.stackTrace).toBeNull();
   });
 
   it("configures onConflictDoUpdate against the partial unique index", async () => {

--- a/server/services/logger.test.ts
+++ b/server/services/logger.test.ts
@@ -2,54 +2,37 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock variables
+//
+// After GitHub issue #448, ErrorLogger.log uses a single atomic
+// `INSERT … ON CONFLICT (level, source, message) WHERE resolved = false
+// DO UPDATE SET …` upsert instead of the prior SELECT-then-INSERT/UPDATE
+// flow. The mock chain tracks `.insert(table).values(row).onConflictDoUpdate(cfg)`.
 // ---------------------------------------------------------------------------
 const {
-  mockDbSelect,
   mockDbInsert,
-  mockDbUpdate,
-  mockSelectLimitFn,
-  mockSelectWhereFn,
-  mockSelectFromFn,
   mockInsertValuesFn,
-  mockUpdateSetFn,
-  mockUpdateWhereFn,
+  mockOnConflictDoUpdateFn,
 } = vi.hoisted(() => {
-  const mockSelectLimitFn = vi.fn();
-  const mockSelectWhereFn = vi.fn(() => ({ limit: mockSelectLimitFn }));
-  const mockSelectFromFn = vi.fn(() => ({ where: mockSelectWhereFn }));
-  const mockDbSelect = vi.fn(() => ({ from: mockSelectFromFn }));
-
-  const mockInsertValuesFn = vi.fn().mockResolvedValue(undefined);
+  const mockOnConflictDoUpdateFn = vi.fn().mockResolvedValue(undefined);
+  const mockInsertValuesFn = vi.fn(() => ({ onConflictDoUpdate: mockOnConflictDoUpdateFn }));
   const mockDbInsert = vi.fn(() => ({ values: mockInsertValuesFn }));
 
-  const mockUpdateWhereFn = vi.fn().mockResolvedValue(undefined);
-  const mockUpdateSetFn = vi.fn(() => ({ where: mockUpdateWhereFn }));
-  const mockDbUpdate = vi.fn(() => ({ set: mockUpdateSetFn }));
-
   return {
-    mockDbSelect,
     mockDbInsert,
-    mockDbUpdate,
-    mockSelectLimitFn,
-    mockSelectWhereFn,
-    mockSelectFromFn,
     mockInsertValuesFn,
-    mockUpdateSetFn,
-    mockUpdateWhereFn,
+    mockOnConflictDoUpdateFn,
   };
 });
 
 vi.mock("../db", () => ({
   db: {
-    select: (...args: any[]) => mockDbSelect(...args),
     insert: (...args: any[]) => mockDbInsert(...args),
-    update: (...args: any[]) => mockDbUpdate(...args),
   },
 }));
 
 import { ErrorLogger } from "./logger";
 
-describe("ErrorLogger deduplication", () => {
+describe("ErrorLogger atomic upsert", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
@@ -57,23 +40,13 @@ describe("ErrorLogger deduplication", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Suppress expected logger output during tests
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    // Reset chain mocks
-    mockSelectWhereFn.mockReturnValue({ limit: mockSelectLimitFn });
-    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn });
-    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
-    mockInsertValuesFn.mockResolvedValue(undefined);
+    mockOnConflictDoUpdateFn.mockResolvedValue(undefined);
+    mockInsertValuesFn.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdateFn });
     mockDbInsert.mockReturnValue({ values: mockInsertValuesFn });
-    mockUpdateWhereFn.mockResolvedValue(undefined);
-    mockUpdateSetFn.mockReturnValue({ where: mockUpdateWhereFn });
-    mockDbUpdate.mockReturnValue({ set: mockUpdateSetFn });
-
-    // Default: no existing entry found
-    mockSelectLimitFn.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -82,13 +55,16 @@ describe("ErrorLogger deduplication", () => {
     consoleLogSpy.mockRestore();
   });
 
-  it("inserts a new entry when no duplicate exists", async () => {
-    mockSelectLimitFn.mockResolvedValue([]);
-
+  it("issues a single atomic insert+onConflictDoUpdate per log call", async () => {
     await ErrorLogger.error("stripe", "Webhook signature validation failed", null, { ip: "1.2.3.4" });
 
-    expect(mockDbInsert).toHaveBeenCalled();
-    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(mockDbInsert).toHaveBeenCalledTimes(1);
+    expect(mockInsertValuesFn).toHaveBeenCalledTimes(1);
+    expect(mockOnConflictDoUpdateFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("inserts values with correct fields on first call", async () => {
+    await ErrorLogger.error("stripe", "Webhook signature validation failed", null, { ip: "1.2.3.4" });
 
     const insertedValues = mockInsertValuesFn.mock.calls[0][0];
     expect(insertedValues.level).toBe("error");
@@ -99,41 +75,26 @@ describe("ErrorLogger deduplication", () => {
     expect(insertedValues.timestamp).toBeInstanceOf(Date);
   });
 
-  it("updates existing entry when a duplicate is found", async () => {
-    mockSelectLimitFn.mockResolvedValue([{ id: 42 }]);
+  it("configures onConflictDoUpdate against the partial unique index", async () => {
+    await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: 1 });
 
-    await ErrorLogger.error("stripe", "Webhook signature validation failed", null, { ip: "5.6.7.8" });
-
-    expect(mockDbUpdate).toHaveBeenCalled();
-    expect(mockDbInsert).not.toHaveBeenCalled();
-
-    // Verify update was called with the correct ID
-    expect(mockUpdateWhereFn).toHaveBeenCalled();
-
-    // Verify the set call includes timestamp and occurrenceCount
-    const setArg = mockUpdateSetFn.mock.calls[0][0];
-    expect(setArg.timestamp).toBeInstanceOf(Date);
-    expect(setArg.occurrenceCount).toBeDefined();
-  });
-
-  it("queries for unresolved entries matching level+source+message", async () => {
-    mockSelectLimitFn.mockResolvedValue([]);
-
-    await ErrorLogger.warning("scraper", "Page returned empty response", { monitorId: 1 });
-
-    // Verify select was called to check for duplicates
-    expect(mockDbSelect).toHaveBeenCalled();
-    expect(mockSelectFromFn).toHaveBeenCalled();
-    expect(mockSelectWhereFn).toHaveBeenCalled();
-    expect(mockSelectLimitFn).toHaveBeenCalled();
+    const conflictConfig = mockOnConflictDoUpdateFn.mock.calls[0][0];
+    // target must be the three-column tuple matching the unique index
+    expect(Array.isArray(conflictConfig.target)).toBe(true);
+    expect(conflictConfig.target).toHaveLength(3);
+    // targetWhere must encode the `resolved = false` partial predicate —
+    // without it Postgres rejects the ON CONFLICT on a partial index.
+    expect(conflictConfig.targetWhere).toBeDefined();
+    // set must bump timestamp and occurrenceCount; stack/context use COALESCE
+    expect(conflictConfig.set.timestamp).toBeInstanceOf(Date);
+    expect(conflictConfig.set.occurrenceCount).toBeDefined();
+    expect(conflictConfig.set.stackTrace).toBeDefined();
+    expect(conflictConfig.set.context).toBeDefined();
   });
 
   it("inserts new entry with correct fields for info level", async () => {
-    mockSelectLimitFn.mockResolvedValue([]);
-
     await ErrorLogger.info("scheduler", "Scheduler run completed");
 
-    expect(mockDbInsert).toHaveBeenCalled();
     const insertedValues = mockInsertValuesFn.mock.calls[0][0];
     expect(insertedValues.level).toBe("info");
     expect(insertedValues.source).toBe("scheduler");
@@ -143,8 +104,6 @@ describe("ErrorLogger deduplication", () => {
   });
 
   it("includes error type and sanitized stack trace when error is provided", async () => {
-    mockSelectLimitFn.mockResolvedValue([]);
-
     const err = new Error("Something went wrong");
     await ErrorLogger.error("api", "Unhandled error", err, { route: "/test" });
 
@@ -154,30 +113,7 @@ describe("ErrorLogger deduplication", () => {
     expect(insertedValues.context).toEqual({ route: "/test" });
   });
 
-  it("updates stack trace and context on duplicate when provided", async () => {
-    mockSelectLimitFn.mockResolvedValue([{ id: 7 }]);
-
-    const err = new Error("New stack");
-    await ErrorLogger.error("email", "Send failed", err, { to: "user@example.com" });
-
-    const setArg = mockUpdateSetFn.mock.calls[0][0];
-    expect(setArg.stackTrace).toContain("New stack");
-    expect(setArg.context).toEqual({ to: "user@example.com" });
-  });
-
-  it("does not overwrite stack/context with undefined when not provided on duplicate", async () => {
-    mockSelectLimitFn.mockResolvedValue([{ id: 7 }]);
-
-    await ErrorLogger.warning("scraper", "Minor issue");
-
-    const setArg = mockUpdateSetFn.mock.calls[0][0];
-    expect(setArg.stackTrace).toBeUndefined();
-    expect(setArg.context).toBeUndefined();
-  });
-
-  it("sanitizes sensitive data in the message before checking for duplicates", async () => {
-    mockSelectLimitFn.mockResolvedValue([]);
-
+  it("sanitizes sensitive data in the message", async () => {
     await ErrorLogger.error("api", "Failed connecting to postgres://user:pass@host/db");
 
     const insertedValues = mockInsertValuesFn.mock.calls[0][0];
@@ -186,8 +122,6 @@ describe("ErrorLogger deduplication", () => {
   });
 
   it("sanitizes sensitive context keys", async () => {
-    mockSelectLimitFn.mockResolvedValue([]);
-
     await ErrorLogger.error("api", "Auth error", null, { password: "secret123", userId: "user-1" });
 
     const insertedValues = mockInsertValuesFn.mock.calls[0][0];
@@ -196,9 +130,8 @@ describe("ErrorLogger deduplication", () => {
   });
 
   it("handles database error gracefully without throwing", async () => {
-    mockSelectLimitFn.mockRejectedValue(new Error("DB connection lost"));
+    mockOnConflictDoUpdateFn.mockRejectedValueOnce(new Error("DB connection lost"));
 
-    // Should not throw
     await expect(
       ErrorLogger.error("api", "Some error")
     ).resolves.toBeUndefined();
@@ -207,7 +140,8 @@ describe("ErrorLogger deduplication", () => {
   it("Browserless warnings use monitor-agnostic message for infra failures so dedup aggregates across monitors", async () => {
     // Contract test: infra-wide failures (service unavailable, circuit breaker open)
     // emit a monitor-agnostic message so every affected monitor dedups into a single
-    // row in the admin UI. Site-specific failures still name the monitor.
+    // row in the admin UI via the partial unique index. Site-specific failures still
+    // name the monitor.
     const infraMsg = "Browserless service unavailable — preserving last known values";
     const circuitMsg = "Browserless circuit breaker open — preserving last known values";
     const siteSpecificMsg = `"My Monitor" — site blocking automated access`;
@@ -219,32 +153,21 @@ describe("ErrorLogger deduplication", () => {
   });
 
   it("convenience methods call log with correct level", async () => {
-    mockSelectLimitFn.mockResolvedValue([]);
-
     await ErrorLogger.error("stripe", "error msg");
-    let insertedValues = mockInsertValuesFn.mock.calls[0][0];
-    expect(insertedValues.level).toBe("error");
+    expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("error");
 
     vi.clearAllMocks();
-    mockSelectWhereFn.mockReturnValue({ limit: mockSelectLimitFn });
-    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn });
-    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+    mockInsertValuesFn.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdateFn });
     mockDbInsert.mockReturnValue({ values: mockInsertValuesFn });
-    mockSelectLimitFn.mockResolvedValue([]);
 
     await ErrorLogger.warning("email", "warning msg");
-    insertedValues = mockInsertValuesFn.mock.calls[0][0];
-    expect(insertedValues.level).toBe("warning");
+    expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("warning");
 
     vi.clearAllMocks();
-    mockSelectWhereFn.mockReturnValue({ limit: mockSelectLimitFn });
-    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn });
-    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+    mockInsertValuesFn.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdateFn });
     mockDbInsert.mockReturnValue({ values: mockInsertValuesFn });
-    mockSelectLimitFn.mockResolvedValue([]);
 
     await ErrorLogger.info("scheduler", "info msg");
-    insertedValues = mockInsertValuesFn.mock.calls[0][0];
-    expect(insertedValues.level).toBe("info");
+    expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("info");
   });
 });

--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -87,6 +87,14 @@ export class ErrorLogger {
       // "Browserless service unavailable" warning) both miss the SELECT and
       // both INSERT, producing duplicate rows in the admin UI. See GitHub
       // issue #448.
+      //
+      // Stack/context semantics: `COALESCE(EXCLUDED.col, currentTable.col)`
+      // is last-writer-wins when the incoming call supplies a non-null value,
+      // and preserves the prior value when the incoming call doesn't. The
+      // admin UI therefore shows the most recent caller's stack/context for
+      // a dedup bucket, not the first-observed one. `firstOccurrence` is set
+      // only on INSERT — the conflict update path deliberately does not
+      // touch it, preserving the original event time.
       const now = new Date();
       await db
         .insert(errorLogs)

--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -1,6 +1,6 @@
 import { db } from "../db";
 import { errorLogs } from "@shared/schema";
-import { and, eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import type { ERROR_LOG_SOURCES } from "@shared/routes";
 
 type LogLevel = "error" | "warning" | "info";
@@ -72,48 +72,45 @@ export class ErrorLogger {
     }
 
     const sanitizedMessage = sanitizeString(message);
+    const sanitizedStack = error?.stack ? sanitizeString(error.stack) : null;
+    const sanitizedContext = context ? sanitizeContext(context) : null;
+    const errorType = error?.constructor?.name || null;
 
     try {
-      // Check for existing unresolved entry with same level+source+message
-      const [existing] = await db
-        .select({ id: errorLogs.id })
-        .from(errorLogs)
-        .where(
-          and(
-            eq(errorLogs.level, level),
-            eq(errorLogs.source, source),
-            eq(errorLogs.message, sanitizedMessage),
-            eq(errorLogs.resolved, false)
-          )
-        )
-        .limit(1);
-
-      if (existing) {
-        // Update existing entry: bump timestamp, increment count, update stack/context
-        await db
-          .update(errorLogs)
-          .set({
-            timestamp: new Date(),
-            occurrenceCount: sql`${errorLogs.occurrenceCount} + 1`,
-            stackTrace: error?.stack ? sanitizeString(error.stack) : undefined,
-            context: context ? sanitizeContext(context) : undefined,
-          })
-          .where(eq(errorLogs.id, existing.id));
-      } else {
-        // Insert new entry
-        const now = new Date();
-        await db.insert(errorLogs).values({
+      // Atomic upsert against the partial unique index
+      // `error_logs_unresolved_dedup_idx` (level, source, message) WHERE
+      // resolved = false. Collapses the read-modify-write window of the old
+      // SELECT-then-INSERT dedup path so concurrent writers with the same
+      // (level, source, message) deterministically land in a single row with
+      // `occurrence_count` bumped by every caller. Without this index +
+      // upsert, concurrent writers with shared messages (e.g. the compacted
+      // "Browserless service unavailable" warning) both miss the SELECT and
+      // both INSERT, producing duplicate rows in the admin UI. See GitHub
+      // issue #448.
+      const now = new Date();
+      await db
+        .insert(errorLogs)
+        .values({
           level,
           source,
           message: sanitizedMessage,
-          errorType: error?.constructor?.name || null,
-          stackTrace: error?.stack ? sanitizeString(error.stack) : null,
-          context: context ? sanitizeContext(context) : null,
+          errorType,
+          stackTrace: sanitizedStack,
+          context: sanitizedContext,
           firstOccurrence: now,
           timestamp: now,
           occurrenceCount: 1,
+        })
+        .onConflictDoUpdate({
+          target: [errorLogs.level, errorLogs.source, errorLogs.message],
+          targetWhere: sql`resolved = false`,
+          set: {
+            timestamp: now,
+            occurrenceCount: sql`${errorLogs.occurrenceCount} + 1`,
+            stackTrace: sql`COALESCE(EXCLUDED.stack_trace, ${errorLogs.stackTrace})`,
+            context: sql`COALESCE(EXCLUDED.context, ${errorLogs.context})`,
+          },
         });
-      }
     } catch (dbError) {
       console.error(`[ErrorLogger] Failed to write log to database:`, dbError);
     }

--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -114,7 +114,14 @@ export class ErrorLogger {
           targetWhere: sql`resolved = false`,
           set: {
             timestamp: now,
-            occurrenceCount: sql`${errorLogs.occurrenceCount} + 1`,
+            // Clamp at INT32_MAX to match the ensureErrorLogColumns dedup
+            // migration's rollup cap. Without this, a hot error bucket that
+            // accumulates past 2,147,483,647 occurrences would overflow the
+            // `integer` column on the next increment, Postgres would reject
+            // the UPDATE, and the catch block below would silently disable
+            // logging for this dedup key. Cast via bigint so the arithmetic
+            // stays in range until the LEAST reduces it back to int.
+            occurrenceCount: sql`LEAST(2147483647::bigint, ${errorLogs.occurrenceCount}::bigint + 1)::int`,
             stackTrace: sql`COALESCE(EXCLUDED.stack_trace, ${errorLogs.stackTrace})`,
             context: sql`COALESCE(EXCLUDED.context, ${errorLogs.context})`,
           },

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -3908,6 +3908,29 @@ describe("self-healing recovery", () => {
     expect(result.error).toBe("Selector not found (rendering service temporarily unavailable)");
   });
 
+  it("logs circuit-breaker-open warning for first-check monitors (no currentValue). See GitHub issue #449", async () => {
+    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
+
+    const cbMock = browserlessCircuitBreaker as unknown as { isAvailable: ReturnType<typeof vi.fn>; recordSuccess: ReturnType<typeof vi.fn>; recordInfraFailure: ReturnType<typeof vi.fn>; getState: ReturnType<typeof vi.fn> };
+    cbMock.isAvailable.mockReturnValue(false);
+
+    const monitor = makeMonitor({ selector: ".missing", currentValue: null });
+    await runWithTimers(monitor);
+
+    // Admin UI must see a circuit-open entry regardless of whether the monitor
+    // has a cached value (graceful degradation) or is first-check. The message
+    // is monitor-agnostic so affected monitors dedup into a single row via the
+    // partial unique index (#448).
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      "Browserless circuit breaker open — preserving last known values",
+      expect.objectContaining({ monitorId: 1 }),
+    );
+  });
+
   it("falls through to blocked when no currentValue, infra failure, and page is blocked", async () => {
     // Page has a captcha element (triggers block detection)
     const blockedHtml = `<html><body><div class="captcha-container">Please verify</div></body></html>`;

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -1265,11 +1265,13 @@ export async function checkMonitor(monitor: Monitor): Promise<{
           } else if (browserlessInfraFailure) {
             // Infra-wide outage: monitor-agnostic message so every affected monitor
             // dedups into a single row in the admin UI. Per-monitor details stay
-            // in context for drill-down. NOTE: context is last-writer-wins
-            // (server/services/logger.ts:99), so during a mixed-mode outage
-            // monitorId/monitorName/url/classifiedReason reflect only the most
-            // recent writer, not an aggregate across affected monitors.
-            // occurrenceCount is the only signal of outage scope.
+            // in context for drill-down. NOTE: context is last-writer-wins at the
+            // DB level — the ON CONFLICT upsert in ErrorLogger.log uses
+            // COALESCE(EXCLUDED.context, current.context), so during a mixed-mode
+            // outage monitorId/monitorName/url/classifiedReason reflect only the
+            // most recent writer that supplied a non-null context, not an
+            // aggregate across affected monitors. occurrenceCount is the only
+            // signal of outage scope.
             await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
           } else {
             // Site-specific failure: keep the monitor name because the site itself is the problem.
@@ -1312,13 +1314,15 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     // When the circuit breaker was already OPEN before we even attempted
     // extraction, the warning inside the `capCheck.allowed` block never fires
     // (capCheck is forced to `{allowed:false}` above). Log one here so the
-    // admin UI always has an entry for the degradation episode — regardless
-    // of whether the monitor has a cached value (graceful degradation) or is
-    // a first-check monitor that falls through to selector_missing. The
-    // message is monitor-agnostic so every affected monitor dedups into a
-    // single row via ErrorLogger's unresolved-dedup index (#448). See GitHub
-    // issue #449.
-    if (skippedDueToOpenCircuit) {
+    // admin UI has an entry for the degradation episode — regardless of
+    // whether the monitor has a cached value (graceful degradation) or is a
+    // first-check monitor that falls through to selector_missing. Gated on
+    // `!newValue` so we don't spam admins when static extraction actually
+    // succeeded (rare: newValue set AND block.blocked flipped true, forcing
+    // the Browserless path). The message is monitor-agnostic so affected
+    // monitors dedup into a single row via the unresolved-dedup index (#448).
+    // See GitHub issue #449.
+    if (skippedDueToOpenCircuit && !newValue) {
       await ErrorLogger.warning(
         "scraper",
         "Browserless circuit breaker open — preserving last known values",

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -1305,9 +1305,26 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     }
 
     const oldValue = monitor.currentValue;
-    
+
     let finalStatus: "ok" | "blocked" | "selector_missing" | "error" = "ok";
     let finalError: string | null = null;
+
+    // When the circuit breaker was already OPEN before we even attempted
+    // extraction, the warning inside the `capCheck.allowed` block never fires
+    // (capCheck is forced to `{allowed:false}` above). Log one here so the
+    // admin UI always has an entry for the degradation episode — regardless
+    // of whether the monitor has a cached value (graceful degradation) or is
+    // a first-check monitor that falls through to selector_missing. The
+    // message is monitor-agnostic so every affected monitor dedups into a
+    // single row via ErrorLogger's unresolved-dedup index (#448). See GitHub
+    // issue #449.
+    if (skippedDueToOpenCircuit) {
+      await ErrorLogger.warning(
+        "scraper",
+        "Browserless circuit breaker open — preserving last known values",
+        { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
+      );
+    }
 
     if (!newValue) {
       if (browserlessInfraFailure && monitor.currentValue) {
@@ -1317,18 +1334,6 @@ export async function checkMonitor(monitor: Monitor): Promise<{
         monitorsNeedingRetry.add(monitor.id);
         await storage.updateMonitor(monitor.id, { lastChecked: new Date() });
         console.log(`[SelfHeal] Monitor ${monitor.id}: Browserless unavailable, preserving last known value`);
-        // When the circuit breaker was already open before we tried extraction,
-        // the warning in the capCheck.allowed block never fires — log one here
-        // so the admin UI still shows an entry for this degradation episode.
-        // Use the flag (not live breaker state) to avoid a duplicate warning
-        // when an attempted extraction just opened the breaker.
-        if (skippedDueToOpenCircuit) {
-          await ErrorLogger.warning(
-            "scraper",
-            "Browserless circuit breaker open — preserving last known values",
-            { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
-          );
-        }
         return {
           changed: false,
           currentValue: monitor.currentValue,

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -1317,12 +1317,12 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     // admin UI has an entry for the degradation episode — regardless of
     // whether the monitor has a cached value (graceful degradation) or is a
     // first-check monitor that falls through to selector_missing. Gated on
-    // `!newValue` so we don't spam admins when static extraction actually
-    // succeeded (rare: newValue set AND block.blocked flipped true, forcing
-    // the Browserless path). The message is monitor-agnostic so affected
-    // monitors dedup into a single row via the unresolved-dedup index (#448).
-    // See GitHub issue #449.
-    if (skippedDueToOpenCircuit && !newValue) {
+    // `newValue == null` (explicit null/undefined, not falsy) so a monitor
+    // whose selector legitimately resolves to an empty string isn't flagged
+    // when static extraction succeeded. The message is monitor-agnostic so
+    // affected monitors dedup into a single row via the unresolved-dedup
+    // index (#448). See GitHub issue #449.
+    if (skippedDueToOpenCircuit && newValue == null) {
       await ErrorLogger.warning(
         "scraper",
         "Browserless circuit breaker open — preserving last known values",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -106,6 +106,14 @@ export const errorLogs = pgTable("error_logs", {
   levelIdx: index("error_logs_level_idx").on(table.level),
   sourceIdx: index("error_logs_source_idx").on(table.source),
   timestampIdx: index("error_logs_timestamp_idx").on(table.timestamp),
+  // Partial unique index collapses the SELECT-then-INSERT dedup race in
+  // ErrorLogger.log: concurrent writers with the same (level, source, message)
+  // while resolved=false deterministically upsert into a single row instead
+  // of racing past a preceding SELECT miss and inserting duplicates. See
+  // GitHub issue #448.
+  unresolvedDedupIdx: uniqueIndex("error_logs_unresolved_dedup_idx")
+    .on(table.level, table.source, table.message)
+    .where(sql`resolved = false`),
 }));
 
 export type ErrorLog = typeof errorLogs.$inferSelect;


### PR DESCRIPTION
## Summary

Closes the last three open bug backlog issues from the #428–#444 series. Ships a full `/magicwand` hardening pass on top of each fix — security, architecture, code, and skeptic reviews all resolved in-branch.

- **Closes #446** — Dashboard bulk-refresh direct-fetch path now tracks an `AbortController` per in-flight fetch via the shared `useAbortableFetchers` hook (refactored out of `use-monitors.ts` into an exported helper). On unmount, all in-flight controllers are aborted so Browserless/Resend quota isn't burnt on orphaned work after the user navigates away.

- **Closes #448** — `ErrorLogger.log` now does a single atomic `INSERT … ON CONFLICT (level, source, message) WHERE resolved = false DO UPDATE` upsert against a new partial unique index `error_logs_unresolved_dedup_idx`. Collapses the SELECT-then-INSERT/UPDATE read-modify-write race so concurrent writers with the same dedup key (e.g. the compacted "Browserless service unavailable" warning) deterministically land in a single row with `occurrence_count` bumped by every caller.

- **Closes #449** — Circuit-breaker-open warning in `scraper.ts` hoisted out of the `monitor.currentValue` guard so it fires for first-check monitors (currentValue === null) as well as cached-value monitors. Admin UI now has an entry for the degradation episode regardless of monitor state.

Also filed two pre-existing adjacent bugs as follow-ups: **#452** (missing ensure* bootstrap for the #447 partial indexes), **#453** (predicate drift between schema.ts and ensureTables.ts for automation_subscriptions dedup).

## Deploy-time safety for the new partial unique index

The #448 index introduces real deploy-time risk that this branch addresses end-to-end:

1. **`ensureErrorLogColumns` bootstrap** — defensively dedupes pre-existing unresolved rows (produced by the old racy code) then `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS`. Without this, either `schema:push` would fail on duplicates or the logger's swallow-catch would silently disable logging during the window between deploy and `schema:push`.
2. **Non-CONCURRENT index build avoided** — `CREATE … CONCURRENTLY` runs outside the dedup transaction so it doesn't hold a SHARE lock blocking every `ErrorLogger.log` caller on the entire app during index creation.
3. **Rolling-deploy race guarded** — `pg_advisory_xact_lock(hashtextextended(...))` at the top of the dedup transaction serializes concurrent instances so only one performs the dedup.
4. **INT32 overflow capped** — `LEAST(2147483647, SUM(occurrence_count) OVER (...))::int` so a site with many already-huge duplicates can't rollback the migration in a loop.
5. **INVALID-index recovery** — `pg_index.indisvalid` check drops and rebuilds leftover invalid indexes from interrupted builds, matching the `ensureMonitorChangesIndexes` pattern.

## Tests

- `server/partial-index-invariants.test.ts` — new byte-for-byte invariant asserting the `ErrorLogger` upsert's `targetWhere` predicate equals the `unresolvedDedupIdx` WHERE clause in `shared/schema.ts`, plus that the index covers exactly `(level, source, message)`. Without this, a Drizzle predicate-normalization drift (e.g. `resolved = false` → `resolved IS FALSE`) would silently break ON CONFLICT inference at runtime and the logger's catch block would disable logging with zero observability.
- `server/services/logger.test.ts` — rewritten (10 tests) for the atomic upsert shape; asserts insert values, onConflictDoUpdate target tuple + `targetWhere`, COALESCE semantics for stack/context, sensitive-data sanitization, graceful error handling.
- `server/services/scraper.test.ts` — new test for the first-check (currentValue=null) circuit-open warning path at `#449`.
- `server/services/ensureTables.test.ts` — new tests cover the 9-call migration path, the valid-index short-circuit, and the INVALID-index drop-and-rebuild branch.
- `server/routes.migration.test.ts` — mock sequences extended for the 9-call error-logs migration path.

All 2462 tests pass. `npm run check` clean.

## Magicwand pipeline findings resolved in-branch

- **Phase 2 security**: clean — no findings.
- **Phase 3 architecture**: 2 suggestions → fixed (shared `useAbortableFetchers` hook, added predicate-match invariant test).
- **Phase 4 code review**: 2 critical + 2 important → fixed (ensure* bootstrap, pre-existing-duplicate dedup, `!newValue` gate, errorType null assertion).
- **Phase 5 skeptic**: 2 blockers + 3 gotchas + 3 patterns → all fixed (CONCURRENTLY index build, advisory lock, INT32 clamp, indisvalid check, explicit `newValue == null` gate, COALESCE semantics comment, Dashboard comment clarified).
- **Phase 6 bug report**: 2 pre-existing bugs filed as #452 and #453.

## How to test

- [ ] **#446** — Sign in with 10+ monitors, click refresh, immediately navigate away. DevTools Network panel: in-flight `/api/monitors/:id/check` requests should be `(cancelled)`.
- [ ] **#448** — Run the migration locally against a DB with pre-existing unresolved duplicates. Verify the rolled-up occurrence_count in the kept row equals the sum of the old ones. Then `Promise.all([ErrorLogger.warning(...), ErrorLogger.warning(...)])` with the same dedup key — expect a single row with `occurrence_count=2`.
- [ ] **#449** — Force `browserlessCircuitBreaker.isAvailable()` to return false, create a brand-new monitor (currentValue=null), run `checkMonitor`. Verify an `error_logs` row with message "Browserless circuit breaker open — preserving last known values" exists.
- [ ] **Deploy safety** — `npm run schema:push` should be a no-op if the index was already created by `ensureErrorLogColumns`. The ensure function itself is idempotent across restarts (skipped if valid index exists).

https://claude.ai/code/session_01U2KFtrtFTxjhqn1TwqUpbo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error logging is now atomic, preventing duplicate unresolved error entries with the same type/source/message
  * Dashboard bulk refresh operations now have improved resource cleanup with proper abort signal handling
  * Enhanced database schema to support concurrent error deduplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->