### PR TITLE
fix: bootstrap campaign partial indexes and align automation dedup predicates

### DIFF
--- a/server/partial-index-invariants.test.ts
+++ b/server/partial-index-invariants.test.ts
@@ -24,6 +24,10 @@ const LOGGER_SRC = fs.readFileSync(
   path.resolve(__dirname, "services", "logger.ts"),
   "utf-8",
 );
+const ENSURE_TABLES_SRC = fs.readFileSync(
+  path.resolve(__dirname, "services", "ensureTables.ts"),
+  "utf-8",
+);
 
 function extractStatusList(label: string): string[] {
   const re = new RegExp(`${label}\\s*=\\s*\\[([^\\]]+)\\]`);
@@ -136,6 +140,74 @@ function extractLoggerConflictTargetColumns(): string[] {
   }
   return Array.from(m[1].matchAll(/errorLogs\.(\w+)/g)).map((mm) => mm[1]);
 }
+
+// -----------------------------------------------------------------------------
+// schema.ts <-> ensureTables.ts predicate parity for partial indexes.
+// Every partial index declared in shared/schema.ts that we rely on Postgres
+// to bootstrap via ensureTables must be present there with a byte-identical
+// WHERE predicate. A mismatch causes:
+//   - ON CONFLICT inference failure (Postgres requires strict predicate
+//     equality), which surfaces as the logger/backfill catch block swallowing
+//     the error and silently disabling the feature.
+//   - Endless drizzle-kit push churn (the diff flips the index back and forth).
+// See GitHub issues #448, #452, #453.
+// -----------------------------------------------------------------------------
+
+type BootstrapRequiredIndex = {
+  name: string;
+  schemaKey: string;
+};
+
+const BOOTSTRAP_REQUIRED_PARTIAL_INDEXES: BootstrapRequiredIndex[] = [
+  { name: "error_logs_unresolved_dedup_idx", schemaKey: "unresolvedDedupIdx" },
+  { name: "campaigns_type_automated_idx", schemaKey: "typeAutomatedIdx" },
+  { name: "campaign_recipients_active_user_idx", schemaKey: "activeUserCampaignIdx" },
+  { name: "automation_subscriptions_dedup_with_monitor", schemaKey: "dedupWithMonitor" },
+  { name: "automation_subscriptions_dedup_global", schemaKey: "dedupGlobal" },
+];
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+function extractEnsureTablesPredicate(indexName: string): string {
+  // Match the CREATE [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS] <name>
+  // ... WHERE <predicate> pattern. Allow the statement to span multiple lines
+  // (the error_logs bootstrap uses a multi-line template literal). Stop at the
+  // closing backtick or the end of statement punctuation so we don't bleed
+  // into trailing SQL fragments.
+  const re = new RegExp(
+    `CREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+(?:CONCURRENTLY\\s+)?(?:IF\\s+NOT\\s+EXISTS\\s+)?${indexName}\\b[\\s\\S]*?WHERE\\s+([\\s\\S]*?)\`\\s*\\)`,
+  );
+  const m = ENSURE_TABLES_SRC.match(re);
+  if (!m) {
+    throw new Error(
+      `failed to extract WHERE predicate for ${indexName} from server/services/ensureTables.ts — ` +
+        "missing bootstrap for this partial index, or the CREATE INDEX " +
+        "statement changed shape (split across db.execute calls, different " +
+        "name, etc.). Add or repair the bootstrap so schema and DDL stay " +
+        "byte-identical.",
+    );
+  }
+  return normalizeWhitespace(m[1]);
+}
+
+function extractSchemaPredicate(schemaKey: string): string {
+  const re = new RegExp(`${schemaKey}[\\s\\S]*?\\.where\\(sql\`([^\`]+)\`\\)`);
+  const m = SCHEMA_SRC.match(re);
+  if (!m) throw new Error(`failed to extract ${schemaKey} predicate from shared/schema.ts`);
+  return normalizeWhitespace(m[1]);
+}
+
+describe("partial-index bootstrap parity between schema.ts and ensureTables.ts", () => {
+  for (const idx of BOOTSTRAP_REQUIRED_PARTIAL_INDEXES) {
+    it(`${idx.name}: ensureTables bootstrap exists and its WHERE predicate byte-matches shared/schema.ts`, () => {
+      const schemaPredicate = extractSchemaPredicate(idx.schemaKey);
+      const ddlPredicate = extractEnsureTablesPredicate(idx.name);
+      expect(ddlPredicate).toBe(schemaPredicate);
+    });
+  }
+});
 
 describe("error_logs_unresolved_dedup_idx predicate matches ErrorLogger upsert targetWhere", () => {
   it("index WHERE clause and onConflictDoUpdate targetWhere are byte-for-byte equal", () => {

--- a/server/routes.conditions.test.ts
+++ b/server/routes.conditions.test.ts
@@ -181,6 +181,7 @@ vi.mock("./services/ensureTables", () => ({
   ensureMonitorPendingRetryColumn: vi.fn().mockResolvedValue(true),
   ensureAutomationSubscriptionsTable: vi.fn().mockResolvedValue(true),
   ensureMonitorChangesIndexes: vi.fn().mockResolvedValue(undefined),
+  ensureCampaignPartialIndexes: vi.fn().mockResolvedValue(undefined),
 }));
 
 // ---------------------------------------------------------------------------

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -36,7 +36,7 @@ import { encryptToken, decryptToken, isValidEncryptedToken } from "./utils/encry
 import { validateHost } from "./utils/hostValidation";
 import { createHmac } from "node:crypto";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
-import { ensureErrorLogColumns, ensureApiKeysTable, ensureChannelTables, ensureTagTables, ensureMonitorHealthColumns, ensureMonitorConditionsTable, ensureNotificationQueueColumns, ensureAutomatedCampaignConfigsTable, ensureMonitorPendingRetryColumn, ensureAutomationSubscriptionsTable, ensureMonitorChangesIndexes } from "./services/ensureTables";
+import { ensureErrorLogColumns, ensureApiKeysTable, ensureChannelTables, ensureTagTables, ensureMonitorHealthColumns, ensureMonitorConditionsTable, ensureNotificationQueueColumns, ensureAutomatedCampaignConfigsTable, ensureMonitorPendingRetryColumn, ensureAutomationSubscriptionsTable, ensureMonitorChangesIndexes, ensureCampaignPartialIndexes } from "./services/ensureTables";
 import { renderRobotsTxt, renderSitemapXml } from "./services/seoFiles";
 
 
@@ -84,6 +84,7 @@ export async function registerRoutes(
   const apiKeysReady = await ensureApiKeysTable();
   await ensureChannelTables();
   await ensureMonitorChangesIndexes();
+  await ensureCampaignPartialIndexes();
   const notificationQueueReady = await ensureNotificationQueueColumns();
   if (!notificationQueueReady) {
     console.error("CRITICAL: notification_queue columns missing — notification cron queries will fail");

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -407,6 +407,58 @@ export async function ensureMonitorChangesIndexes(): Promise<void> {
 }
 
 /**
+ * Ensures the partial indexes on `campaigns(id) WHERE type='automated'` and
+ * `campaign_recipients(user_id, campaign_id) WHERE status IN (<active>)` exist
+ * (PR #447). Without them, the welcome-exclusion anti-join in
+ * resolveRecipients (server/services/campaignEmail.ts) falls back to a Seq
+ * Scan + Hash Anti Join whose runtime scales O(N) in total historical
+ * recipient rows — see GitHub issue #452.
+ *
+ * Predicates are kept byte-identical to shared/schema.ts. The
+ * partial-index-invariants test asserts this parity so drift between schema
+ * and DDL is caught before it ships.
+ */
+export async function ensureCampaignPartialIndexes(): Promise<void> {
+  try {
+    // campaigns_type_automated_idx
+    const existingCampaignIdx = await db.execute(sql`
+      SELECT i.indisvalid
+      FROM pg_indexes ix
+      JOIN pg_class c ON c.relname = ix.indexname
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE ix.indexname = 'campaigns_type_automated_idx'
+    `);
+    const campaignRows = (existingCampaignIdx as any).rows as Array<{ indisvalid: boolean }> | undefined;
+    if (campaignRows && campaignRows.length > 0) {
+      if (!campaignRows[0].indisvalid) {
+        console.warn("[ensureTables] Dropping invalid index campaigns_type_automated_idx");
+        await db.execute(sql`DROP INDEX IF EXISTS campaigns_type_automated_idx`);
+      }
+    }
+    await db.execute(sql`CREATE INDEX CONCURRENTLY IF NOT EXISTS campaigns_type_automated_idx ON campaigns(id) WHERE type = 'automated'`);
+
+    // campaign_recipients_active_user_idx — predicate must byte-match schema.ts
+    const existingRecipientIdx = await db.execute(sql`
+      SELECT i.indisvalid
+      FROM pg_indexes ix
+      JOIN pg_class c ON c.relname = ix.indexname
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE ix.indexname = 'campaign_recipients_active_user_idx'
+    `);
+    const recipientRows = (existingRecipientIdx as any).rows as Array<{ indisvalid: boolean }> | undefined;
+    if (recipientRows && recipientRows.length > 0) {
+      if (!recipientRows[0].indisvalid) {
+        console.warn("[ensureTables] Dropping invalid index campaign_recipients_active_user_idx");
+        await db.execute(sql`DROP INDEX IF EXISTS campaign_recipients_active_user_idx`);
+      }
+    }
+    await db.execute(sql`CREATE INDEX CONCURRENTLY IF NOT EXISTS campaign_recipients_active_user_idx ON campaign_recipients(user_id, campaign_id) WHERE status IN ('pending', 'sent', 'delivered', 'opened', 'clicked')`);
+  } catch (e) {
+    console.warn("Could not ensure campaign partial indexes:", e);
+  }
+}
+
+/**
  * Ensures tags and monitor_tags tables exist (added in PR #86).
  * Without this, getMonitorsWithTags() fails when the tables have not been created yet.
  */

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -420,18 +420,30 @@ export async function ensureMonitorChangesIndexes(): Promise<void> {
  */
 export async function ensureCampaignPartialIndexes(): Promise<void> {
   try {
-    // campaigns_type_automated_idx
+    // campaigns_type_automated_idx — also check pg_get_indexdef so a stale
+    // same-name index with wrong columns/predicate gets dropped and rebuilt
+    // (CREATE INDEX CONCURRENTLY IF NOT EXISTS is name-based only). Matches
+    // the ensureErrorLogColumns pattern — see CodeRabbit review on PR #455.
     const existingCampaignIdx = await db.execute(sql`
-      SELECT i.indisvalid
+      SELECT i.indisvalid, pg_get_indexdef(i.indexrelid) AS indexdef
       FROM pg_indexes ix
       JOIN pg_class c ON c.relname = ix.indexname
       JOIN pg_index i ON i.indexrelid = c.oid
       WHERE ix.indexname = 'campaigns_type_automated_idx'
     `);
-    const campaignRows = (existingCampaignIdx as any).rows as Array<{ indisvalid: boolean }> | undefined;
+    const campaignRows = (existingCampaignIdx as any).rows as Array<{ indisvalid: boolean; indexdef: string }> | undefined;
     if (campaignRows && campaignRows.length > 0) {
-      if (!campaignRows[0].indisvalid) {
-        console.warn("[ensureTables] Dropping invalid index campaigns_type_automated_idx");
+      const { indisvalid, indexdef } = campaignRows[0];
+      // Postgres canonicalizes `type = 'automated'` and may emit ::text casts
+      // and extra parens; match the key tokens rather than the raw string.
+      const defIsCorrect =
+        / ON [^.]*\.?campaigns\b/i.test(indexdef) &&
+        /\(id\)/.test(indexdef) &&
+        /type\s*=\s*'automated'/i.test(indexdef);
+      if (!indisvalid || !defIsCorrect) {
+        console.warn(
+          `[ensureTables] Dropping existing campaigns_type_automated_idx (valid=${indisvalid} defMatch=${defIsCorrect}) so it can be rebuilt with the expected shape`,
+        );
         await db.execute(sql`DROP INDEX IF EXISTS campaigns_type_automated_idx`);
       }
     }
@@ -439,16 +451,27 @@ export async function ensureCampaignPartialIndexes(): Promise<void> {
 
     // campaign_recipients_active_user_idx — predicate must byte-match schema.ts
     const existingRecipientIdx = await db.execute(sql`
-      SELECT i.indisvalid
+      SELECT i.indisvalid, pg_get_indexdef(i.indexrelid) AS indexdef
       FROM pg_indexes ix
       JOIN pg_class c ON c.relname = ix.indexname
       JOIN pg_index i ON i.indexrelid = c.oid
       WHERE ix.indexname = 'campaign_recipients_active_user_idx'
     `);
-    const recipientRows = (existingRecipientIdx as any).rows as Array<{ indisvalid: boolean }> | undefined;
+    const recipientRows = (existingRecipientIdx as any).rows as Array<{ indisvalid: boolean; indexdef: string }> | undefined;
     if (recipientRows && recipientRows.length > 0) {
-      if (!recipientRows[0].indisvalid) {
-        console.warn("[ensureTables] Dropping invalid index campaign_recipients_active_user_idx");
+      const { indisvalid, indexdef } = recipientRows[0];
+      // Postgres rewrites `status IN ('a','b',...)` as
+      // `status = ANY (ARRAY['a'::text, ...])`, so check for each status
+      // literal and the column tuple rather than the raw `IN (...)` form.
+      const activeStatuses = ["pending", "sent", "delivered", "opened", "clicked"];
+      const defIsCorrect =
+        / ON [^.]*\.?campaign_recipients\b/i.test(indexdef) &&
+        /\(user_id,\s*campaign_id\)/.test(indexdef) &&
+        activeStatuses.every((s) => indexdef.includes(`'${s}'`));
+      if (!indisvalid || !defIsCorrect) {
+        console.warn(
+          `[ensureTables] Dropping existing campaign_recipients_active_user_idx (valid=${indisvalid} defMatch=${defIsCorrect}) so it can be rebuilt with the expected shape`,
+        );
         await db.execute(sql`DROP INDEX IF EXISTS campaign_recipients_active_user_idx`);
       }
     }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -506,13 +506,15 @@ export const automationSubscriptions = pgTable("automation_subscriptions", {
 }, (table) => ({
   userIdx: index("automation_subscriptions_user_idx").on(table.userId),
   platformIdx: index("automation_subscriptions_platform_idx").on(table.platform),
-  // Dedup: one active sub per (user, platform, hookUrlHash, monitorId) — split into two partial indexes
+  // Dedup: one active sub per (user, platform, hookUrlHash, monitorId) — split into two partial indexes.
+  // Predicate must stay byte-identical to the DDL in ensureAutomationSubscriptionsTable so
+  // a future ON CONFLICT against these indexes can match (see GitHub issue #453 and #448).
   dedupWithMonitor: uniqueIndex("automation_subscriptions_dedup_with_monitor")
     .on(table.userId, table.platform, table.hookUrlHash, table.monitorId)
-    .where(sql`active = true AND monitor_id IS NOT NULL`),
+    .where(sql`active = true AND monitor_id IS NOT NULL AND hook_url_hash IS NOT NULL`),
   dedupGlobal: uniqueIndex("automation_subscriptions_dedup_global")
     .on(table.userId, table.platform, table.hookUrlHash)
-    .where(sql`active = true AND monitor_id IS NULL`),
+    .where(sql`active = true AND monitor_id IS NULL AND hook_url_hash IS NOT NULL`),
 }));
 
 export const automationSubscriptionsRelations = relations(automationSubscriptions, ({ one }) => ({


### PR DESCRIPTION
## Summary

Closes #452 and #453 — both pre-existing drift bugs between `shared/schema.ts` and `server/services/ensureTables.ts` that were filed as follow-ups by the `/magicwand` Phase 6 bug reporter on PR #454. A future `INSERT … ON CONFLICT` against either pair of indexes would have silently failed inference (same failure mode as #448), and the campaign anti-join from #447 was silently running as a Seq Scan in production until someone ran `schema:push`.

Adds a regression guard that byte-compares every bootstrap-required partial-index predicate in `schema.ts` against the corresponding `CREATE INDEX … WHERE` in `ensureTables.ts`, so this class of drift fails CI rather than deploy.

## Changes

### Fix #452 — bootstrap the campaign partial indexes (`server/services/ensureTables.ts`, `server/routes.ts`)

- New `ensureCampaignPartialIndexes()` that creates `campaigns_type_automated_idx` and `campaign_recipients_active_user_idx` at boot using `CREATE INDEX CONCURRENTLY IF NOT EXISTS` and drops any leftover INVALID build (matches the `ensureMonitorChangesIndexes` pattern).
- Wired into `registerRoutes()` alongside the other `ensure*` calls, so the welcome-exclusion anti-join in `resolveRecipients` gets an Index Only Scan immediately on deploy instead of a Seq Scan + Hash Anti Join until `schema:push` runs.

### Fix #453 — align automation_subscriptions dedup predicates (`shared/schema.ts`)

- Added `AND hook_url_hash IS NOT NULL` to both `dedupWithMonitor` and `dedupGlobal` `.where()` clauses so they match the existing `ensureAutomationSubscriptionsTable` DDL byte-for-byte.
- Stops `drizzle-kit push` from flipping the indexes back and forth on every run, and makes future `INSERT … ON CONFLICT ON CONSTRAINT automation_subscriptions_dedup_with_monitor` match under Postgres's strict-equality inference.

### Regression guard (`server/partial-index-invariants.test.ts`)

- New `BOOTSTRAP_REQUIRED_PARTIAL_INDEXES` table covering all five partial indexes we rely on `ensureTables` to create: `error_logs_unresolved_dedup_idx`, `campaigns_type_automated_idx`, `campaign_recipients_active_user_idx`, and both `automation_subscriptions_dedup_*`.
- For each entry, extracts the `.where(sql\`…\`)` predicate from `shared/schema.ts` and the `CREATE [UNIQUE] INDEX … WHERE …` predicate from `server/services/ensureTables.ts`, whitespace-normalizes both, and asserts byte equality. Also fails with a descriptive error if the bootstrap is missing entirely (which is how the test would have caught #452 before it shipped).

### Test mock (`server/routes.conditions.test.ts`)

- Added `ensureCampaignPartialIndexes: vi.fn().mockResolvedValue(undefined)` to the `./services/ensureTables` mock so routes tests keep passing after the new export.

## How to test

- [ ] `npm run check` passes (tsc clean).
- [ ] `npm run test` passes — 2469/2469 tests across 100 files, including 10 assertions in `server/partial-index-invariants.test.ts`.
- [ ] Drift detection: edit either `shared/schema.ts` or `server/services/ensureTables.ts` to change one of the five covered predicates (e.g. add a trailing `AND 1=1`). `npx vitest run server/partial-index-invariants.test.ts` should fail with a byte-mismatch error naming the specific index.
- [ ] Bootstrap idempotence: on a fresh DB, boot the server and verify `pg_indexes` shows both `campaigns_type_automated_idx` and `campaign_recipients_active_user_idx` without running `schema:push`. Reboot — the valid-index fast path (`CREATE INDEX CONCURRENTLY IF NOT EXISTS`) is a no-op.
- [ ] Predicate byte-match: after deploy, `SELECT indexdef FROM pg_indexes WHERE indexname IN ('automation_subscriptions_dedup_with_monitor', 'automation_subscriptions_dedup_global')` should show `active = true AND monitor_id {IS NULL|IS NOT NULL} AND hook_url_hash IS NOT NULL`. Then `npx drizzle-kit push` should be a no-op (no churn on these indexes).

https://claude.ai/code/session_01Nnp3Uy1q5xgHTNC5pqNup1