### PR TITLE
fix: resolve open bugs #456-#460 across scheduler/retry pipelines

### DIFF
--- a/server/routes.conditions.test.ts
+++ b/server/routes.conditions.test.ts
@@ -167,7 +167,7 @@ vi.mock("./services/ensureTables", () => ({
   ensureChannelTables: vi.fn().mockResolvedValue(undefined),
   ensureNotificationQueueColumns: vi.fn().mockResolvedValue(true),
   ensureTagTables: vi.fn().mockResolvedValue(undefined),
-  ensureMonitorHealthColumns: vi.fn().mockResolvedValue(undefined),
+  ensureMonitorHealthColumns: vi.fn().mockResolvedValue(true),
   ensureMonitorConditionsTable: vi.fn().mockResolvedValue(true),
   ensureAutomatedCampaignConfigsTable: vi.fn().mockResolvedValue(true),
   ensureMonitorPendingRetryColumn: vi.fn().mockResolvedValue(true),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -61,13 +61,20 @@ export async function registerRoutes(
   app: Express
 ): Promise<{ httpServer: Server; campaignConfigsReady: boolean }> {
 
+  // Columns/tables referenced directly by Drizzle-generated SELECTs must be
+  // provisioned before we accept traffic. If any of these fail, every
+  // downstream query would throw `column … does not exist` for the life of
+  // the process. Rather than serving partial-liveness (port open, every
+  // user-facing request 500s), install a global /api 503 gate so clients
+  // receive a clear SCHEMA_NOT_READY signal. See GitHub issue #457.
+  const criticalSchemaFailures: string[] = [];
   const healthColumnsReady = await ensureMonitorHealthColumns();
   if (!healthColumnsReady) {
-    console.error("CRITICAL: Monitor health columns missing — health alerts and recovery emails will be disabled");
+    criticalSchemaFailures.push("monitor health columns");
   }
   const pendingRetryReady = await ensureMonitorPendingRetryColumn();
   if (!pendingRetryReady) {
-    console.error("CRITICAL: monitors.pending_retry_at column missing — auto-retry scheduling will fail");
+    criticalSchemaFailures.push("monitors.pending_retry_at column");
   }
   const apiKeysReady = await ensureApiKeysTable();
   await ensureChannelTables();
@@ -75,12 +82,21 @@ export async function registerRoutes(
   await ensureCampaignPartialIndexes();
   const notificationQueueReady = await ensureNotificationQueueColumns();
   if (!notificationQueueReady) {
-    console.error("CRITICAL: notification_queue columns missing — notification cron queries will fail");
+    criticalSchemaFailures.push("notification_queue columns");
   }
   await ensureTagTables();
   const automationSubsReady = await ensureAutomationSubscriptionsTable();
   if (!automationSubsReady) {
-    console.error("CRITICAL: automation_subscriptions table missing — Zapier endpoints and automation delivery will fail");
+    criticalSchemaFailures.push("automation_subscriptions table");
+  }
+  if (criticalSchemaFailures.length > 0) {
+    const detail = criticalSchemaFailures.join(", ");
+    console.error(
+      `CRITICAL: required schema missing — ${detail}. All /api/* routes will return 503 SCHEMA_NOT_READY until the server restarts on a healthy DB.`,
+    );
+    app.use("/api", (_req, res) => {
+      res.status(503).json({ message: `Schema not ready: ${detail}`, code: "SCHEMA_NOT_READY" });
+    });
   }
   let campaignConfigsReady = await ensureAutomatedCampaignConfigsTable();
   if (!campaignConfigsReady) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -77,7 +77,10 @@ export async function registerRoutes(
     criticalSchemaFailures.push("monitors.pending_retry_at column");
   }
   const apiKeysReady = await ensureApiKeysTable();
-  await ensureChannelTables();
+  const channelTablesReady = await ensureChannelTables();
+  if (!channelTablesReady) {
+    criticalSchemaFailures.push("notification channel / delivery_log columns");
+  }
   await ensureMonitorChangesIndexes();
   await ensureCampaignPartialIndexes();
   const notificationQueueReady = await ensureNotificationQueueColumns();

--- a/server/services/automationDelivery.test.ts
+++ b/server/services/automationDelivery.test.ts
@@ -158,6 +158,27 @@ describe("deliverToAutomationSubscriptions", () => {
     expect(mockTouchAndResetAutomationSubscription).not.toHaveBeenCalled();
   });
 
+  it.each([408, 429])("queues durable retry on transient HTTP %s response", async (status) => {
+    mockGetActiveAutomationSubscriptions.mockResolvedValue([makeSub({ id: 3 })]);
+    mockSsrfSafeFetch.mockResolvedValue({ ok: false, status });
+
+    await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
+
+    expect(mockAddDeliveryLog).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "automation",
+      status: "pending",
+      attempt: 1,
+      response: expect.objectContaining({
+        subscriptionId: 3,
+        platform: "zapier",
+        error: `HTTP ${status}`,
+        transient: true,
+      }),
+    }));
+    expect(mockIncrementAutomationSubscriptionFailures).not.toHaveBeenCalled();
+    expect(mockTouchAndResetAutomationSubscription).not.toHaveBeenCalled();
+  });
+
   it("queues durable retry on network error (does NOT bump failure counter)", async () => {
     mockGetActiveAutomationSubscriptions.mockResolvedValue([makeSub({ id: 3 })]);
     mockSsrfSafeFetch.mockRejectedValue(new Error("ECONNREFUSED"));

--- a/server/services/automationDelivery.test.ts
+++ b/server/services/automationDelivery.test.ts
@@ -5,12 +5,14 @@ const mockGetActiveAutomationSubscriptions = vi.fn();
 const mockTouchAndResetAutomationSubscription = vi.fn().mockResolvedValue(undefined);
 const mockIncrementAutomationSubscriptionFailures = vi.fn().mockResolvedValue(1);
 const mockDeactivateAutomationSubscription = vi.fn().mockResolvedValue(true);
+const mockAddDeliveryLog = vi.fn().mockResolvedValue({ id: 1 });
 vi.mock("../storage", () => ({
   storage: {
     getActiveAutomationSubscriptions: (...args: any[]) => mockGetActiveAutomationSubscriptions(...args),
     touchAndResetAutomationSubscription: (...args: any[]) => mockTouchAndResetAutomationSubscription(...args),
     incrementAutomationSubscriptionFailures: (...args: any[]) => mockIncrementAutomationSubscriptionFailures(...args),
     deactivateAutomationSubscription: (...args: any[]) => mockDeactivateAutomationSubscription(...args),
+    addDeliveryLog: (...args: any[]) => mockAddDeliveryLog(...args),
   },
 }));
 
@@ -140,30 +142,47 @@ describe("deliverToAutomationSubscriptions", () => {
     );
   });
 
-  it("increments consecutive failures on non-2xx response", async () => {
+  it("queues durable retry on transient 5xx response (does NOT bump failure counter)", async () => {
     mockGetActiveAutomationSubscriptions.mockResolvedValue([makeSub({ id: 3 })]);
     mockSsrfSafeFetch.mockResolvedValue({ ok: false, status: 500 });
 
     await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
 
-    expect(mockIncrementAutomationSubscriptionFailures).toHaveBeenCalledWith(3);
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Automation delivery failed"),
-      expect.objectContaining({ error: "HTTP 500", consecutiveFailures: 1 }),
-    );
+    expect(mockAddDeliveryLog).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "automation",
+      status: "pending",
+      attempt: 1,
+      response: expect.objectContaining({ subscriptionId: 3, platform: "zapier", error: "HTTP 500", transient: true }),
+    }));
+    expect(mockIncrementAutomationSubscriptionFailures).not.toHaveBeenCalled();
     expect(mockTouchAndResetAutomationSubscription).not.toHaveBeenCalled();
   });
 
-  it("increments consecutive failures on network error", async () => {
+  it("queues durable retry on network error (does NOT bump failure counter)", async () => {
     mockGetActiveAutomationSubscriptions.mockResolvedValue([makeSub({ id: 3 })]);
     mockSsrfSafeFetch.mockRejectedValue(new Error("ECONNREFUSED"));
 
     await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
 
+    expect(mockAddDeliveryLog).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "automation",
+      status: "pending",
+      response: expect.objectContaining({ error: "ECONNREFUSED", transient: true }),
+    }));
+    expect(mockIncrementAutomationSubscriptionFailures).not.toHaveBeenCalled();
+  });
+
+  it("increments consecutive failures on persistent 4xx response", async () => {
+    mockGetActiveAutomationSubscriptions.mockResolvedValue([makeSub({ id: 3 })]);
+    mockSsrfSafeFetch.mockResolvedValue({ ok: false, status: 404 });
+
+    await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
+
     expect(mockIncrementAutomationSubscriptionFailures).toHaveBeenCalledWith(3);
+    expect(mockAddDeliveryLog).not.toHaveBeenCalled();
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining("Automation delivery failed"),
-      expect.objectContaining({ error: "ECONNREFUSED", consecutiveFailures: 1 }),
+      expect.objectContaining({ error: "HTTP 404", consecutiveFailures: 1 }),
     );
   });
 
@@ -173,12 +192,13 @@ describe("deliverToAutomationSubscriptions", () => {
 
     await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
 
-    const loggedError = (consoleWarnSpy.mock.calls[0][1] as any).error;
-    expect(loggedError).not.toContain("hooks.zapier.com");
-    expect(loggedError).toContain("[redacted-url]");
+    // Sanitization now happens in the transient-retry log entry
+    const logged = mockAddDeliveryLog.mock.calls[0][0];
+    expect(logged.response.error).not.toContain("hooks.zapier.com");
+    expect(logged.response.error).toContain("[redacted-url]");
   });
 
-  it("deactivates subscription after reaching failure threshold", async () => {
+  it("deactivates subscription after reaching failure threshold (persistent 4xx)", async () => {
     mockIncrementAutomationSubscriptionFailures.mockResolvedValue(15); // equals threshold
     mockGetActiveAutomationSubscriptions.mockResolvedValue([makeSub({ id: 9 })]);
     mockSsrfSafeFetch.mockResolvedValue({ ok: false, status: 410 });
@@ -192,7 +212,7 @@ describe("deliverToAutomationSubscriptions", () => {
     );
   });
 
-  it("does not deactivate subscription below failure threshold", async () => {
+  it("does not deactivate subscription on transient 5xx (retry queued instead)", async () => {
     mockIncrementAutomationSubscriptionFailures.mockResolvedValue(14); // below threshold of 15
     mockGetActiveAutomationSubscriptions.mockResolvedValue([makeSub({ id: 9 })]);
     mockSsrfSafeFetch.mockResolvedValue({ ok: false, status: 500 });
@@ -200,6 +220,7 @@ describe("deliverToAutomationSubscriptions", () => {
     await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
 
     expect(mockDeactivateAutomationSubscription).not.toHaveBeenCalled();
+    expect(mockAddDeliveryLog).toHaveBeenCalled();
   });
 
   it("delivers to multiple subscriptions in parallel", async () => {

--- a/server/services/automationDelivery.ts
+++ b/server/services/automationDelivery.ts
@@ -4,9 +4,56 @@ import { storage } from "../storage";
 import { ssrfSafeFetch } from "../utils/ssrf";
 import { buildWebhookPayload } from "./webhookDelivery";
 
+export type AutomationDeliveryOutcome =
+  | { kind: "success"; statusCode: number }
+  | { kind: "transient"; error: string; statusCode?: number }
+  | { kind: "persistent"; error: string; statusCode: number };
+
+/**
+ * Perform a single automation delivery POST and classify the outcome.
+ * Exported so the retry cron can reuse the exact same request logic and
+ * error classification as the initial fire-and-forget attempt.
+ */
+export async function performAutomationDelivery(
+  hookUrl: string,
+  body: string,
+): Promise<AutomationDeliveryOutcome> {
+  try {
+    const response = await ssrfSafeFetch(hookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "FetchTheChange-Zapier/1.0",
+      },
+      body,
+      signal: AbortSignal.timeout(5000),
+    });
+    if (response.ok) {
+      return { kind: "success", statusCode: response.status };
+    }
+    // 5xx/429 are transient (upstream problem); 4xx are persistent (our request is wrong).
+    if (response.status >= 500 || response.status === 429 || response.status === 408) {
+      return { kind: "transient", error: `HTTP ${response.status}`, statusCode: response.status };
+    }
+    return { kind: "persistent", error: `HTTP ${response.status}`, statusCode: response.status };
+  } catch (err) {
+    // Network errors, aborts, DNS failures — all transient.
+    const rawMsg = err instanceof Error ? err.message : String(err);
+    const safeError = rawMsg.replace(/https?:\/\/[^\s)]+/g, "[redacted-url]");
+    return { kind: "transient", error: safeError };
+  }
+}
+
 /**
  * Deliver change events to active automation subscriptions (Zapier REST Hooks etc.).
  * Called fire-and-forget from processChangeNotification — errors are logged, never rethrown.
+ *
+ * Behavior on failure (see issue #456):
+ *   - Transient (5xx/429/408/network): enqueue a delivery_log row with
+ *     status='pending' so the automation retry cron picks it up. Does NOT
+ *     bump consecutive_failures so a flaky upstream does not auto-deactivate.
+ *   - Persistent (4xx): bump consecutive_failures + log failed row; no retry,
+ *     since 4xx responses will not get better on retry.
  */
 export async function deliverToAutomationSubscriptions(
   monitor: Monitor,
@@ -22,35 +69,48 @@ export async function deliverToAutomationSubscriptions(
   const body = JSON.stringify({ ...payload, id: change.id });
 
   const deliveries = subscriptions.map(async (sub) => {
-    try {
-      // Automation hook URLs (e.g. Zapier) are unguessable bearer tokens.
-      // No HMAC signature header — the hookUrl itself authenticates the request.
-      // Webhook channels use X-FTC-Signature-256 with a per-channel secret.
-      const response = await ssrfSafeFetch(sub.hookUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "User-Agent": "FetchTheChange-Zapier/1.0",
-        },
-        body,
-        signal: AbortSignal.timeout(5000),
-      });
+    const outcome = await performAutomationDelivery(sub.hookUrl, body);
 
-      if (response.ok) {
-        console.log(`[Automation] Delivered successfully (monitorId=${monitor.id}, platform=${sub.platform}, subId=${sub.id}, status=${response.status})`);
-        // Atomic touch + failure counter reset in a single UPDATE
-        storage.touchAndResetAutomationSubscription(sub.id).catch((err) => {
-          console.warn(`[Automation] Failed to reset failure counter for subscription ${sub.id}`, err);
-        });
-      } else {
-        await handleDeliveryFailure(sub.id, monitor, sub.platform, `HTTP ${response.status}`);
-      }
-    } catch (err) {
-      // Sanitize error to avoid leaking hookUrl secrets in logs
-      const rawMsg = err instanceof Error ? err.message : String(err);
-      const safeError = rawMsg.replace(/https?:\/\/[^\s)]+/g, "[redacted-url]");
-      await handleDeliveryFailure(sub.id, monitor, sub.platform, safeError);
+    if (outcome.kind === "success") {
+      console.log(`[Automation] Delivered successfully (monitorId=${monitor.id}, platform=${sub.platform}, subId=${sub.id}, status=${outcome.statusCode})`);
+      storage.touchAndResetAutomationSubscription(sub.id).catch((err) => {
+        console.warn(`[Automation] Failed to reset failure counter for subscription ${sub.id}`, err);
+      });
+      return;
     }
+
+    if (outcome.kind === "transient") {
+      // Enqueue a durable retry — cron will re-attempt up to 3 times total.
+      try {
+        await storage.addDeliveryLog({
+          monitorId: monitor.id,
+          changeId: change.id,
+          channel: "automation",
+          status: "pending",
+          attempt: 1,
+          response: {
+            subscriptionId: sub.id,
+            platform: sub.platform,
+            error: outcome.error,
+            transient: true,
+          },
+        });
+        console.warn(`[scheduler] Automation delivery transient failure — queued for retry for monitor "${monitor.name}"`, {
+          subscriptionId: sub.id,
+          monitorId: monitor.id,
+          platform: sub.platform,
+          error: outcome.error,
+        });
+      } catch (logErr) {
+        // If we can't enqueue the retry, fall back to the old behavior to avoid losing all signal.
+        console.error(`[Automation] Failed to enqueue retry delivery_log row — falling back to failure counter bump`, logErr);
+        await handleDeliveryFailure(sub.id, monitor, sub.platform, outcome.error);
+      }
+      return;
+    }
+
+    // Persistent (4xx) — no retry; bump failure counter as before.
+    await handleDeliveryFailure(sub.id, monitor, sub.platform, outcome.error);
   });
 
   await Promise.allSettled(deliveries);
@@ -82,4 +142,23 @@ async function handleDeliveryFailure(
       error,
     });
   }
+}
+
+/**
+ * Called by the automation retry cron after an enqueued delivery is finalized
+ * (success, permanent failure, or retries exhausted).
+ */
+export async function finalizeAutomationRetry(
+  subscriptionId: number,
+  monitor: Monitor,
+  platform: string,
+  outcome: AutomationDeliveryOutcome,
+): Promise<void> {
+  if (outcome.kind === "success") {
+    storage.touchAndResetAutomationSubscription(subscriptionId).catch((err) => {
+      console.warn(`[Automation] Failed to reset failure counter for subscription ${subscriptionId}`, err);
+    });
+    return;
+  }
+  await handleDeliveryFailure(subscriptionId, monitor, platform, outcome.error);
 }

--- a/server/services/automationDelivery.ts
+++ b/server/services/automationDelivery.ts
@@ -113,7 +113,23 @@ export async function deliverToAutomationSubscriptions(
     await handleDeliveryFailure(sub.id, monitor, sub.platform, outcome.error);
   });
 
-  await Promise.allSettled(deliveries);
+  const results = await Promise.allSettled(deliveries);
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === "rejected") {
+      // A rejection here means the fallback path (addDeliveryLog) itself
+      // threw and handleDeliveryFailure also threw, OR handleDeliveryFailure
+      // threw on the persistent path. Silently ignoring loses the signal.
+      const sub = subscriptions[i];
+      const errorMessage = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      console.error("[Automation] Delivery handling failed — retry and failure-counter updates may be inconsistent", {
+        subscriptionId: sub?.id,
+        monitorId: monitor.id,
+        platform: sub?.platform,
+        errorMessage,
+      });
+    }
+  }
 }
 
 async function handleDeliveryFailure(

--- a/server/services/ensureTables.test.ts
+++ b/server/services/ensureTables.test.ts
@@ -101,8 +101,10 @@ describe("ensureChannelTables", () => {
   it("executes all CREATE TABLE and CREATE INDEX statements without throwing", async () => {
     mockExecute.mockResolvedValue([]);
     await ensureChannelTables();
-    // 3 CREATE TABLE + 1 CREATE INDEX + 1 CREATE UNIQUE INDEX + 2 CREATE INDEX + 1 ALTER delivery_log ADD claimed_at + 1 backfill SELECT = 9
-    expect(mockExecute).toHaveBeenCalledTimes(9);
+    // 3 CREATE TABLE + 1 CREATE INDEX + 1 CREATE UNIQUE INDEX + 2 CREATE INDEX
+    //   + 1 ALTER delivery_log ADD claimed_at + 1 CREATE INDEX (claimed_at)
+    //   + 1 backfill SELECT = 10
+    expect(mockExecute).toHaveBeenCalledTimes(10);
   });
 
   it("emits CREATE INDEX for delivery_log_channel_status_attempt_idx", async () => {
@@ -114,9 +116,14 @@ describe("ensureChannelTables", () => {
     expect(statements.some((s: string) => s.includes("delivery_log_channel_status_attempt_idx"))).toBe(true);
   });
 
-  it("catches errors and does not throw", async () => {
+  it("catches errors and returns false without throwing", async () => {
     mockExecute.mockRejectedValue(new Error("connection refused"));
-    await expect(ensureChannelTables()).resolves.toBeUndefined();
+    await expect(ensureChannelTables()).resolves.toBe(false);
+  });
+
+  it("returns true on successful schema provisioning", async () => {
+    mockExecute.mockResolvedValue([]);
+    await expect(ensureChannelTables()).resolves.toBe(true);
   });
 
   it("logs error when table creation fails", async () => {

--- a/server/services/ensureTables.test.ts
+++ b/server/services/ensureTables.test.ts
@@ -101,8 +101,8 @@ describe("ensureChannelTables", () => {
   it("executes all CREATE TABLE and CREATE INDEX statements without throwing", async () => {
     mockExecute.mockResolvedValue([]);
     await ensureChannelTables();
-    // 3 CREATE TABLE + 1 CREATE INDEX + 1 CREATE UNIQUE INDEX + 2 CREATE INDEX + 1 backfill SELECT = 8
-    expect(mockExecute).toHaveBeenCalledTimes(8);
+    // 3 CREATE TABLE + 1 CREATE INDEX + 1 CREATE UNIQUE INDEX + 2 CREATE INDEX + 1 ALTER delivery_log ADD claimed_at + 1 backfill SELECT = 9
+    expect(mockExecute).toHaveBeenCalledTimes(9);
   });
 
   it("emits CREATE INDEX for delivery_log_channel_status_attempt_idx", async () => {
@@ -425,7 +425,7 @@ describe("schema sync between ensureTables DDL and Drizzle schema", () => {
   // These MUST match the Drizzle definitions in shared/schema.ts exactly.
   const DDL_COLUMNS = {
     notification_channels: ["id", "monitor_id", "channel", "enabled", "config", "created_at", "updated_at"],
-    delivery_log: ["id", "monitor_id", "change_id", "channel", "status", "attempt", "response", "delivered_at", "created_at"],
+    delivery_log: ["id", "monitor_id", "change_id", "channel", "status", "attempt", "response", "delivered_at", "claimed_at", "created_at"],
     slack_connections: ["id", "user_id", "team_id", "team_name", "bot_token", "scope", "created_at", "updated_at"],
     monitor_conditions: ["id", "monitor_id", "type", "value", "group_index", "created_at"],
     automated_campaign_configs: ["id", "key", "name", "subject", "html_body", "text_body", "enabled", "last_run_at", "next_run_at", "created_at", "updated_at"],

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -58,10 +58,12 @@ export async function ensureApiKeysTable(): Promise<boolean> {
 
 /**
  * Ensures notification channel tables exist (notification_channels, delivery_log, slack_connections).
- * Without this, channel management routes return 503 "not available"
- * if schema:push has not been run after these tables were added to the schema.
+ * Returns true when schema is ready, false when provisioning failed — callers
+ * should gate traffic off the result because delivery_log.claimed_at is
+ * referenced by retry/recovery queries that would otherwise throw
+ * `column "claimed_at" does not exist` for the life of the process.
  */
-export async function ensureChannelTables(): Promise<void> {
+export async function ensureChannelTables(): Promise<boolean> {
   try {
     await db.execute(sql`
       CREATE TABLE IF NOT EXISTS notification_channels (
@@ -94,6 +96,9 @@ export async function ensureChannelTables(): Promise<void> {
     await db.execute(sql`CREATE INDEX IF NOT EXISTS delivery_log_channel_status_attempt_idx ON delivery_log(channel, status, created_at, attempt)`);
     // claimed_at column for multi-replica atomic claim coordination (see scheduler webhook retry cron).
     await db.execute(sql`ALTER TABLE delivery_log ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMP`);
+    // Recovery scans filter by (channel, status, claimed_at) to find rows stuck
+    // in 'processing' after a replica crash — index matches the query shape.
+    await db.execute(sql`CREATE INDEX IF NOT EXISTS delivery_log_channel_status_claimed_idx ON delivery_log(channel, status, claimed_at)`);
 
     await db.execute(sql`
       CREATE TABLE IF NOT EXISTS slack_connections (
@@ -109,8 +114,10 @@ export async function ensureChannelTables(): Promise<void> {
     `);
     // Backfill: encrypt existing plaintext webhook URLs
     await backfillNotificationChannelWebhookUrls();
+    return true;
   } catch (e) {
     console.error("Could not ensure notification channel tables:", e);
+    return false;
   }
 }
 

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -92,6 +92,8 @@ export async function ensureChannelTables(): Promise<void> {
     `);
     await db.execute(sql`CREATE INDEX IF NOT EXISTS delivery_log_monitor_created_idx ON delivery_log(monitor_id, created_at)`);
     await db.execute(sql`CREATE INDEX IF NOT EXISTS delivery_log_channel_status_attempt_idx ON delivery_log(channel, status, created_at, attempt)`);
+    // claimed_at column for multi-replica atomic claim coordination (see scheduler webhook retry cron).
+    await db.execute(sql`ALTER TABLE delivery_log ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMP`);
 
     await db.execute(sql`
       CREATE TABLE IF NOT EXISTS slack_connections (
@@ -502,20 +504,26 @@ async function backfillNotificationChannelWebhookUrls(): Promise<void> {
           const secretNeedsEncrypt = secret && !isValidEncryptedToken(secret);
           if (!urlNeedsEncrypt && !secretNeedsEncrypt) continue;
 
-          // Validate that plaintext values look like URLs/secrets before encrypting
-          // to avoid double-encrypting corrupted/already-encrypted data
+          // Validate each plaintext value independently before encrypting so a
+          // corrupted URL does not block encryption of a valid secret (and vice versa).
+          let urlSkipped = false;
+          let secretSkipped = false;
           if (urlNeedsEncrypt && url && !/^https?:\/\//i.test(url)) {
-            console.warn(`[ensureTables] Skipping notification channel ${row.id}: URL does not look like a valid http(s) URL`);
-            continue;
+            console.warn(`[ensureTables] Skipping URL encryption for notification channel ${row.id}: URL does not look like a valid http(s) URL`);
+            urlSkipped = true;
           }
           if (secretNeedsEncrypt && secret && !secret.startsWith("whsec_")) {
-            console.warn(`[ensureTables] Skipping notification channel ${row.id}: secret does not start with whsec_ prefix`);
-            continue;
+            console.warn(`[ensureTables] Skipping secret encryption for notification channel ${row.id}: secret does not start with whsec_ prefix`);
+            secretSkipped = true;
           }
 
+          const willEncryptUrl = urlNeedsEncrypt && !urlSkipped;
+          const willEncryptSecret = secretNeedsEncrypt && !secretSkipped;
+          if (!willEncryptUrl && !willEncryptSecret) continue;
+
           const newConfig = { ...cfg };
-          if (urlNeedsEncrypt) newConfig.url = encryptUrl(url);
-          if (secretNeedsEncrypt) newConfig.secret = encryptUrl(secret);
+          if (willEncryptUrl) newConfig.url = encryptUrl(url!);
+          if (willEncryptSecret) newConfig.secret = encryptUrl(secret!);
           await tx.execute(sql`UPDATE notification_channels SET config = ${JSON.stringify(newConfig)}::jsonb WHERE id = ${row.id}`);
           batchUpdated++;
         }

--- a/server/services/scheduler.test.ts
+++ b/server/services/scheduler.test.ts
@@ -29,6 +29,18 @@ vi.mock("../storage", () => ({
     getAllActiveMonitors: mockGetAllActiveMonitors,
     cleanupPollutedValues: mockCleanupPollutedValues,
     getPendingWebhookRetries: vi.fn().mockResolvedValue([]),
+    claimWebhookDeliveryForRetry: vi.fn().mockImplementation(async (id: number, attempt: number) => ({
+      id, attempt, channel: "webhook", status: "processing", createdAt: new Date(),
+      monitorId: id, changeId: id, response: null, deliveredAt: null, claimedAt: new Date(),
+    })),
+    claimDeliveryForRetry: vi.fn().mockImplementation(async (id: number, attempt: number, channel: string) => ({
+      id, attempt, channel, status: "processing", createdAt: new Date(),
+      monitorId: id, changeId: id, response: null, deliveredAt: null, claimedAt: new Date(),
+    })),
+    recoverStalledWebhookDeliveries: vi.fn().mockResolvedValue(0),
+    recoverStalledDeliveries: vi.fn().mockResolvedValue(0),
+    getPendingAutomationRetries: vi.fn().mockResolvedValue([]),
+    getAutomationSubscriptionById: vi.fn().mockResolvedValue(undefined),
     getMonitorChannels: vi.fn().mockResolvedValue([]),
     getMonitor: vi.fn().mockResolvedValue(undefined),
     getMonitorChanges: vi.fn().mockResolvedValue([]),
@@ -50,6 +62,12 @@ vi.mock("./notification", () => ({
 
 vi.mock("./webhookDelivery", () => ({
   deliver: (...args: any[]) => mockDeliverWebhook(...args),
+  buildWebhookPayload: (_m: any, c: any) => ({ event: "change.detected", id: c?.id ?? 0 }),
+}));
+
+vi.mock("./automationDelivery", () => ({
+  performAutomationDelivery: vi.fn().mockResolvedValue({ kind: "success", statusCode: 200 }),
+  finalizeAutomationRetry: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../db", () => ({
@@ -916,6 +934,11 @@ describe("withDbRetry and re-entrancy guards", () => {
     const callbacks = cronCallbacks["*/1 * * * *"];
     // Fire webhook cron (index 1) without awaiting — it blocks on getPendingWebhookRetries
     const firstRun = callbacks[1]();
+    // Flush microtasks so the first run progresses past recoverStalledWebhookDeliveries
+    // and is actually parked on the hanging getPendingWebhookRetries promise.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 
     // Fire webhook cron again while first is blocked — guard should skip it
     await callbacks[1]();
@@ -1026,7 +1049,7 @@ describe("webhook retry cumulative backoff", () => {
     await runCron("*/1 * * * *");
 
     expect(mockStorage.getMonitor).toHaveBeenCalledWith(1);
-    expect(mockStorage.updateDeliveryLog).toHaveBeenCalledWith(1, { status: "failed" });
+    expect(mockStorage.updateDeliveryLog).toHaveBeenCalledWith(1, expect.objectContaining({ status: "failed" }));
   });
 
   it("retries updateDeliveryLog with withDbRetry after successful webhook delivery", async () => {

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -2,7 +2,8 @@ import cron from "node-cron";
 import { storage, PENDING_WEBHOOK_RETRY_QUERY_LIMIT } from "../storage";
 import { checkMonitor, monitorsNeedingRetry } from "./scraper";
 import { processQueuedNotifications, processDigestCron } from "./notification";
-import { deliver as deliverWebhook, type WebhookConfig } from "./webhookDelivery";
+import { deliver as deliverWebhook, type WebhookConfig, buildWebhookPayload } from "./webhookDelivery";
+import { performAutomationDelivery, finalizeAutomationRetry } from "./automationDelivery";
 import { notificationTablesExist } from "./notificationReady";
 import { browserlessCircuitBreaker } from "./browserlessCircuitBreaker";
 import { ensureMonitorConditionsTable } from "./ensureTables";
@@ -76,7 +77,7 @@ export function waitForActiveChecks(timeoutMs: number): Promise<void> {
       if (activeChecks === 0 || Date.now() - start > timeoutMs) {
         resolve();
       } else {
-        setTimeout(check, 100);
+        trackTimeout(check, 100);
       }
     };
     check();
@@ -288,12 +289,27 @@ export async function startScheduler() {
     // backlogs within a few minutes after a server restart.
     const MAX_WEBHOOK_RETRIES_PER_TICK = 10;
     const WEBHOOK_BACKLOG_WARN_INTERVAL_MS = 15 * 60 * 1000;
+    // Rows claimed (status='processing') but not finalized within this window
+    // are presumed orphaned by a crashed replica and re-queued to 'pending'.
+    // Must exceed the webhook delivery timeout (5s) plus update latency by a
+    // comfortable margin so a still-in-flight delivery is never re-queued.
+    const WEBHOOK_CLAIM_RECOVERY_MS = 5 * 60 * 1000;
     let lastWebhookBacklogWarnAt = 0;
     let webhookCronRunning = false;
     cronTasks.push(cron.schedule("*/1 * * * *", async () => {
       if (webhookCronRunning) return;
       webhookCronRunning = true;
       try {
+        // Recover any rows stuck in 'processing' from a prior crashed replica.
+        try {
+          const recovered = await withDbRetry(() => storage.recoverStalledWebhookDeliveries(new Date(Date.now() - WEBHOOK_CLAIM_RECOVERY_MS)));
+          if (recovered > 0) {
+            console.warn(`[Webhook] Recovered ${recovered} stalled delivery row(s) from 'processing' back to 'pending'`);
+          }
+        } catch (recoveryErr) {
+          logSchedulerError("Webhook stalled-delivery recovery failed", recoveryErr);
+        }
+
         const pendingRetries = await withDbRetry(() => storage.getPendingWebhookRetries());
         if (pendingRetries.length >= PENDING_WEBHOOK_RETRY_QUERY_LIMIT) {
           const nowMs = Date.now();
@@ -318,28 +334,34 @@ export async function startScheduler() {
           const requiredWait = cumulativeBackoffMs[entry.attempt] || 155000;
           if (elapsed < requiredWait) continue;
 
+          // Atomic cross-replica claim: transition 'pending' → 'processing'.
+          // If another replica claimed this row between our SELECT and the
+          // UPDATE, the attempt counter won't match and we'll get null.
+          const claimed = await withDbRetry(() => storage.claimWebhookDeliveryForRetry(entry.id, entry.attempt));
+          if (!claimed) continue;
+
           const monitor = await storage.getMonitor(entry.monitorId);
           if (!monitor) {
-            await storage.updateDeliveryLog(entry.id, { status: "failed" });
+            await storage.updateDeliveryLog(entry.id, { status: "failed", claimedAt: null });
             continue;
           }
 
           const channels = await storage.getMonitorChannels(monitor.id);
           const webhookChannel = channels.find((c) => c.channel === "webhook" && c.enabled);
           if (!webhookChannel) {
-            await storage.updateDeliveryLog(entry.id, { status: "failed" });
+            await storage.updateDeliveryLog(entry.id, { status: "failed", claimedAt: null });
             continue;
           }
 
           const config = webhookChannel.config as unknown as WebhookConfig;
           if (!config?.url || !config?.secret) {
-            await storage.updateDeliveryLog(entry.id, { status: "failed" });
+            await storage.updateDeliveryLog(entry.id, { status: "failed", claimedAt: null });
             continue;
           }
 
           const change = await storage.getMonitorChangeById(entry.changeId);
           if (!change || change.monitorId !== monitor.id) {
-            await storage.updateDeliveryLog(entry.id, { status: "failed" });
+            await storage.updateDeliveryLog(entry.id, { status: "failed", claimedAt: null });
             continue;
           }
 
@@ -353,6 +375,7 @@ export async function startScheduler() {
                 status: "success",
                 attempt: nextAttempt,
                 deliveredAt: new Date(),
+                claimedAt: null,
                 response: { statusCode: result.statusCode } as Record<string, unknown>,
               }));
             } catch (dbErr) {
@@ -364,6 +387,7 @@ export async function startScheduler() {
             await withDbRetry(() => storage.updateDeliveryLog(entry.id, {
               status: "failed",
               attempt: nextAttempt,
+              claimedAt: null,
               response: { error: result.error } as Record<string, unknown>,
             }));
             console.error(`[Webhook] Delivery failed after all retries (monitorId=${monitor.id}, domain=${urlDomain})`);
@@ -371,6 +395,7 @@ export async function startScheduler() {
             await withDbRetry(() => storage.updateDeliveryLog(entry.id, {
               status: "pending",
               attempt: nextAttempt,
+              claimedAt: null,
               response: { error: result.error } as Record<string, unknown>,
             }));
             console.warn(`[Webhook] Delivery failed, scheduling retry (monitorId=${monitor.id}, attempt=${nextAttempt}, error=${result.error})`);
@@ -380,6 +405,108 @@ export async function startScheduler() {
         logSchedulerError("Webhook retry processing failed", error);
       } finally {
         webhookCronRunning = false;
+      }
+    }));
+
+    // Automation retry cron: every minute, re-attempt transient automation
+    // (Zapier REST Hooks etc.) deliveries that failed on first try (see #456).
+    // Mirrors the webhook retry cron's cumulative-backoff + atomic-claim pattern.
+    const MAX_AUTOMATION_RETRIES_PER_TICK = 10;
+    let automationCronRunning = false;
+    cronTasks.push(cron.schedule("*/1 * * * *", async () => {
+      if (automationCronRunning) return;
+      automationCronRunning = true;
+      try {
+        try {
+          const recovered = await withDbRetry(() => storage.recoverStalledDeliveries("automation", new Date(Date.now() - WEBHOOK_CLAIM_RECOVERY_MS)));
+          if (recovered > 0) {
+            console.warn(`[Automation] Recovered ${recovered} stalled delivery row(s) from 'processing' back to 'pending'`);
+          }
+        } catch (recoveryErr) {
+          logSchedulerError("Automation stalled-delivery recovery failed", recoveryErr);
+        }
+
+        const pendingRetries = await withDbRetry(() => storage.getPendingAutomationRetries());
+        const now = Date.now();
+        const cumulativeBackoffMs: Record<number, number> = { 1: 5000, 2: 35000, 3: 155000 };
+
+        let processed = 0;
+        for (const entry of pendingRetries) {
+          if (processed >= MAX_AUTOMATION_RETRIES_PER_TICK) break;
+
+          const elapsed = now - new Date(entry.createdAt).getTime();
+          const requiredWait = cumulativeBackoffMs[entry.attempt] || 155000;
+          if (elapsed < requiredWait) continue;
+
+          const claimed = await withDbRetry(() => storage.claimDeliveryForRetry(entry.id, entry.attempt, "automation"));
+          if (!claimed) continue;
+
+          const respMeta = (entry.response ?? {}) as { subscriptionId?: number; platform?: string };
+          const subscriptionId = respMeta.subscriptionId;
+          const platform = respMeta.platform ?? "unknown";
+
+          if (!subscriptionId) {
+            await storage.updateDeliveryLog(entry.id, { status: "failed", claimedAt: null });
+            continue;
+          }
+
+          const monitor = await storage.getMonitor(entry.monitorId);
+          const change = await storage.getMonitorChangeById(entry.changeId);
+          const sub = await storage.getAutomationSubscriptionById(subscriptionId);
+
+          if (!monitor || !change || change.monitorId !== monitor.id || !sub || !sub.active) {
+            await storage.updateDeliveryLog(entry.id, { status: "failed", claimedAt: null });
+            continue;
+          }
+
+          const payload = buildWebhookPayload(monitor, change);
+          const body = JSON.stringify({ ...payload, id: change.id });
+
+          const outcome = await performAutomationDelivery(sub.hookUrl, body);
+          processed++;
+          const nextAttempt = entry.attempt + 1;
+
+          if (outcome.kind === "success") {
+            await withDbRetry(() => storage.updateDeliveryLog(entry.id, {
+              status: "success",
+              attempt: nextAttempt,
+              deliveredAt: new Date(),
+              claimedAt: null,
+              response: { statusCode: outcome.statusCode } as Record<string, unknown>,
+            }));
+            await finalizeAutomationRetry(sub.id, monitor, platform, outcome);
+          } else if (outcome.kind === "persistent" || nextAttempt >= 3) {
+            await withDbRetry(() => storage.updateDeliveryLog(entry.id, {
+              status: "failed",
+              attempt: nextAttempt,
+              claimedAt: null,
+              response: {
+                subscriptionId: sub.id,
+                platform,
+                error: outcome.error,
+                transient: outcome.kind === "transient",
+              } as Record<string, unknown>,
+            }));
+            await finalizeAutomationRetry(sub.id, monitor, platform, outcome);
+          } else {
+            await withDbRetry(() => storage.updateDeliveryLog(entry.id, {
+              status: "pending",
+              attempt: nextAttempt,
+              claimedAt: null,
+              response: {
+                subscriptionId: sub.id,
+                platform,
+                error: outcome.error,
+                transient: true,
+              } as Record<string, unknown>,
+            }));
+            console.warn(`[Automation] Delivery failed, scheduling retry (monitorId=${monitor.id}, subscriptionId=${sub.id}, attempt=${nextAttempt}, error=${outcome.error})`);
+          }
+        }
+      } catch (error) {
+        logSchedulerError("Automation retry processing failed", error);
+      } finally {
+        automationCronRunning = false;
       }
     }));
   }

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -25,6 +25,9 @@ let activeChecks = 0;
 let schedulerStarted = false;
 const cronTasks: ReturnType<typeof cron.schedule>[] = [];
 const pendingTimeouts = new Set<ReturnType<typeof setTimeout>>();
+// Resolvers for any outstanding waitForActiveChecks() promises. stopScheduler
+// must call each one so shutdown cannot hang after the poll timer is cleared.
+const activeCheckWaiters = new Set<() => void>();
 
 
 /** Retry a DB operation once after a 1 s delay on transient connection errors. */
@@ -72,10 +75,19 @@ function trackTimeout(callback: () => void, delayMs: number): ReturnType<typeof 
  */
 export function waitForActiveChecks(timeoutMs: number): Promise<void> {
   return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      activeCheckWaiters.delete(finish);
+      resolve();
+    };
+    activeCheckWaiters.add(finish);
     const start = Date.now();
     const check = () => {
+      if (settled) return;
       if (activeChecks === 0 || Date.now() - start > timeoutMs) {
-        resolve();
+        finish();
       } else {
         trackTimeout(check, 100);
       }
@@ -583,6 +595,10 @@ export function stopScheduler(): void {
   cronTasks.length = 0;
   pendingTimeouts.forEach((handle) => { clearTimeout(handle); });
   pendingTimeouts.clear();
+  // Unblock any waitForActiveChecks waiters — their poll timer has just been
+  // cancelled above, so without explicit resolution the promise would hang.
+  activeCheckWaiters.forEach((finish) => finish());
+  activeCheckWaiters.clear();
   retryBackoff.clear();
   schedulerStarted = false;
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -440,7 +440,7 @@ export class DatabaseStorage implements IStorage {
       .limit(limit);
   }
 
-  async updateDeliveryLog(id: number, updates: Partial<Pick<DeliveryLogEntry, "status" | "attempt" | "response" | "deliveredAt">>): Promise<void> {
+  async updateDeliveryLog(id: number, updates: Partial<Pick<DeliveryLogEntry, "status" | "attempt" | "response" | "deliveredAt" | "claimedAt">>): Promise<void> {
     await db.update(deliveryLog).set(updates).where(eq(deliveryLog.id, id));
   }
 
@@ -453,6 +453,84 @@ export class DatabaseStorage implements IStorage {
       ))
       .orderBy(deliveryLog.createdAt)
       .limit(PENDING_WEBHOOK_RETRY_QUERY_LIMIT);
+  }
+
+  /**
+   * Atomically claim a single pending delivery for retry. Transitions
+   * `status` from 'pending' to 'processing' and stamps `claimed_at=now()`.
+   * The `attempt` filter acts as an optimistic concurrency check: if another
+   * replica already claimed the row (and thereby bumped `attempt`), the
+   * UPDATE matches zero rows and this returns null.
+   *
+   * This prevents multi-replica double-delivery of retries under Replit
+   * autoscale (see issue #458 for webhooks, #456 for automation).
+   */
+  async claimDeliveryForRetry(id: number, expectedAttempt: number, channel: string): Promise<DeliveryLogEntry | null> {
+    const [row] = await db.update(deliveryLog)
+      .set({ status: "processing", claimedAt: new Date() })
+      .where(and(
+        eq(deliveryLog.id, id),
+        eq(deliveryLog.channel, channel),
+        eq(deliveryLog.status, "pending"),
+        eq(deliveryLog.attempt, expectedAttempt),
+      ))
+      .returning();
+    return row ?? null;
+  }
+
+  /** @deprecated use claimDeliveryForRetry(id, attempt, "webhook") */
+  async claimWebhookDeliveryForRetry(id: number, expectedAttempt: number): Promise<DeliveryLogEntry | null> {
+    return this.claimDeliveryForRetry(id, expectedAttempt, "webhook");
+  }
+
+  /**
+   * Re-queue deliveries stuck in 'processing' for longer than the recovery
+   * threshold — happens when a replica crashed mid-delivery after claiming
+   * a row but before writing the final status. Safe to run every cron tick;
+   * idempotent.
+   */
+  async recoverStalledDeliveries(channel: string, olderThan: Date): Promise<number> {
+    const rows = await db.update(deliveryLog)
+      .set({ status: "pending", claimedAt: null })
+      .where(and(
+        eq(deliveryLog.channel, channel),
+        eq(deliveryLog.status, "processing"),
+        lt(deliveryLog.claimedAt, olderThan),
+      ))
+      .returning({ id: deliveryLog.id });
+    return rows.length;
+  }
+
+  /** @deprecated use recoverStalledDeliveries("webhook", olderThan) */
+  async recoverStalledWebhookDeliveries(olderThan: Date): Promise<number> {
+    return this.recoverStalledDeliveries("webhook", olderThan);
+  }
+
+  /**
+   * Pending retries for automation subscription deliveries (Zapier REST Hooks
+   * etc). Mirrors getPendingWebhookRetries but for channel='automation'.
+   */
+  async getPendingAutomationRetries(): Promise<DeliveryLogEntry[]> {
+    return await db.select().from(deliveryLog)
+      .where(and(
+        eq(deliveryLog.channel, "automation"),
+        eq(deliveryLog.status, "pending"),
+        lt(deliveryLog.attempt, 3)
+      ))
+      .orderBy(deliveryLog.createdAt)
+      .limit(PENDING_WEBHOOK_RETRY_QUERY_LIMIT);
+  }
+
+  async getAutomationSubscriptionById(id: number): Promise<AutomationSubscription | undefined> {
+    const [row] = await db.select().from(automationSubscriptions)
+      .where(eq(automationSubscriptions.id, id));
+    if (!row) return undefined;
+    try {
+      return { ...row, hookUrl: decryptUrl(row.hookUrl) };
+    } catch {
+      console.warn(`[Automation] getAutomationSubscriptionById(${id}): hookUrl decryption failed`);
+      return undefined;
+    }
   }
 
   async cleanupOldDeliveryLogs(olderThan: Date): Promise<number> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -73,6 +73,30 @@ export interface IStorage {
   resetAutomationSubscriptionFailures(id: number): Promise<void>;
   cleanupStaleAutomationSubscriptions(olderThan: Date): Promise<number>;
   getRecentChangesForMonitors(monitorIds: number[], limit: number): Promise<MonitorChange[]>;
+
+  // Delivery log retry primitives
+  addDeliveryLog(entry: {
+    monitorId: number;
+    changeId: number;
+    channel: string;
+    status: string;
+    attempt?: number;
+    response?: Record<string, unknown> | null;
+    deliveredAt?: Date | null;
+  }): Promise<DeliveryLogEntry>;
+  updateDeliveryLog(
+    id: number,
+    updates: Partial<Pick<DeliveryLogEntry, "status" | "attempt" | "response" | "deliveredAt" | "claimedAt">>,
+  ): Promise<void>;
+  getPendingWebhookRetries(): Promise<DeliveryLogEntry[]>;
+  claimDeliveryForRetry(id: number, expectedAttempt: number, channel: string): Promise<DeliveryLogEntry | null>;
+  /** @deprecated use claimDeliveryForRetry(id, attempt, "webhook") */
+  claimWebhookDeliveryForRetry(id: number, expectedAttempt: number): Promise<DeliveryLogEntry | null>;
+  recoverStalledDeliveries(channel: string, olderThan: Date): Promise<number>;
+  /** @deprecated use recoverStalledDeliveries("webhook", olderThan) */
+  recoverStalledWebhookDeliveries(olderThan: Date): Promise<number>;
+  getPendingAutomationRetries(): Promise<DeliveryLogEntry[]>;
+  getAutomationSubscriptionById(id: number): Promise<AutomationSubscription | undefined>;
 }
 
 export class DatabaseStorage implements IStorage {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -329,6 +329,8 @@ export const deliveryLog = pgTable("delivery_log", {
 }, (table) => ({
   monitorCreatedIdx: index("delivery_log_monitor_created_idx").on(table.monitorId, table.createdAt),
   channelStatusAttemptIdx: index("delivery_log_channel_status_attempt_idx").on(table.channel, table.status, table.createdAt, table.attempt),
+  // Supports the per-tick stalled-delivery recovery UPDATE: WHERE channel=? AND status='processing' AND claimed_at < ?
+  channelStatusClaimedIdx: index("delivery_log_channel_status_claimed_idx").on(table.channel, table.status, table.claimedAt),
 }));
 
 export const deliveryLogRelations = relations(deliveryLog, ({ one }) => ({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -315,11 +315,16 @@ export const deliveryLog = pgTable("delivery_log", {
   id: serial("id").primaryKey(),
   monitorId: integer("monitor_id").notNull().references(() => monitors.id, { onDelete: "cascade" }),
   changeId: integer("change_id").notNull().references(() => monitorChanges.id),
-  channel: text("channel").notNull(), // "email" | "webhook" | "slack"
-  status: text("status").notNull(), // "success" | "failed" | "pending"
+  channel: text("channel").notNull(), // "email" | "webhook" | "slack" | "automation"
+  status: text("status").notNull(), // "success" | "failed" | "pending" | "processing"
   attempt: integer("attempt").default(1).notNull(),
   response: jsonb("response").$type<Record<string, unknown> | null>(),
   deliveredAt: timestamp("delivered_at"),
+  // Timestamp of the current in-flight delivery attempt. Set atomically when a
+  // replica transitions status='pending' → 'processing'; cleared when the final
+  // status is written. Stale 'processing' rows (claimed_at older than the
+  // recovery threshold) are re-queued to 'pending' by the retry cron.
+  claimedAt: timestamp("claimed_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (table) => ({
   monitorCreatedIdx: index("delivery_log_monitor_created_idx").on(table.monitorId, table.createdAt),


### PR DESCRIPTION
## Summary

Fixes the five open bugs triaged during `/magicwand` Phase 6: one high-severity data-loss bug in the Zapier/automation delivery path, two medium-severity multi-replica / boot-hardening bugs in the webhook retry cron and the `ensure*` startup sequence, and two low-severity hygiene bugs in scheduler shutdown and webhook-URL backfill encryption. All fixes are on `server/services/*`, `server/storage.ts`, `server/routes.ts`, and `shared/schema.ts`; `npm run check`, `npm run test` (2334/2334), and `npm run build` all pass.

## Changes

### #456 (high) — Durable retry queue for automation (Zapier REST Hook) deliveries
- `server/services/automationDelivery.ts`: classify delivery failures as **transient** (5xx / 429 / 408 / network) vs **persistent** (4xx). Transient failures enqueue a `delivery_log` row (`channel='automation'`, `status='pending'`, `response={subscriptionId, platform, error, transient:true}`) and do **not** bump `consecutive_failures`. Persistent 4xx keeps the old behaviour (bump counter, potentially auto-deactivate). Adds exported `performAutomationDelivery` + `finalizeAutomationRetry` so the retry cron reuses the exact request/classification logic.
- `server/services/scheduler.ts`: new `*/1 * * * *` **automation retry cron** mirroring the webhook cron — atomic claim, cumulative backoff (5s / 35s / 155s), 3 attempts, stalled-row recovery. Caps at 10 retries per tick.
- `server/storage.ts`: new `getPendingAutomationRetries`, `getAutomationSubscriptionById` (with hookUrl decryption).
- `server/services/automationDelivery.test.ts`: replaced the two "increments failures on 500 / network" tests with new ones asserting transient failures queue a retry without bumping the counter; persistent 4xx still bumps it.

### #457 (medium) — 503 SCHEMA_NOT_READY gate on critical `ensure*` failures
- `server/routes.ts`: `ensureMonitorHealthColumns`, `ensureMonitorPendingRetryColumn`, `ensureNotificationQueueColumns`, and `ensureAutomationSubscriptionsTable` each contribute to a `criticalSchemaFailures` array. If any fail, log `CRITICAL:` and install a global `app.use("/api", ...)` handler that returns `503 { code: "SCHEMA_NOT_READY" }` for every API route until the server restarts. Avoids the silent per-route 500 storm that the original comment described as "health alerts will be disabled" but was actually a full outage.
- Chose the 503 middleware approach over `process.exit(1)` because it doesn't churn every route-test file's `ensureTables` mocks.

### #458 (medium) — Atomic cross-replica claim for webhook retries
- `shared/schema.ts`: new `claimed_at` column on `delivery_log` and expanded `status` doc comment (`pending` / `processing` / `success` / `failed`).
- `server/services/ensureTables.ts`: `ALTER TABLE delivery_log ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMP` (idempotent, added to `ensureChannelTables`).
- `server/storage.ts`: new `claimDeliveryForRetry(id, expectedAttempt, channel)` atomic UPDATE using `attempt` as an optimistic concurrency key — if another replica already claimed the row, zero rows match and we return `null`. Companion `recoverStalledDeliveries(channel, olderThan)` re-queues rows stuck in `processing` for >5 minutes (crashed-replica recovery). Legacy `claimWebhookDeliveryForRetry` / `recoverStalledWebhookDeliveries` kept as thin deprecated wrappers.
- `server/services/scheduler.ts`: webhook retry cron now (1) runs stalled-row recovery at the start of each tick, (2) atomically claims each row before delivering (skips if already claimed), (3) clears `claimed_at` in every final-state update.
- Fixes the autoscale double-delivery case described in the issue (same `X-FTC-Signature-256` + payload sent from two replicas at the same cron tick).

### #459 (low) — Cancellable shutdown poll
- `server/services/scheduler.ts`: `waitForActiveChecks` poll now goes through `trackTimeout` so `stopScheduler()` cancels the recursive 100 ms `setTimeout`, matching every other timer in the file.

### #460 (low) — Per-field skip in webhook-URL backfill encryption
- `server/services/ensureTables.ts`: `backfillNotificationChannelWebhookUrls` no longer `continue`s the whole row when one of `config.url` / `config.secret` fails validation. Instead, it sets per-field `urlSkipped` / `secretSkipped` flags so a broken URL doesn't block encryption of a valid `whsec_…` secret (and vice versa).

### Test wiring
- `server/services/ensureTables.test.ts`: expect 9 execute() calls (added `ALTER TABLE delivery_log ADD COLUMN claimed_at`); added `claimed_at` to the `delivery_log` column parity list.
- `server/services/scheduler.test.ts`: mock the new storage methods (`claimDeliveryForRetry`, `recoverStalledDeliveries`, `getPendingAutomationRetries`, `getAutomationSubscriptionById`) + mock `automationDelivery` module. Added a microtask-flush in the "skips webhook cron when previous iteration is still running" test so the assertion runs after the new recovery-sweep step completes and the cron is actually parked on the hanging `getPendingWebhookRetries`.
- `server/routes.conditions.test.ts`: `ensureMonitorHealthColumns` mock now returns `true` so the 503 gate isn't installed in this mock app.

## How to test

### Type check + unit tests
```bash
npm run check
npm run test
```
All 2334 tests should pass.

### #459 — shutdown poll cancellation
1. Start dev server, `curl` an endpoint that triggers a long-running monitor check so `activeChecks > 0`.
2. `kill -SIGTERM <pid>` and confirm the process exits within `SHUTDOWN_TIMEOUT_MS` without "unhandled error after resolution" warnings in the log.

### #460 — per-field skip
1. Seed a row: `INSERT INTO notification_channels (monitor_id, channel, config) VALUES (<id>, 'webhook', '{"url":"not-a-url","secret":"whsec_abc123plaintext","events":[]}'::jsonb);`
2. Restart the server. Expect log: `Skipping URL encryption for notification channel <id>: …`.
3. `SELECT config FROM notification_channels WHERE id = <id>;` — `secret` should now be encrypted (no longer the plaintext `whsec_abc123plaintext`); `url` remains plaintext.

### #457 — SCHEMA_NOT_READY gate
1. Before boot: `ALTER TABLE monitors DROP COLUMN health_alert_sent_at;` and revoke `ALTER` privilege on `monitors` from the app role.
2. Start the server. Expect log: `CRITICAL: required schema missing — monitor health columns. …`.
3. `curl -i http://localhost:5000/api/monitors` — expect `503 {"message":"Schema not ready: …","code":"SCHEMA_NOT_READY"}` instead of a 500.
4. Re-grant privilege, restart, and confirm normal 200s.

### #458 — cross-replica webhook retry claim
1. Point two local processes at the same Postgres (simulate autoscale).
2. Insert a pending webhook delivery: `INSERT INTO delivery_log (monitor_id, change_id, channel, status, attempt, created_at) VALUES (<id>,<id>,'webhook','pending',1, NOW() - INTERVAL '10 seconds');`
3. Wait for both replicas' cron tick. Exactly one should log `[Webhook] Delivered …`; the other should see 0 rows returned from `claimDeliveryForRetry` and skip.
4. Verify `delivery_log` shows a single final status transition (`success` / `pending` / `failed`), no double-writes.
5. Stalled-row recovery: `UPDATE delivery_log SET status='processing', claimed_at=NOW() - INTERVAL '6 minutes' WHERE id=<id>;`. Next cron tick should log `Recovered 1 stalled delivery row(s)` and re-process.

### #456 — automation retry queue
1. Subscribe a Zapier-style hook via `POST /api/zapier/v1/subscribe` pointing to a test endpoint that returns HTTP 503.
2. Trigger a change on the monitored URL (or `POST /api/monitors/:id/check`).
3. Expect log: `Automation delivery transient failure — queued for retry …` and a new `delivery_log` row with `channel='automation'`, `status='pending'`, `response.transient=true`.
4. Verify the subscription's `consecutive_failures` is still **0** (no auto-deactivation from one flaky event).
5. Switch the endpoint to return HTTP 200. Wait for the next automation-retry cron tick. Expect `[Automation] Delivered successfully` and the delivery_log row transitions to `status='success'`.
6. For persistent failure: switch the endpoint to HTTP 404 before triggering a change. Expect `consecutive_failures` to increment and no retry row in `delivery_log`.

https://claude.ai/code/session_016C3aevHcGMqJL7MaEHdqN9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now returns a clear 503 "Schema not ready" response when required database schema pieces are missing, preventing partial service behavior.
  * Automation deliveries gain retry handling with durable delivery logs and improved retry scheduling.

* **Bug Fixes**
  * Added recovery for stalled webhook and automation delivery attempts to resume pending work.
  * Improved distinction between transient and persistent delivery failures for more reliable retry and deactivation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->