### PR TITLE
Restore admin Event Log; drop warning-level to silence Browserless noise

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,6 +26,7 @@ import DocsZapier from "@/pages/DocsZapier";
 import DocsMake from "@/pages/DocsMake";
 import Privacy from "@/pages/Privacy";
 import Changelog from "@/pages/Changelog";
+import AdminErrors from "@/pages/AdminErrors";
 import AdminCampaigns from "@/pages/AdminCampaigns";
 import AdminCampaignDetail from "@/pages/AdminCampaignDetail";
 import ExtensionAuth from "@/pages/ExtensionAuth";
@@ -100,6 +101,7 @@ function Router() {
       <Route path="/privacy" component={Privacy} />
       <Route path="/extension-auth" component={ExtensionAuth} />
       <Route path="/developer" component={() => <ProtectedRoute component={Developer} requiredTier="power" />} />
+      <Route path="/admin/errors" component={() => <ProtectedRoute component={AdminErrors} />} />
       <Route path="/admin/campaigns" component={() => <ProtectedRoute component={AdminCampaigns} />} />
       <Route path="/admin/campaigns/:id" component={() => <ProtectedRoute component={AdminCampaignDetail} />} />
       {/* Fallback to 404 */}

--- a/client/src/components/DashboardNav.tsx
+++ b/client/src/components/DashboardNav.tsx
@@ -1,13 +1,27 @@
 import { useAuth } from "@/hooks/use-auth";
 import { NotificationEmailDialog } from "@/components/NotificationEmailDialog";
 import { Button } from "@/components/ui/button";
-import { LogOut, LayoutDashboard, HelpCircle, Send, BookOpen } from "lucide-react";
+import { LogOut, LayoutDashboard, FileWarning, HelpCircle, Send, BookOpen } from "lucide-react";
 import { Link, useLocation } from "wouter";
+import { useQuery } from "@tanstack/react-query";
 
 export default function DashboardNav() {
   const { user, logout } = useAuth();
   const [location] = useLocation();
   const isOnDashboard = location === "/" || location === "/dashboard";
+
+  const { data: errorCountData } = useQuery<{ count: number }>({
+    queryKey: ["/api/admin/error-logs/count"],
+    queryFn: async () => {
+      const res = await fetch("/api/admin/error-logs/count", { credentials: "include" });
+      if (!res.ok) return { count: 0 };
+      return res.json().catch(() => ({ count: 0 }));
+    },
+    enabled: user?.tier === "power",
+    refetchInterval: 60000,
+  });
+
+  const errorCount = errorCountData?.count ?? 0;
 
   if (!user) return null;
 
@@ -35,12 +49,29 @@ export default function DashboardNav() {
             </Button>
           )}
           {(user?.tier === "power") && (
-            <Button variant="ghost" size="sm" asChild className="text-muted-foreground">
-              <Link href="/admin/campaigns">
-                <Send className="h-4 w-4 mr-2" />
-                <span className="sr-only sm:not-sr-only">Campaigns</span>
-              </Link>
-            </Button>
+            <>
+              <Button variant="ghost" size="sm" asChild className="text-muted-foreground">
+                <Link href="/admin/campaigns">
+                  <Send className="h-4 w-4 mr-2" />
+                  <span className="hidden sm:inline">Campaigns</span>
+                </Link>
+              </Button>
+              <Button variant="ghost" size="sm" asChild className="text-muted-foreground relative" data-testid="link-error-logs">
+                <Link href="/admin/errors">
+                  <FileWarning className="h-4 w-4 mr-2" />
+                  <span className="hidden sm:inline">Event Log</span>
+                  {errorCount > 0 && (
+                    <span
+                      className="absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold px-1"
+                      data-testid="badge-error-count"
+                      aria-label={`${errorCount > 99 ? "99+" : errorCount} unresolved errors`}
+                    >
+                      {errorCount > 99 ? "99+" : errorCount}
+                    </span>
+                  )}
+                </Link>
+              </Button>
+            </>
           )}
           <Button variant="ghost" size="sm" asChild className="text-muted-foreground" data-testid="link-support">
             <Link href="/support">

--- a/client/src/components/UpgradeDialog.tsx
+++ b/client/src/components/UpgradeDialog.tsx
@@ -104,6 +104,7 @@ export function UpgradeDialog({ currentTier, children }: UpgradeDialogProps) {
         "JavaScript-rendered pages",
         "Fix Selector tool",
         "Full change history",
+        "Admin event log",
       ],
     };
     return features[tier] || [];

--- a/client/src/pages/AdminErrors.test.ts
+++ b/client/src/pages/AdminErrors.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import type { ErrorLog } from "@shared/schema";
+
+/**
+ * Regression test for issue #296: the AdminErrors page used snake_case
+ * property names (error_type, stack_trace, etc.) but Drizzle ORM returns
+ * camelCase. This test ensures the schema fields that AdminErrors.tsx
+ * relies on exist with the expected camelCase names.
+ */
+describe("AdminErrors ErrorLogEntry alignment with schema", () => {
+  // Build a minimal ErrorLog to verify the camelCase field names exist
+  // at the type level. If the schema ever renames these fields, this
+  // test will fail at compile time (npm run check) and at runtime.
+  const schemaKeys: (keyof ErrorLog)[] = [
+    "id",
+    "timestamp",
+    "level",
+    "source",
+    "errorType",
+    "message",
+    "stackTrace",
+    "context",
+    "resolved",
+    "firstOccurrence",
+    "occurrenceCount",
+  ];
+
+  it("schema exports camelCase field names used by AdminErrors", () => {
+    // These are the fields AdminErrors.tsx references — if the schema
+    // renames them, this array literal will cause a TS error and the
+    // runtime check below will also catch it.
+    expect(schemaKeys).toContain("errorType");
+    expect(schemaKeys).toContain("stackTrace");
+    expect(schemaKeys).toContain("firstOccurrence");
+    expect(schemaKeys).toContain("occurrenceCount");
+  });
+
+  it("schema does NOT export snake_case names", () => {
+    const keys = schemaKeys as string[];
+    expect(keys).not.toContain("error_type");
+    expect(keys).not.toContain("stack_trace");
+    expect(keys).not.toContain("first_occurrence");
+    expect(keys).not.toContain("occurrence_count");
+  });
+});

--- a/client/src/pages/AdminErrors.tsx
+++ b/client/src/pages/AdminErrors.tsx
@@ -390,7 +390,6 @@ export default function AdminErrors() {
               <SelectContent>
                 <SelectItem value="all">All levels</SelectItem>
                 <SelectItem value="error">Errors</SelectItem>
-                <SelectItem value="warning">Warnings</SelectItem>
                 <SelectItem value="info">Info</SelectItem>
               </SelectContent>
             </Select>

--- a/client/src/pages/AdminErrors.tsx
+++ b/client/src/pages/AdminErrors.tsx
@@ -1,0 +1,813 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+import { formatDate, formatDateTime } from "@/lib/date-format";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { buildBatchDeletePayload } from "./adminErrorsUtils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
+import { XCircle, AlertTriangle, Info, ArrowLeft, RefreshCw, Globe, Mail, Users, Trash2, Loader2, X } from "lucide-react";
+import { Link } from "wouter";
+import { ERROR_LOG_SOURCES } from "@shared/routes";
+import type { ErrorLog } from "@shared/schema";
+import { queryClient } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { usePageTitle } from "@/hooks/use-page-title";
+import { ToastAction } from "@/components/ui/toast";
+
+/** JSON-serialized ErrorLog — Date fields become strings over the wire. */
+type ErrorLogEntry = {
+  [K in keyof ErrorLog]: ErrorLog[K] extends Date ? string : ErrorLog[K] extends Date | null ? string | null : ErrorLog[K];
+};
+
+interface BrowserlessUsageData {
+  systemUsage: number;
+  systemCap: number;
+  tierCaps: { free: number; pro: number; power: number };
+  topConsumers: Array<{ userId: string; callCount: number }>;
+  tierBreakdown: Record<string, { users: number; totalCalls: number }>;
+  resetDate: string;
+}
+
+interface ResendUsageData {
+  dailyUsage: number;
+  dailyCap: number;
+  monthlyUsage: number;
+  monthlyCap: number;
+  failedThisMonth: number;
+  recentHistory: Array<{ date: string; count: number }>;
+  resetDate: string;
+}
+
+interface UserOverviewEntry {
+  id: string;
+  email: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  tier: string;
+  created_at: string | null;
+  updated_at: string | null;
+  monitor_count: number;
+  active_monitor_count: number;
+  last_activity: string | null;
+  browserless_usage_this_month: number;
+  emails_sent_this_month: number;
+}
+
+const levelConfig: Record<string, { icon: typeof XCircle; variant: "destructive" | "secondary" | "outline"; label: string }> = {
+  error: { icon: XCircle, variant: "destructive", label: "Error" },
+  warning: { icon: AlertTriangle, variant: "secondary", label: "Warning" },
+  info: { icon: Info, variant: "outline", label: "Info" },
+};
+
+const UNDO_TIMEOUT_MS = 5000;
+
+export default function AdminErrors() {
+  usePageTitle("Admin: Errors — FetchTheChange");
+  const [levelFilter, setLevelFilter] = useState<string>("all");
+  const [sourceFilter, setSourceFilter] = useState<string>("all");
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [selectAll, setSelectAll] = useState(false);
+  const [excludedIds, setExcludedIds] = useState<Set<number>>(new Set());
+  const { toast, dismiss } = useToast();
+
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeToastRef = useRef<string | null>(null);
+  const pendingFinalizeRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    };
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+    setSelectAll(false);
+    setExcludedIds(new Set());
+  }, []);
+
+  const { data: browserlessData } = useQuery<BrowserlessUsageData>({
+    queryKey: ["/api/admin/browserless-usage"],
+    queryFn: async () => {
+      const res = await fetch("/api/admin/browserless-usage", { credentials: "include" });
+      if (!res.ok) return null;
+      return res.json().catch(() => {
+        throw new Error("Unexpected response format from server");
+      });
+    },
+    refetchInterval: 60000,
+  });
+
+  const { data: resendData } = useQuery<ResendUsageData>({
+    queryKey: ["/api/admin/resend-usage"],
+    queryFn: async () => {
+      const res = await fetch("/api/admin/resend-usage", { credentials: "include" });
+      if (!res.ok) return null;
+      return res.json().catch(() => {
+        throw new Error("Unexpected response format from server");
+      });
+    },
+    refetchInterval: 60000,
+  });
+
+  const { data: usersOverview } = useQuery<UserOverviewEntry[]>({
+    queryKey: ["/api/admin/users-overview"],
+    queryFn: async () => {
+      const res = await fetch("/api/admin/users-overview", { credentials: "include" });
+      if (res.status === 403) {
+        const err = new Error("forbidden");
+        (err as any).status = 403;
+        throw err;
+      }
+      if (!res.ok) return null;
+      return res.json().catch(() => {
+        throw new Error("Unexpected response format from server");
+      });
+    },
+    retry: (_count, error) => (error as any)?.status !== 403,
+    refetchInterval: (query) =>
+      (query.state.error as any)?.status === 403 ? false : 60000,
+  });
+
+  const queryKey = ["/api/admin/error-logs", levelFilter, sourceFilter];
+  const { data: logs = [], isLoading, isFetching, isError } = useQuery<ErrorLogEntry[]>({
+    queryKey,
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (levelFilter !== "all") params.set("level", levelFilter);
+      if (sourceFilter !== "all") params.set("source", sourceFilter);
+      params.set("limit", "100");
+      const res = await fetch(`/api/admin/error-logs?${params}`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to fetch logs");
+      return res.json().catch(() => {
+        throw new Error("Unexpected response format from server");
+      });
+    },
+    refetchInterval: 30000,
+  });
+
+  const invalidateAll = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/error-logs"] });
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/error-logs/count"] });
+  }, []);
+
+  const finalizeMutation = useMutation({
+    mutationFn: async (): Promise<{ count: number; hasMore?: boolean }> => {
+      const res = await fetch("/api/admin/error-logs/finalize", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to finalize deletion");
+      return res.json().catch(() => {
+        throw new Error("Unexpected response format from server");
+      });
+    },
+    onSuccess: (data) => {
+      invalidateAll();
+      clearSelection();
+      if (data.hasMore) {
+        toast({ title: "More entries remain", description: "Some soft-deleted entries were not finalized. Repeat to finalize more." });
+      }
+    },
+    onError: () => {
+      toast({ title: "Error", description: "Failed to permanently delete entries", variant: "destructive" });
+    },
+  });
+
+  const restoreMutation = useMutation({
+    mutationFn: async (): Promise<{ count: number; hasMore?: boolean }> => {
+      const res = await fetch("/api/admin/error-logs/restore", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to restore entries");
+      return res.json().catch(() => {
+        throw new Error("Unexpected response format from server");
+      });
+    },
+    onSuccess: (data) => {
+      invalidateAll();
+      if (data.hasMore) {
+        toast({ title: "More entries remain", description: "Some soft-deleted entries were not restored. Repeat to restore more." });
+      }
+    },
+    onError: () => {
+      toast({ title: "Error", description: "Failed to restore entries", variant: "destructive" });
+    },
+  });
+
+  const finalizePrevious = useCallback(() => {
+    if (undoTimerRef.current) {
+      clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+    if (activeToastRef.current) {
+      dismiss(activeToastRef.current);
+      activeToastRef.current = null;
+    }
+    if (pendingFinalizeRef.current) {
+      pendingFinalizeRef.current = false;
+      finalizeMutation.mutate();
+    }
+  }, [dismiss, finalizeMutation]);
+
+  const showUndoToast = useCallback((count: number) => {
+    pendingFinalizeRef.current = true;
+
+    const { id } = toast({
+      title: `${count} ${count === 1 ? "entry" : "entries"} deleted`,
+      action: (
+        <ToastAction altText="Undo" onClick={() => {
+          if (undoTimerRef.current) {
+            clearTimeout(undoTimerRef.current);
+            undoTimerRef.current = null;
+          }
+          pendingFinalizeRef.current = false;
+          activeToastRef.current = null;
+          restoreMutation.mutate();
+        }}>
+          Undo
+        </ToastAction>
+      ),
+      duration: UNDO_TIMEOUT_MS,
+    });
+
+    activeToastRef.current = id;
+
+    undoTimerRef.current = setTimeout(() => {
+      undoTimerRef.current = null;
+      activeToastRef.current = null;
+      pendingFinalizeRef.current = false;
+      finalizeMutation.mutate();
+    }, UNDO_TIMEOUT_MS);
+  }, [toast, restoreMutation, finalizeMutation]);
+
+  const batchDeleteMutation = useMutation({
+    mutationFn: async (body: { ids?: number[]; filters?: { level?: string; source?: string }; excludeIds?: number[] }) => {
+      const res = await fetch("/api/admin/error-logs/batch-delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.message || "Failed to delete entries");
+      }
+      return res.json().catch(() => {
+        throw new Error("Unexpected response format from server");
+      }) as Promise<{ count: number; hasMore?: boolean }>;
+    },
+    onSuccess: (data) => {
+      invalidateAll();
+      clearSelection();
+      showUndoToast(data.count);
+      if (data.hasMore) {
+        toast({ title: "More entries remain", description: "Some matching entries were not deleted. Repeat to delete more." });
+      }
+    },
+    onError: (error: Error) => {
+      toast({ title: "Error", description: error.message, variant: "destructive" });
+    },
+  });
+
+  const handleSingleDelete = useCallback((id: number) => {
+    finalizePrevious();
+    batchDeleteMutation.mutate({ ids: [id] });
+  }, [finalizePrevious, batchDeleteMutation]);
+
+  const handleBatchDelete = useCallback(() => {
+    const payload = buildBatchDeletePayload({
+      selectAll, selectedIds, excludedIds, levelFilter, sourceFilter, logs,
+    });
+    if (!payload) return;
+    finalizePrevious();
+    batchDeleteMutation.mutate(payload);
+  }, [finalizePrevious, batchDeleteMutation, selectAll, selectedIds, excludedIds, levelFilter, sourceFilter, logs]);
+
+  const selectionCount = selectAll ? logs.length - excludedIds.size : selectedIds.size;
+  const hasSelection = selectionCount > 0;
+
+  const isEntrySelected = useCallback((id: number) => {
+    if (selectAll) return !excludedIds.has(id);
+    return selectedIds.has(id);
+  }, [selectAll, excludedIds, selectedIds]);
+
+  const toggleEntry = useCallback((id: number) => {
+    if (selectAll) {
+      setExcludedIds(prev => {
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return next;
+      });
+    } else {
+      setSelectedIds(prev => {
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return next;
+      });
+    }
+  }, [selectAll]);
+
+  const toggleSelectAll = useCallback((checked: boolean) => {
+    if (checked) {
+      setSelectAll(true);
+      setExcludedIds(new Set());
+      setSelectedIds(new Set());
+    } else {
+      clearSelection();
+    }
+  }, [clearSelection]);
+
+  const allVisibleSelected = selectAll
+    ? excludedIds.size === 0
+    : logs.length > 0 && logs.every(l => selectedIds.has(l.id));
+
+  const someVisibleSelected = selectAll
+    ? excludedIds.size > 0 && excludedIds.size < logs.length
+    : selectedIds.size > 0 && !allVisibleSelected;
+
+  const formatTimestamp = (ts: string) => {
+    return formatDateTime(ts);
+  };
+
+  const getTierBadgeClass = (tier: string) => {
+    switch (tier) {
+      case "power": return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300";
+      case "pro": return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+      default: return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300";
+    }
+  };
+
+  const formatRelativeTime = (dateStr: string | null) => {
+    if (!dateStr) return "Never";
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 1) return "Just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 30) return `${diffDays}d ago`;
+    return formatDate(date);
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="icon" asChild data-testid="button-back-dashboard">
+              <Link href="/dashboard">
+                <ArrowLeft className="h-4 w-4" />
+              </Link>
+            </Button>
+            <h1 className="text-2xl font-bold" data-testid="text-admin-title">Event Log</h1>
+            <Badge variant="secondary">{logs.length} entries</Badge>
+          </div>
+          <div className="flex items-center gap-3">
+            <Select value={levelFilter} onValueChange={setLevelFilter} data-testid="select-level-filter">
+              <SelectTrigger className="w-[140px]" data-testid="button-level-filter">
+                <SelectValue placeholder="Filter level" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All levels</SelectItem>
+                <SelectItem value="error">Errors</SelectItem>
+                <SelectItem value="warning">Warnings</SelectItem>
+                <SelectItem value="info">Info</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={sourceFilter} onValueChange={setSourceFilter} data-testid="select-source-filter">
+              <SelectTrigger className="w-[140px]" data-testid="button-source-filter">
+                <SelectValue placeholder="Filter category" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All categories</SelectItem>
+                {ERROR_LOG_SOURCES.map((source) => (
+                  <SelectItem key={source} value={source}>
+                    {source.charAt(0).toUpperCase() + source.slice(1)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => {
+                queryClient.invalidateQueries({ queryKey });
+                queryClient.invalidateQueries({ queryKey: ["/api/admin/browserless-usage"] });
+                queryClient.invalidateQueries({ queryKey: ["/api/admin/resend-usage"] });
+                queryClient.invalidateQueries({ queryKey: ["/api/admin/users-overview"] });
+              }}
+              disabled={isFetching}
+              data-testid="button-refresh-logs"
+            >
+              <RefreshCw className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+            </Button>
+          </div>
+        </div>
+
+        {usersOverview && usersOverview.length > 0 && (
+          <Card className="mb-6" data-testid="card-users-overview">
+            <CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Users className="h-4 w-4" />
+                User Overview
+              </CardTitle>
+              <span className="text-xs text-muted-foreground">
+                {usersOverview.length} user{usersOverview.length !== 1 ? "s" : ""}
+              </span>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[200px]">User</TableHead>
+                      <TableHead>Tier</TableHead>
+                      <TableHead className="text-right">Monitors</TableHead>
+                      <TableHead className="text-right">Browserless</TableHead>
+                      <TableHead className="text-right">Emails</TableHead>
+                      <TableHead className="text-right">Last Active</TableHead>
+                      <TableHead className="text-right">Joined</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {usersOverview.map((u) => (
+                      <TableRow key={u.id} data-testid={`row-user-${u.id}`}>
+                        <TableCell className="font-medium">
+                          <div className="flex flex-col">
+                            <span className="truncate max-w-[180px]">
+                              {u.first_name || u.last_name
+                                ? `${u.first_name || ""} ${u.last_name || ""}`.trim()
+                                : u.email || u.id.slice(0, 8) + "..."}
+                            </span>
+                            {(u.first_name || u.last_name) && u.email && (
+                              <span className="text-xs text-muted-foreground truncate max-w-[180px]">
+                                {u.email}
+                              </span>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="outline"
+                            className={getTierBadgeClass(u.tier)}
+                            data-testid={`badge-tier-${u.id}`}
+                          >
+                            {u.tier}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right font-mono">
+                          <span data-testid={`text-monitors-${u.id}`}>
+                            {u.active_monitor_count}/{u.monitor_count}
+                          </span>
+                          <span className="text-xs text-muted-foreground ml-1">active</span>
+                        </TableCell>
+                        <TableCell className="text-right font-mono" data-testid={`text-browserless-${u.id}`}>
+                          {u.browserless_usage_this_month}
+                        </TableCell>
+                        <TableCell className="text-right font-mono" data-testid={`text-emails-${u.id}`}>
+                          {u.emails_sent_this_month}
+                        </TableCell>
+                        <TableCell className="text-right text-xs text-muted-foreground">
+                          {formatRelativeTime(u.last_activity)}
+                        </TableCell>
+                        <TableCell className="text-right text-xs text-muted-foreground">
+                          {u.created_at
+                            ? formatDate(u.created_at)
+                            : "\u2014"}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {browserlessData && (
+          <Card className="mb-6" data-testid="card-browserless-usage">
+            <CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Globe className="h-4 w-4" />
+                Browserless Usage
+              </CardTitle>
+              <span className="text-xs text-muted-foreground">Resets {browserlessData.resetDate}</span>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <div className="flex justify-between text-sm mb-1">
+                  <span data-testid="text-system-usage-label">System Usage</span>
+                  <span className="font-mono" data-testid="text-system-usage-value">
+                    {browserlessData.systemUsage} / {browserlessData.systemCap}
+                  </span>
+                </div>
+                <div className="h-2 rounded-full bg-secondary overflow-hidden" data-testid="progress-system-usage">
+                  <div
+                    className={`h-full rounded-full transition-all ${
+                      browserlessData.systemUsage / browserlessData.systemCap > 0.95
+                        ? "bg-destructive"
+                        : browserlessData.systemUsage / browserlessData.systemCap > 0.8
+                        ? "bg-orange-500 dark:bg-orange-400"
+                        : "bg-primary"
+                    }`}
+                    style={{ width: `${Math.min(100, (browserlessData.systemUsage / browserlessData.systemCap) * 100)}%` }}
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                {(["pro", "power"] as const).map((tier) => {
+                  const data = browserlessData.tierBreakdown[tier];
+                  return (
+                    <div key={tier} className="text-center" data-testid={`text-tier-breakdown-${tier}`}>
+                      <p className="text-xs text-muted-foreground capitalize">{tier}</p>
+                      <p className="text-lg font-semibold">{data?.totalCalls ?? 0}</p>
+                      <p className="text-xs text-muted-foreground">{data?.users ?? 0} users</p>
+                    </div>
+                  );
+                })}
+                <div className="text-center" data-testid="text-tier-caps">
+                  <p className="text-xs text-muted-foreground">Per-User Caps</p>
+                  <p className="text-xs mt-1">Pro: {browserlessData.tierCaps.pro}</p>
+                  <p className="text-xs">Power: {browserlessData.tierCaps.power}</p>
+                </div>
+              </div>
+              {browserlessData.topConsumers.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground mb-2">Top Consumers</p>
+                  <div className="space-y-1">
+                    {browserlessData.topConsumers.slice(0, 5).map((c, i) => (
+                      <div key={c.userId} className="flex justify-between text-xs" data-testid={`text-consumer-${c.userId}`}>
+                        <span className="text-muted-foreground truncate max-w-[200px]">
+                          {i + 1}. {c.userId}
+                        </span>
+                        <span className="font-mono">{c.callCount} calls</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {resendData && (
+          <Card className="mb-6" data-testid="card-resend-usage">
+            <CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Mail className="h-4 w-4" />
+                Resend Email Usage
+              </CardTitle>
+              <span className="text-xs text-muted-foreground">Resets {resendData.resetDate}</span>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span data-testid="text-resend-daily-label">Daily</span>
+                    <span className="font-mono" data-testid="text-resend-daily-value">
+                      {resendData.dailyUsage} / {resendData.dailyCap}
+                    </span>
+                  </div>
+                  <div className="h-2 rounded-full bg-secondary overflow-hidden" data-testid="progress-resend-daily">
+                    <div
+                      className={`h-full rounded-full transition-all ${
+                        resendData.dailyUsage / resendData.dailyCap > 0.95
+                          ? "bg-destructive"
+                          : resendData.dailyUsage / resendData.dailyCap > 0.8
+                          ? "bg-orange-500 dark:bg-orange-400"
+                          : "bg-primary"
+                      }`}
+                      style={{ width: `${Math.min(100, (resendData.dailyUsage / resendData.dailyCap) * 100)}%` }}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span data-testid="text-resend-monthly-label">Monthly</span>
+                    <span className="font-mono" data-testid="text-resend-monthly-value">
+                      {resendData.monthlyUsage} / {resendData.monthlyCap}
+                    </span>
+                  </div>
+                  <div className="h-2 rounded-full bg-secondary overflow-hidden" data-testid="progress-resend-monthly">
+                    <div
+                      className={`h-full rounded-full transition-all ${
+                        resendData.monthlyUsage / resendData.monthlyCap > 0.95
+                          ? "bg-destructive"
+                          : resendData.monthlyUsage / resendData.monthlyCap > 0.8
+                          ? "bg-orange-500 dark:bg-orange-400"
+                          : "bg-primary"
+                      }`}
+                      style={{ width: `${Math.min(100, (resendData.monthlyUsage / resendData.monthlyCap) * 100)}%` }}
+                    />
+                  </div>
+                </div>
+              </div>
+              {resendData.failedThisMonth > 0 && (
+                <div className="text-xs text-muted-foreground" data-testid="text-resend-failed">
+                  {resendData.failedThisMonth} failed this month
+                </div>
+              )}
+              {resendData.recentHistory.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground mb-2">Last 7 Days</p>
+                  <div className="flex items-end gap-1 h-12">
+                    {resendData.recentHistory.slice().reverse().map((day) => {
+                      const maxCount = Math.max(...resendData.recentHistory.map(d => d.count), 1);
+                      const heightPct = Math.max(4, (day.count / maxCount) * 100);
+                      return (
+                        <div key={day.date} className="flex-1 flex flex-col items-center gap-1" data-testid={`bar-resend-${day.date}`}>
+                          <div
+                            className="w-full bg-primary/60 rounded-sm min-w-[4px]"
+                            style={{ height: `${heightPct}%` }}
+                            title={`${day.date}: ${day.count} emails`}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div className="flex gap-1 mt-1">
+                    {resendData.recentHistory.slice().reverse().map((day) => (
+                      <div key={day.date} className="flex-1 text-center">
+                        <span className="text-[10px] text-muted-foreground">{day.count}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {isLoading ? (
+          <div className="text-center py-12 text-muted-foreground">Loading logs...</div>
+        ) : isError ? (
+          <div className="text-center py-12 text-muted-foreground">Failed to load event log.</div>
+        ) : logs.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-muted-foreground">
+              No log entries found.
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <div className="flex items-center gap-3 mb-3">
+              <Checkbox
+                checked={allVisibleSelected ? true : someVisibleSelected ? "indeterminate" : false}
+                onCheckedChange={(checked) => toggleSelectAll(!!checked)}
+                data-testid="checkbox-select-all"
+                aria-label="Select all entries"
+              />
+              <span className="text-sm text-muted-foreground">
+                {selectAll ? `All ${logs.length} visible entries selected` : "Select all"}
+              </span>
+            </div>
+            <div className="space-y-2">
+              {logs.map((log) => {
+                const config = levelConfig[log.level] || levelConfig.info;
+                const Icon = config.icon;
+                const isExpanded = expandedId === log.id;
+                const checked = isEntrySelected(log.id);
+
+                return (
+                  <Card
+                    key={log.id}
+                    className={`hover-elevate cursor-pointer ${checked ? "ring-1 ring-primary/50" : ""}`}
+                    onClick={() => setExpandedId(isExpanded ? null : log.id)}
+                    data-testid={`card-log-${log.id}`}
+                  >
+                    <CardContent className="py-3 px-4">
+                      <div className="flex flex-wrap items-start gap-3">
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={() => toggleEntry(log.id)}
+                          onClick={(e) => e.stopPropagation()}
+                          className="mt-0.5 shrink-0"
+                          data-testid={`checkbox-log-${log.id}`}
+                          aria-label={`Select log entry ${log.id}`}
+                        />
+                        <Icon className={`h-4 w-4 mt-0.5 shrink-0 ${log.level === "error" ? "text-destructive" : log.level === "warning" ? "text-yellow-500" : "text-muted-foreground"}`} />
+                        <div className="flex-1 min-w-0">
+                          <div className="flex flex-wrap items-center gap-2 mb-1">
+                            <Badge variant={config.variant} data-testid={`badge-level-${log.id}`}>
+                              {config.label}
+                            </Badge>
+                            <Badge variant="outline" data-testid={`badge-source-${log.id}`}>
+                              {log.source}
+                            </Badge>
+                            {log.errorType && (
+                              <span className="text-xs text-muted-foreground">{log.errorType}</span>
+                            )}
+                            {log.occurrenceCount > 1 && (
+                              <Badge variant="secondary" className="text-[10px] px-1.5 py-0" data-testid={`badge-count-${log.id}`}>
+                                {log.occurrenceCount}x
+                              </Badge>
+                            )}
+                            <span className="text-xs text-muted-foreground ml-auto shrink-0">
+                              {log.occurrenceCount > 1 && log.firstOccurrence
+                                ? `${formatTimestamp(log.firstOccurrence)} \u2014 ${formatTimestamp(log.timestamp)}`
+                                : formatTimestamp(log.timestamp)}
+                            </span>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
+                              aria-label={`Delete log entry ${log.id}`}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleSingleDelete(log.id);
+                              }}
+                              disabled={batchDeleteMutation.isPending}
+                              data-testid={`button-delete-log-${log.id}`}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                          <p className="text-sm truncate" data-testid={`text-message-${log.id}`}>
+                            {log.message}
+                          </p>
+                          {isExpanded && (
+                            <div className="mt-3 space-y-2" onClick={(e) => e.stopPropagation()}>
+                              {log.stackTrace && (
+                                <div>
+                                  <p className="text-xs font-medium text-muted-foreground mb-1">Stack Trace</p>
+                                  <pre className="text-xs bg-secondary/50 p-3 rounded-md overflow-x-auto max-h-48 overflow-y-auto select-text">
+                                    {log.stackTrace}
+                                  </pre>
+                                </div>
+                              )}
+                              {log.context != null && (
+                                <div>
+                                  <p className="text-xs font-medium text-muted-foreground mb-1">Context</p>
+                                  <pre className="text-xs bg-secondary/50 p-3 rounded-md overflow-x-auto max-h-32 overflow-y-auto select-text">
+                                    {JSON.stringify(log.context, null, 2)}
+                                  </pre>
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+
+      {hasSelection && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50" data-testid="floating-action-bar">
+          <div className="flex items-center gap-3 bg-background border rounded-lg shadow-lg px-4 py-3">
+            <span className="text-sm font-medium" data-testid="text-selection-count">
+              {selectAll ? `${selectionCount} visible entries` : `${selectionCount} selected`}
+            </span>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleBatchDelete}
+              disabled={batchDeleteMutation.isPending}
+              data-testid="button-delete-selected"
+            >
+              {batchDeleteMutation.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5 mr-1" />
+              )}
+              Delete selected
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearSelection}
+              data-testid="button-clear-selection"
+            >
+              <X className="h-3.5 w-3.5 mr-1" />
+              Clear
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -69,6 +69,7 @@ const plans = [
       "JavaScript-rendered pages",
       "Fix Selector tool",
       "Full change history",
+      "Admin event log",
       "REST API access (300 req/min)",
       "Zapier integration (7,000+ apps, no server required)",
     ],

--- a/client/src/pages/adminErrorsUtils.test.ts
+++ b/client/src/pages/adminErrorsUtils.test.ts
@@ -50,10 +50,10 @@ describe("buildBatchDeletePayload", () => {
     const result = buildBatchDeletePayload({
       ...defaults,
       selectAll: true,
-      levelFilter: "warning",
+      levelFilter: "info",
       sourceFilter: "api",
     });
-    expect(result).toEqual({ filters: { level: "warning", source: "api" } });
+    expect(result).toEqual({ filters: { level: "info", source: "api" } });
   });
 
   it("includes excludeIds when filters are active and entries are excluded", () => {

--- a/client/src/pages/adminErrorsUtils.test.ts
+++ b/client/src/pages/adminErrorsUtils.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { buildBatchDeletePayload } from "./adminErrorsUtils";
+
+const defaults = {
+  selectAll: false,
+  selectedIds: new Set<number>(),
+  excludedIds: new Set<number>(),
+  levelFilter: "all",
+  sourceFilter: "all",
+  logs: [{ id: 1 }, { id: 2 }, { id: 3 }],
+};
+
+describe("buildBatchDeletePayload", () => {
+  // --- individual selection (selectAll = false) ---
+
+  it("returns ids when individual entries are selected", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectedIds: new Set([1, 3]),
+    });
+    expect(result).toEqual({ ids: [1, 3] });
+  });
+
+  it("returns null when no individual entries are selected", () => {
+    const result = buildBatchDeletePayload(defaults);
+    expect(result).toBeNull();
+  });
+
+  // --- selectAll with filters ---
+
+  it("returns filter-based payload when level filter is active", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+      levelFilter: "error",
+    });
+    expect(result).toEqual({ filters: { level: "error" } });
+  });
+
+  it("returns filter-based payload when source filter is active", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+      sourceFilter: "scheduler",
+    });
+    expect(result).toEqual({ filters: { source: "scheduler" } });
+  });
+
+  it("returns filter-based payload with both filters", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+      levelFilter: "warning",
+      sourceFilter: "api",
+    });
+    expect(result).toEqual({ filters: { level: "warning", source: "api" } });
+  });
+
+  it("includes excludeIds when filters are active and entries are excluded", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+      levelFilter: "error",
+      excludedIds: new Set([2]),
+    });
+    expect(result).toEqual({ filters: { level: "error" }, excludeIds: [2] });
+  });
+
+  it("omits excludeIds when the set is empty", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+      levelFilter: "error",
+      excludedIds: new Set(),
+    });
+    expect(result).toEqual({ filters: { level: "error" } });
+    expect(result).not.toHaveProperty("excludeIds");
+  });
+
+  // --- selectAll without filters (the bug fix) ---
+
+  it("falls back to visible log ids when no filters are active", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+    });
+    expect(result).toEqual({ ids: [1, 2, 3] });
+  });
+
+  it("excludes entries from the ids fallback when excludedIds is set", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+      excludedIds: new Set([2]),
+    });
+    expect(result).toEqual({ ids: [1, 3] });
+  });
+
+  it("returns null when selectAll is true but all entries are excluded", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+      excludedIds: new Set([1, 2, 3]),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when selectAll is true with no filters and logs are empty", () => {
+    const result = buildBatchDeletePayload({
+      ...defaults,
+      selectAll: true,
+      logs: [],
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/client/src/pages/adminErrorsUtils.ts
+++ b/client/src/pages/adminErrorsUtils.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure utility for computing the batch-delete payload for admin error logs.
+ * Extracted so the branching logic can be unit-tested without React.
+ */
+
+export type BatchDeletePayload =
+  | { ids: number[] }
+  | { filters: { level?: string; source?: string }; excludeIds?: number[] };
+
+/**
+ * Decides which payload shape to send to POST /api/admin/error-logs/batch-delete.
+ *
+ * @returns the payload, or `null` when there is nothing to delete.
+ */
+export function buildBatchDeletePayload(opts: {
+  selectAll: boolean;
+  selectedIds: Set<number>;
+  excludedIds: Set<number>;
+  levelFilter: string;
+  sourceFilter: string;
+  logs: { id: number }[];
+}): BatchDeletePayload | null {
+  const { selectAll, selectedIds, excludedIds, levelFilter, sourceFilter, logs } = opts;
+
+  if (!selectAll) {
+    const ids = Array.from(selectedIds);
+    return ids.length > 0 ? { ids } : null;
+  }
+
+  // selectAll path — prefer filter-based delete when a filter is active
+  const filters: { level?: string; source?: string } = {};
+  if (levelFilter !== "all") filters.level = levelFilter;
+  if (sourceFilter !== "all") filters.source = sourceFilter;
+
+  if (filters.level || filters.source) {
+    const excluded = Array.from(excludedIds);
+    return {
+      filters,
+      ...(excluded.length > 0 ? { excludeIds: excluded } : {}),
+    };
+  }
+
+  // No filters — fall back to sending visible IDs directly
+  const ids = logs.filter(l => !excludedIds.has(l.id)).map(l => l.id);
+  return ids.length > 0 ? { ids } : null;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -148,14 +148,18 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
 
         await WebhookHandlers.processWebhook(req.body as Buffer, sig);
         res.status(200).json({ received: true });
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error ?? '');
+      } catch (error: any) {
+        const msg = error.message || '';
         if (msg.includes('signature') || msg.includes('No signatures found') || msg.includes('timestamp')) {
-          console.error('[stripe] Webhook signature validation failed', msg, { ip: req.ip });
+          const { ErrorLogger } = await import('./services/logger');
+          await ErrorLogger.error('stripe', 'Webhook signature validation failed', error, {
+            ip: req.ip,
+          });
           return res.status(401).json({ error: 'Invalid signature' });
         }
 
-        console.error('[stripe] Webhook processing failed', msg);
+        const { ErrorLogger } = await import('./services/logger');
+        await ErrorLogger.error('stripe', 'Webhook processing failed', error);
         return res.status(500).json({ error: 'Processing failed' });
       }
     }
@@ -176,14 +180,18 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
         const event = await verifyResendWebhook(req.body, req.headers as Record<string, string | string[] | undefined>);
         await handleResendWebhookEvent(event);
         res.status(200).json({ received: true });
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error ?? '');
+      } catch (error: any) {
+        const msg = error.message || '';
         if (msg.includes('signature') || msg.includes('timestamp') || msg.includes('No signatures found')) {
-          console.error('[email] Resend webhook signature validation failed', msg, { ip: req.ip });
+          const { ErrorLogger } = await import('./services/logger');
+          await ErrorLogger.error('email', 'Resend webhook signature validation failed', error, {
+            ip: req.ip,
+          });
           return res.status(401).json({ error: 'Invalid signature' });
         }
 
-        console.error('[email] Resend webhook processing failed', msg);
+        const { ErrorLogger } = await import('./services/logger');
+        await ErrorLogger.error('email', 'Resend webhook processing failed', error);
         return res.status(500).json({ error: 'Processing failed' });
       }
     }
@@ -286,6 +294,15 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
       }
     } catch (err) {
       console.error("[Bootstrap] Welcome campaign bootstrap failed:", err);
+      try {
+        const { ErrorLogger } = await import("./services/logger");
+        await ErrorLogger.error("scheduler", "Welcome campaign bootstrap failed",
+          err instanceof Error ? err : null,
+          { errorMessage: err instanceof Error ? err.message : String(err) }
+        ).catch(() => {});
+      } catch {
+        // Logger import failed — already logged to console above
+      }
     }
   })().catch((err) => console.error("[Bootstrap] Unhandled bootstrap error:", err));
 
@@ -293,6 +310,7 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
   // the ensure* migrations release their DB connections first, preventing
   // pool exhaustion that causes connection timeouts.
   const { startScheduler } = await import("./services/scheduler");
+  const { ErrorLogger } = await import("./services/logger");
   (async () => {
     const maxRetries = 5;
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -310,7 +328,10 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
         }
       }
     }
-    console.error("[CRITICAL] Scheduler failed to start after all retries — monitoring is disabled. Exiting so the platform restarts the process.", { maxRetries });
+    console.error("[CRITICAL] Scheduler failed to start after all retries — monitoring is disabled. Exiting so the platform restarts the process.");
+    try {
+      await ErrorLogger.error("scheduler", "Scheduler failed to start after all retries — monitoring is disabled", null, { maxRetries });
+    } catch { /* DB may be down — already logged to stderr */ }
     process.exit(1);
   })().catch((err) => {
     console.error("[CRITICAL] Scheduler IIFE unhandled error:", err);
@@ -339,17 +360,10 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
 
   startStripeInitWithRetry();
 
-  // Error Handler — log safe fields only; never emit err.stack so DSNs,
-  // bearer tokens, and provider keys embedded in library stack traces
-  // don't land in stdout.
+  // Error Handler
   app.use((err: any, _req: any, res: any, next: any) => {
-    const isErrObj = err !== null && err !== undefined && typeof err === "object";
-    const status = isErrObj ? (err.status || err.statusCode || 500) : 500;
-    console.error("Internal Server Error:", {
-      name: isErrObj && typeof err.name === "string" ? err.name : "NonErrorThrow",
-      code: isErrObj && err.code ? String(err.code) : undefined,
-      message: err instanceof Error ? err.message : String(err ?? "Unhandled error"),
-    });
+    const status = err.status || err.statusCode || 500;
+    console.error("Internal Server Error:", err);
     if (res.headersSent) return next(err);
     return res.status(status).json({ message: "Internal Server Error" });
   });
@@ -389,6 +403,7 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
   const cron = (await import("node-cron")).default;
   const { browserPool } = await import("./services/browserPool");
   const { stopScheduler } = await import("./services/scheduler");
+  const { stopRouteTimers } = await import("./routes");
   const { pool: dbPool } = await import("./db");
   let shuttingDown = false;
   const shutdown = async () => {
@@ -427,6 +442,9 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
         }
       }, 9_000).unref();
     });
+    // Stop route timers before closing DB pool
+    console.log("Stopping route timers...");
+    stopRouteTimers();
     // Drain warm browsers
     let cleanupFailed = false;
     console.log("Draining browser pool...");

--- a/server/partial-index-invariants.test.ts
+++ b/server/partial-index-invariants.test.ts
@@ -4,9 +4,9 @@
  * causes the planner to regress because the index no longer covers the new
  * status values. See Phase 5 skeptic Concern 3.
  *
- * Reads the campaignEmail.ts / schema.ts source as text rather than importing
- * them — the service modules pull in db.ts which requires a live DATABASE_URL,
- * and these tests only compare string predicates.
+ * Reads the campaignEmail.ts / logger.ts / schema.ts source as text rather
+ * than importing them — the service modules pull in db.ts which requires a
+ * live DATABASE_URL, and these tests only compare string predicates.
  */
 import { describe, it, expect } from "vitest";
 import fs from "fs";
@@ -18,6 +18,10 @@ const CAMPAIGN_EMAIL_SRC = fs.readFileSync(
 );
 const SCHEMA_SRC = fs.readFileSync(
   path.resolve(__dirname, "..", "shared", "schema.ts"),
+  "utf-8",
+);
+const LOGGER_SRC = fs.readFileSync(
+  path.resolve(__dirname, "services", "logger.ts"),
   "utf-8",
 );
 const ENSURE_TABLES_SRC = fs.readFileSync(
@@ -55,7 +59,7 @@ function extractActiveUserIdxPredicate(): string {
 }
 
 // Known non-active recipient statuses per the column comment in
-// shared/schema.ts. Kept in lockstep there — if a new terminal status is
+// shared/schema.ts:170. Kept in lockstep there — if a new terminal status is
 // added to the schema but the partial-index predicate isn't updated, this
 // list catches the leak before the planner regresses silently.
 const NON_ACTIVE_RECIPIENT_STATUSES = ["bounced", "complained"] as const;
@@ -91,15 +95,62 @@ describe("TERMINAL_RECIPIENT_STATUSES is a subset of ACTIVE_RECIPIENT_STATUSES",
 });
 
 // -----------------------------------------------------------------------------
+// error_logs_unresolved_dedup_idx — the ErrorLogger upsert's ON CONFLICT
+// partial-index predicate must exactly match the index's WHERE clause.
+// Postgres matches ON CONFLICT inference specs by strict predicate equality;
+// a mismatch produces a runtime error ("there is no unique or exclusion
+// constraint matching the ON CONFLICT specification") that ErrorLogger's
+// catch block swallows, silently disabling logging. See GitHub issue #448.
+// -----------------------------------------------------------------------------
+
+function extractIndexPredicate(indexName: string): string {
+  const re = new RegExp(`${indexName}[\\s\\S]*?\\.where\\(sql\`([^\`]+)\`\\)`);
+  const m = SCHEMA_SRC.match(re);
+  if (!m) throw new Error(`failed to extract ${indexName} predicate from shared/schema.ts`);
+  return m[1].trim();
+}
+
+function extractLoggerTargetWherePredicate(): string {
+  const m = LOGGER_SRC.match(/targetWhere:\s*sql`([^`]+)`/);
+  if (!m) {
+    throw new Error(
+      "failed to extract targetWhere predicate from server/services/logger.ts — " +
+        "did the onConflictDoUpdate call move, split the predicate across " +
+        "fragments, or switch to a non-sql`` expression? The invariant test " +
+        "cannot validate the upsert until this regex matches the call shape again.",
+    );
+  }
+  return m[1].trim();
+}
+
+function extractLoggerConflictTargetColumns(): string[] {
+  // Match `target: [errorLogs.level, errorLogs.source, errorLogs.message]` on
+  // the onConflictDoUpdate call. Extracts the column names after the
+  // `errorLogs.` prefix so they can be compared against the schema's .on(...)
+  // tuple directly. If this regex stops matching, the caller-side assertion
+  // throws a descriptive error so the drift is caught rather than silently
+  // skipped.
+  const m = LOGGER_SRC.match(/target:\s*\[([^\]]+)\]/);
+  if (!m) {
+    throw new Error(
+      "failed to extract onConflictDoUpdate target column list from server/services/logger.ts — " +
+        "did the target tuple move, use a spread, or split across lines? The invariant test " +
+        "cannot validate the upsert target until this regex matches the call shape again.",
+    );
+  }
+  return Array.from(m[1].matchAll(/errorLogs\.(\w+)/g)).map((mm) => mm[1]);
+}
+
+// -----------------------------------------------------------------------------
 // schema.ts <-> ensureTables.ts predicate parity for partial indexes.
 // Every partial index declared in shared/schema.ts that we rely on Postgres
 // to bootstrap via ensureTables must be present there with a byte-identical
 // WHERE predicate. A mismatch causes:
 //   - ON CONFLICT inference failure (Postgres requires strict predicate
-//     equality), which surfaces as the caller's catch block swallowing the
-//     error and silently disabling the feature.
+//     equality), which surfaces as the logger/backfill catch block swallowing
+//     the error and silently disabling the feature.
 //   - Endless drizzle-kit push churn (the diff flips the index back and forth).
-// See GitHub issues #452, #453.
+// See GitHub issues #448, #452, #453.
 // -----------------------------------------------------------------------------
 
 type BootstrapRequiredIndex = {
@@ -108,6 +159,7 @@ type BootstrapRequiredIndex = {
 };
 
 const BOOTSTRAP_REQUIRED_PARTIAL_INDEXES: BootstrapRequiredIndex[] = [
+  { name: "error_logs_unresolved_dedup_idx", schemaKey: "unresolvedDedupIdx" },
   { name: "campaigns_type_automated_idx", schemaKey: "typeAutomatedIdx" },
   { name: "campaign_recipients_active_user_idx", schemaKey: "activeUserCampaignIdx" },
   { name: "automation_subscriptions_dedup_with_monitor", schemaKey: "dedupWithMonitor" },
@@ -119,6 +171,11 @@ function normalizeWhitespace(s: string): string {
 }
 
 function extractEnsureTablesPredicate(indexName: string): string {
+  // Match the CREATE [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS] <name>
+  // ... WHERE <predicate> pattern. Allow the statement to span multiple lines
+  // (the error_logs bootstrap uses a multi-line template literal). Stop at the
+  // closing backtick or the end of statement punctuation so we don't bleed
+  // into trailing SQL fragments.
   const re = new RegExp(
     `CREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+(?:CONCURRENTLY\\s+)?(?:IF\\s+NOT\\s+EXISTS\\s+)?${indexName}\\b[\\s\\S]*?WHERE\\s+([\\s\\S]*?)\`\\s*\\)`,
   );
@@ -150,4 +207,32 @@ describe("partial-index bootstrap parity between schema.ts and ensureTables.ts",
       expect(ddlPredicate).toBe(schemaPredicate);
     });
   }
+});
+
+describe("error_logs_unresolved_dedup_idx predicate matches ErrorLogger upsert targetWhere", () => {
+  it("index WHERE clause and onConflictDoUpdate targetWhere are byte-for-byte equal", () => {
+    const indexPredicate = extractIndexPredicate("unresolvedDedupIdx");
+    const loggerPredicate = extractLoggerTargetWherePredicate();
+    expect(loggerPredicate).toBe(indexPredicate);
+  });
+
+  it("schema index .on(...) and ErrorLogger target [...] both list exactly (level, source, message)", () => {
+    // Match the exact .on(...) column list for the unresolved-dedup index.
+    // If new columns are added or the order changes, the ErrorLogger upsert's
+    // `target: [errorLogs.level, errorLogs.source, errorLogs.message]` tuple
+    // must be updated in lockstep or Postgres rejects the conflict spec. We
+    // assert both sides match the canonical tuple AND each other, so schema-
+    // only or logger-only drift both fail the test.
+    const m = SCHEMA_SRC.match(
+      /unresolvedDedupIdx[\s\S]*?\.on\(([^)]+)\)/,
+    );
+    if (!m) throw new Error("failed to extract unresolvedDedupIdx .on(...) columns");
+    const schemaColumns = m[1]
+      .split(",")
+      .map((c) => c.trim().replace(/^table\./, ""))
+      .filter(Boolean);
+    const loggerColumns = extractLoggerConflictTargetColumns();
+    expect(schemaColumns).toEqual(["level", "source", "message"]);
+    expect(loggerColumns).toEqual(schemaColumns);
+  });
 });

--- a/server/routes.bugfixes.test.ts
+++ b/server/routes.bugfixes.test.ts
@@ -100,7 +100,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.bugfixes.test.ts
+++ b/server/routes.bugfixes.test.ts
@@ -97,6 +97,14 @@ vi.mock("./db", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./services/scraper", () => ({
   checkMonitor: vi.fn(),
   extractWithBrowserless: vi.fn(),
@@ -317,6 +325,78 @@ describe("#293: PATCH /api/admin/campaigns/:id rejects empty body", () => {
     const res = await callHandler("patch", ENDPOINT, req);
     expect(res._status).toBe(200);
     expect(res._json.name).toBe("Updated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #292 — Error log list filters by resolved=false
+// ---------------------------------------------------------------------------
+describe("#292: GET /api/admin/error-logs filters by resolved=false", () => {
+  const ENDPOINT = "/api/admin/error-logs";
+
+  beforeEach(async () => {
+    await ensureRoutes();
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ limit: mockLimitFn, orderBy: mockOrderByFn });
+    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn, orderBy: mockOrderByFn });
+    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+  });
+
+  it("returns only unresolved entries (resolved entries excluded from list)", async () => {
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: null, resolved: false },
+    ]);
+
+    const req = ownerReq({ query: {} });
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    // The WHERE clause now includes eq(errorLogs.resolved, false),
+    // so the DB mock only returns unresolved entries. Verify the query was built.
+    expect(mockSelectWhereFn).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #288 — Single-delete filters already-deleted entries
+// ---------------------------------------------------------------------------
+describe("#288: DELETE /api/admin/error-logs/:id rejects already-deleted entries", () => {
+  const ENDPOINT = "/api/admin/error-logs/:id";
+
+  beforeEach(async () => {
+    await ensureRoutes();
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ limit: mockLimitFn, orderBy: mockOrderByFn });
+    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn, orderBy: mockOrderByFn });
+    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+    mockUpdateWhereFn.mockResolvedValue(undefined);
+    mockUpdateSetFn.mockReturnValue({ where: mockUpdateWhereFn });
+    mockDbUpdate.mockReturnValue({ set: mockUpdateSetFn });
+  });
+
+  it("returns 404 when entry is already soft-deleted (not found by query)", async () => {
+    // The query now includes isNull(errorLogs.deletedAt), so a soft-deleted
+    // entry won't be returned — mockLimitFn returns empty array
+    mockLimitFn.mockResolvedValue([]);
+
+    const req = ownerReq({ params: { id: "5" } });
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(404);
+    expect(res._json).toEqual({ message: "Log entry not found" });
+  });
+
+  it("successfully soft-deletes a non-deleted entry", async () => {
+    mockLimitFn.mockResolvedValue([{ id: 5, context: null, deletedAt: null }]);
+
+    const req = ownerReq({ params: { id: "5" } });
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "Deleted" });
   });
 });
 
@@ -549,6 +629,7 @@ describe("app.param id validation (#346)", () => {
 // ---------------------------------------------------------------------------
 describe("#373: Negative limit query parameter is clamped to 1", () => {
   const DELIVERIES_ENDPOINT = "/api/monitors/:id/deliveries";
+  const ERROR_LOGS_ENDPOINT = "/api/admin/error-logs";
 
   beforeEach(async () => {
     await ensureRoutes();
@@ -593,6 +674,36 @@ describe("#373: Negative limit query parameter is clamped to 1", () => {
     expect(res._status).toBe(200);
     // Number("0") is falsy, so || 50 kicks in, then Math.max(1, 50) = 50
     expect(mockGetDeliveryLog).toHaveBeenCalledWith(1, 50, undefined);
+  });
+
+  it("error-logs endpoint clamps limit=-1 to 1", async () => {
+    const req = ownerReq({ query: { limit: "-1" } });
+    const res = await callHandler("get", ERROR_LOGS_ENDPOINT, req);
+    expect(res._status).toBe(200);
+    // The DB select chain should have .limit(1) called, not .limit(-1)
+    expect(mockLimitFn).toHaveBeenCalledWith(1);
+  });
+
+  it("error-logs endpoint defaults limit to 100 for non-numeric input", async () => {
+    const req = ownerReq({ query: { limit: "abc" } });
+    const res = await callHandler("get", ERROR_LOGS_ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(mockLimitFn).toHaveBeenCalledWith(100);
+  });
+
+  it("error-logs endpoint caps limit at 500", async () => {
+    const req = ownerReq({ query: { limit: "9999" } });
+    const res = await callHandler("get", ERROR_LOGS_ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(mockLimitFn).toHaveBeenCalledWith(500);
+  });
+
+  it("error-logs endpoint treats limit=0 as default (100)", async () => {
+    const req = ownerReq({ query: { limit: "0" } });
+    const res = await callHandler("get", ERROR_LOGS_ENDPOINT, req);
+    expect(res._status).toBe(200);
+    // Number("0") is falsy, so || 100 kicks in, then Math.max(1, 100) = 100
+    expect(mockLimitFn).toHaveBeenCalledWith(100);
   });
 
   it("campaign analytics endpoint clamps limit=-1 to 1", async () => {

--- a/server/routes.campaignDashboard.test.ts
+++ b/server/routes.campaignDashboard.test.ts
@@ -71,7 +71,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.campaignRecover.test.ts
+++ b/server/routes.campaignRecover.test.ts
@@ -70,6 +70,14 @@ vi.mock("./db", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./services/scraper", () => ({
   checkMonitor: vi.fn(),
   extractWithBrowserless: vi.fn(),

--- a/server/routes.campaignRecover.test.ts
+++ b/server/routes.campaignRecover.test.ts
@@ -73,7 +73,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.campaignSendTest.test.ts
+++ b/server/routes.campaignSendTest.test.ts
@@ -92,7 +92,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.campaignSendTest.test.ts
+++ b/server/routes.campaignSendTest.test.ts
@@ -89,6 +89,14 @@ vi.mock("./db", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./services/scraper", () => ({
   checkMonitor: vi.fn(),
   extractWithBrowserless: vi.fn(),

--- a/server/routes.conditions.test.ts
+++ b/server/routes.conditions.test.ts
@@ -93,7 +93,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.conditions.test.ts
+++ b/server/routes.conditions.test.ts
@@ -90,6 +90,13 @@ vi.mock("./db", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
 
 vi.mock("./services/scraper", () => ({
   checkMonitor: vi.fn(),
@@ -163,6 +170,7 @@ vi.mock("express-rate-limit", () => ({
 }));
 
 vi.mock("./services/ensureTables", () => ({
+  ensureErrorLogColumns: vi.fn().mockResolvedValue(undefined),
   ensureApiKeysTable: vi.fn().mockResolvedValue(undefined),
   ensureChannelTables: vi.fn().mockResolvedValue(undefined),
   ensureNotificationQueueColumns: vi.fn().mockResolvedValue(true),

--- a/server/routes.deleteErrorLog.test.ts
+++ b/server/routes.deleteErrorLog.test.ts
@@ -1,0 +1,963 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock variables
+// ---------------------------------------------------------------------------
+const {
+  mockGetUser,
+  mockGetMonitors,
+  mockDbSelect,
+  mockDbDelete,
+  mockDbUpdate,
+  mockLimitFn,
+  mockSelectWhereFn,
+  mockSelectFromFn,
+  mockDeleteWhereFn,
+  mockUpdateSetFn,
+  mockUpdateWhereFn,
+  mockOrderByFn,
+} = vi.hoisted(() => {
+  const mockLimitFn = vi.fn();
+  const mockOrderByFn = vi.fn(() => ({ limit: mockLimitFn }));
+  const mockSelectWhereFn = vi.fn(() => ({ limit: mockLimitFn, orderBy: mockOrderByFn }));
+  const mockSelectFromFn = vi.fn(() => ({ where: mockSelectWhereFn, orderBy: mockOrderByFn }));
+  const mockDbSelect = vi.fn(() => ({ from: mockSelectFromFn }));
+
+  const mockDeleteWhereFn = vi.fn().mockResolvedValue(undefined);
+  const mockDbDelete = vi.fn(() => ({ where: mockDeleteWhereFn }));
+
+  const mockUpdateWhereFn = vi.fn().mockResolvedValue(undefined);
+  const mockUpdateSetFn = vi.fn(() => ({ where: mockUpdateWhereFn }));
+  const mockDbUpdate = vi.fn(() => ({ set: mockUpdateSetFn }));
+
+  return {
+    mockGetUser: vi.fn(),
+    mockGetMonitors: vi.fn(),
+    mockDbSelect,
+    mockDbDelete,
+    mockDbUpdate,
+    mockLimitFn,
+    mockSelectWhereFn,
+    mockSelectFromFn,
+    mockDeleteWhereFn,
+    mockUpdateSetFn,
+    mockUpdateWhereFn,
+    mockOrderByFn,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock("./replit_integrations/auth", () => ({
+  setupAuth: vi.fn().mockResolvedValue(undefined),
+  registerAuthRoutes: vi.fn(),
+  isAuthenticated: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("./replit_integrations/auth/storage", () => ({
+  authStorage: {
+    getUser: (...args: any[]) => mockGetUser(...args),
+  },
+}));
+
+vi.mock("./storage", () => ({
+  storage: {
+    getMonitor: vi.fn(),
+    getMonitors: (...args: any[]) => mockGetMonitors(...args),
+    getAllActiveMonitors: vi.fn().mockResolvedValue([]),
+    deleteMonitor: vi.fn(),
+    createMonitor: vi.fn(),
+    updateMonitor: vi.fn(),
+  },
+}));
+
+vi.mock("./db", () => ({
+  db: {
+    select: (...args: any[]) => mockDbSelect(...args),
+    delete: (...args: any[]) => mockDbDelete(...args),
+    insert: vi.fn().mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }),
+    update: (...args: any[]) => mockDbUpdate(...args),
+    execute: vi.fn().mockResolvedValue({ rows: [] }),
+  },
+}));
+
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("./services/scraper", () => ({
+  checkMonitor: vi.fn(),
+  extractWithBrowserless: vi.fn(),
+  detectPageBlockReason: vi.fn().mockReturnValue({ blocked: false }),
+  discoverSelectors: vi.fn(),
+  validateCssSelector: vi.fn(),
+  extractValueFromHtml: vi.fn(),
+}));
+
+vi.mock("./stripeClient", () => ({
+  getUncachableStripeClient: vi.fn(),
+  getStripePublishableKey: vi.fn().mockReturnValue("pk_test_123"),
+}));
+
+vi.mock("./services/email", () => ({
+  sendNotificationEmail: vi.fn(),
+}));
+
+vi.mock("./services/browserlessTracker", () => ({
+  BrowserlessUsageTracker: { getMonthlyUsage: vi.fn(), recordUsage: vi.fn() },
+  getMonthResetDate: vi.fn().mockReturnValue("2026-03-01"),
+}));
+
+vi.mock("./services/resendTracker", () => ({
+  ResendUsageTracker: { recordSend: vi.fn() },
+  getResendResetDate: vi.fn().mockReturnValue("2026-03-01"),
+}));
+
+vi.mock("./middleware/rateLimiter", () => ({
+  generalRateLimiter: (_req: any, _res: any, next: any) => next(),
+  createMonitorRateLimiter: (_req: any, _res: any, next: any) => next(),
+  checkMonitorRateLimiter: (_req: any, _res: any, next: any) => next(),
+  suggestSelectorsRateLimiter: (_req: any, _res: any, next: any) => next(),
+  emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
+  contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
+  unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("./services/scheduler", () => ({
+  startScheduler: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers: capture route handlers from Express mock
+// ---------------------------------------------------------------------------
+type RouteHandler = (req: any, res: any, next?: any) => Promise<any>;
+const registeredRoutes: Record<string, Record<string, RouteHandler[]>> = {};
+
+function makeMockApp() {
+  const makeRegistrar = (method: string) => (path: string, ...handlers: any[]) => {
+    if (!registeredRoutes[method]) registeredRoutes[method] = {};
+    registeredRoutes[method][path] = handlers;
+  };
+  return {
+    get: makeRegistrar("get"),
+    post: makeRegistrar("post"),
+    put: makeRegistrar("put"),
+    patch: makeRegistrar("patch"),
+    delete: makeRegistrar("delete"),
+    use: vi.fn(),
+    set: vi.fn(),
+    param: vi.fn(),
+  };
+}
+
+function makeRes() {
+  const res: any = {
+    _status: 200,
+    _json: null,
+    status(code: number) { res._status = code; return res; },
+    json(body: any) { res._json = body; return res; },
+    send(body: any) { res._body = body; return res; },
+  };
+  return res;
+}
+
+async function callHandler(method: string, path: string, req: any) {
+  const handlers = registeredRoutes[method]?.[path];
+  if (!handlers) throw new Error(`No handler for ${method.toUpperCase()} ${path}`);
+  const res = makeRes();
+  // Skip middleware (isAuthenticated), call the last handler directly
+  const handler = handlers[handlers.length - 1];
+  await handler(req, res);
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Register routes once
+// ---------------------------------------------------------------------------
+let routesRegistered = false;
+
+async function ensureRoutes() {
+  if (routesRegistered) return;
+  process.env.APP_OWNER_ID = "owner-123";
+
+  const { registerRoutes } = await import("./routes");
+  const app = makeMockApp();
+  // registerRoutes expects (httpServer, app) but we only need route registration
+  await registerRoutes(app as any, app as any);
+  routesRegistered = true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("DELETE /api/admin/error-logs/:id", () => {
+  const ENDPOINT = "/api/admin/error-logs/:id";
+
+  beforeEach(async () => {
+    await ensureRoutes();
+    vi.clearAllMocks();
+
+    // Reset db chain mocks after clearAllMocks
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ limit: mockLimitFn, orderBy: mockOrderByFn });
+    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn, orderBy: mockOrderByFn });
+    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+    mockDeleteWhereFn.mockResolvedValue(undefined);
+    mockDbDelete.mockReturnValue({ where: mockDeleteWhereFn });
+    mockUpdateWhereFn.mockResolvedValue(undefined);
+    mockUpdateSetFn.mockReturnValue({ where: mockUpdateWhereFn });
+    mockDbUpdate.mockReturnValue({ set: mockUpdateSetFn });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const req = { user: null, params: { id: "1" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(401);
+    expect(res._json).toEqual({ message: "Unauthorized" });
+  });
+
+  it("returns 403 when user is not power tier", async () => {
+    mockGetUser.mockResolvedValue({ tier: "pro" });
+    const req = { user: { claims: { sub: "user-1" } }, params: { id: "1" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Admin access required" });
+  });
+
+  it("returns 403 when user is null in database", async () => {
+    mockGetUser.mockResolvedValue(null);
+    const req = { user: { claims: { sub: "user-1" } }, params: { id: "1" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Admin access required" });
+  });
+
+  it("returns 400 for non-numeric log ID", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "abc" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json).toEqual({ message: "Invalid log ID" });
+  });
+
+  it("returns 404 when log entry does not exist", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockLimitFn.mockResolvedValue([]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "99" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(404);
+    expect(res._json).toEqual({ message: "Log entry not found" });
+  });
+
+  it("soft-deletes log entry when user is app owner (no monitorId in context)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([{ id: 5, context: null }]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "5" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "Deleted" });
+    expect(mockDbUpdate).toHaveBeenCalled();
+    expect(mockUpdateSetFn).toHaveBeenCalled();
+    expect(mockUpdateWhereFn).toHaveBeenCalled();
+  });
+
+  it("deletes log entry when user owns the monitor referenced in context", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 42 }]);
+    mockLimitFn.mockResolvedValue([{ id: 10, context: { monitorId: 42 } }]);
+
+    const req = { user: { claims: { sub: "user-power" } }, params: { id: "10" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "Deleted" });
+  });
+
+  it("returns 403 when non-owner user's monitors don't match the log's monitorId", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 99 }]);
+    mockLimitFn.mockResolvedValue([{ id: 10, context: { monitorId: 42 } }]);
+
+    const req = { user: { claims: { sub: "user-power" } }, params: { id: "10" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Not authorized to delete this log entry" });
+  });
+
+  it("returns 403 when non-owner tries to delete log with no monitorId in context", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 1 }]);
+    mockLimitFn.mockResolvedValue([{ id: 10, context: null }]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, params: { id: "10" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Not authorized to delete this log entry" });
+  });
+
+  it("returns 500 when database throws an error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockLimitFn.mockRejectedValue(new Error("DB connection lost"));
+
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "5" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(500);
+    expect(res._json).toEqual({ message: "Failed to delete error log" });
+    errorSpy.mockRestore();
+  });
+
+  // --- ID validation edge cases (Number.isInteger + id > 0) ---
+
+  it("returns 400 for id '0' (zero is not a valid serial ID)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "0" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json).toEqual({ message: "Invalid log ID" });
+  });
+
+  it("returns 400 for negative id", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "-1" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json).toEqual({ message: "Invalid log ID" });
+  });
+
+  it("returns 400 for float id", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "1.5" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json).toEqual({ message: "Invalid log ID" });
+  });
+
+  it("returns 400 for empty string id", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json).toEqual({ message: "Invalid log ID" });
+  });
+
+  // --- Type guard on context.monitorId ---
+
+  it("treats string monitorId in context as missing (falls back to owner check)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 42 }]);
+    // monitorId is a string, not a number — the type guard should ignore it
+    mockLimitFn.mockResolvedValue([{ id: 10, context: { monitorId: "42" } }]);
+
+    // Non-owner: should be denied because string monitorId is treated as absent
+    const req = { user: { claims: { sub: "not-the-owner" } }, params: { id: "10" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Not authorized to delete this log entry" });
+  });
+
+  it("treats boolean monitorId in context as missing (falls back to owner check)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([{ id: 10, context: { monitorId: true } }]);
+
+    // Owner should still be able to delete
+    const req = { user: { claims: { sub: "owner-123" } }, params: { id: "10" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "Deleted" });
+  });
+
+  it("treats context with empty object (no monitorId key) same as null context", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([{ id: 10, context: {} }]);
+
+    // Non-owner with no monitorId in context: denied
+    const req = { user: { claims: { sub: "not-the-owner" } }, params: { id: "10" } };
+    const res = await callHandler("delete", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Not authorized to delete this log entry" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/error-logs — context.monitorId type guard filtering
+// ---------------------------------------------------------------------------
+describe("GET /api/admin/error-logs — context type guard filtering", () => {
+  const ENDPOINT = "/api/admin/error-logs";
+
+  beforeEach(async () => {
+    await ensureRoutes();
+    vi.clearAllMocks();
+
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ limit: mockLimitFn, orderBy: mockOrderByFn });
+    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn, orderBy: mockOrderByFn });
+    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+  });
+
+  it("includes logs with numeric monitorId matching user's monitors", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 10 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 10 } },
+      { id: 2, context: { monitorId: 99 } },
+    ]);
+
+    const req = { user: { claims: { sub: "user-power" } }, query: {} };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    // Only log with monitorId 10 should be included
+    expect(res._json).toHaveLength(1);
+    expect(res._json[0].id).toBe(1);
+  });
+
+  it("excludes logs with string monitorId (non-owner user)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 42 }]);
+    // monitorId is a string "42" — type guard should treat it as undefined
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: "42" } },
+    ]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, query: {} };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    // String monitorId treated as missing → non-owner can't see it
+    expect(res._json).toHaveLength(0);
+  });
+
+  it("owner sees logs with string monitorId (treated as no-monitor system log)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    // monitorId is a string — type guard treats it as absent → falls through to isAppOwner
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: "injected" } },
+    ]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, query: {} };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toHaveLength(1);
+  });
+
+  it("excludes logs with boolean monitorId for non-owner", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 1 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: true } },
+    ]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, query: {} };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toHaveLength(0);
+  });
+
+  it("correctly filters mixed context types", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 5 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 5 } },          // numeric, matches → included
+      { id: 2, context: { monitorId: "5" } },         // string → excluded (non-owner)
+      { id: 3, context: null },                        // null context → excluded (non-owner)
+      { id: 4, context: { monitorId: 99 } },          // numeric, doesn't match → excluded
+      { id: 5, context: { other: "data" } },           // no monitorId key → excluded (non-owner)
+    ]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, query: {} };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toHaveLength(1);
+    expect(res._json[0].id).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/error-logs/batch-delete
+// ---------------------------------------------------------------------------
+describe("POST /api/admin/error-logs/batch-delete", () => {
+  const ENDPOINT = "/api/admin/error-logs/batch-delete";
+
+  beforeEach(async () => {
+    await ensureRoutes();
+    vi.clearAllMocks();
+
+    // For batch endpoints:
+    // - ID path: .where() resolves directly (no .limit/.orderBy)
+    // - Filter path: .where().orderBy().limit(500)
+    // Default to filter chain; ID-based tests override with mockResolvedValue.
+    mockLimitFn.mockResolvedValue([]);
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ orderBy: mockOrderByFn, limit: mockLimitFn });
+    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn });
+    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+
+    mockUpdateWhereFn.mockResolvedValue(undefined);
+    mockUpdateSetFn.mockReturnValue({ where: mockUpdateWhereFn });
+    mockDbUpdate.mockReturnValue({ set: mockUpdateSetFn });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const req = { user: null, body: { ids: [1] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(401);
+    expect(res._json).toEqual({ message: "Unauthorized" });
+  });
+
+  it("returns 403 when user is not power tier", async () => {
+    mockGetUser.mockResolvedValue({ tier: "pro" });
+    const req = { user: { claims: { sub: "user-1" } }, body: { ids: [1] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Admin access required" });
+  });
+
+  it("returns 400 when neither ids nor filters provided", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    const req = { user: { claims: { sub: "owner-123" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("returns 400 when both ids and filters provided", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    const req = { user: { claims: { sub: "owner-123" } }, body: { ids: [1], filters: { level: "error" } } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("returns 400 for empty ids array", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    const req = { user: { claims: { sub: "owner-123" } }, body: { ids: [] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("returns 400 for ids containing non-integers", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    const req = { user: { claims: { sub: "owner-123" } }, body: { ids: [1, "abc", 3] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("returns 400 for ids containing zero or negative values", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    const req = { user: { claims: { sub: "owner-123" } }, body: { ids: [0, -1] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("soft-deletes authorized entries by IDs for app owner", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockSelectWhereFn.mockResolvedValue([
+      { id: 1, context: null },
+      { id: 2, context: null },
+    ]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: { ids: [1, 2] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "2 entries deleted", count: 2 });
+    expect(mockDbUpdate).toHaveBeenCalled();
+    expect(mockUpdateSetFn).toHaveBeenCalled();
+  });
+
+  it("excludes unauthorized entries when deleting by IDs (non-owner)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 10 }]);
+    mockSelectWhereFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 10 } },  // authorized
+      { id: 2, context: { monitorId: 99 } },  // not authorized
+      { id: 3, context: null },                // no monitorId, non-owner → excluded
+    ]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, body: { ids: [1, 2, 3] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "1 entries deleted", count: 1 });
+  });
+
+  it("returns count 0 when no entries are authorized", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 10 }]);
+    mockSelectWhereFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 99 } },
+    ]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, body: { ids: [1] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "0 entries deleted", count: 0 });
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it("soft-deletes entries matching filters for app owner", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: null },
+      { id: 2, context: null },
+      { id: 3, context: null },
+    ]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: { filters: { level: "error" } } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "3 entries deleted", count: 3, hasMore: false });
+    expect(mockDbUpdate).toHaveBeenCalled();
+  });
+
+  it("soft-deletes with filter and excludeIds", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: null },
+      { id: 3, context: null },
+    ]);
+
+    const req = {
+      user: { claims: { sub: "owner-123" } },
+      body: { filters: { source: "scraper" }, excludeIds: [2] },
+    };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "2 entries deleted", count: 2, hasMore: false });
+  });
+
+  it("rejects empty filters object", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 10 }]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, body: { filters: {} } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("rejects excludeIds when combined with ids", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: { ids: [1, 2, 3], excludeIds: [2] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("applies ownership filtering with filters mode", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 10 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 10 } },
+      { id: 2, context: null },
+    ]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, body: { filters: { level: "error" } } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "1 entries deleted", count: 1, hasMore: false });
+  });
+
+  it("returns hasMore true when filter query hits the 500-row limit", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    // Simulate exactly 500 rows returned (the limit)
+    const entries = Array.from({ length: 500 }, (_, i) => ({ id: i + 1, context: null }));
+    mockLimitFn.mockResolvedValue(entries);
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: { filters: { level: "error" } } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json.count).toBe(500);
+    expect(res._json.hasMore).toBe(true);
+  });
+
+  it("rejects filters with only invalid values", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+
+    const req = {
+      user: { claims: { sub: "owner-123" } },
+      body: { filters: { level: "critical", source: "unknown" } },
+    };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("rejects empty filters even with excludeIds", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+
+    const req = {
+      user: { claims: { sub: "owner-123" } },
+      body: { filters: {}, excludeIds: ["abc", -1, 0] },
+    };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("rejects non-integer excludeIds with valid filters", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+
+    const req = {
+      user: { claims: { sub: "owner-123" } },
+      body: { filters: { level: "error" }, excludeIds: ["abc", -1, 0] },
+    };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("rejects unexpected properties via strict schema", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+
+    const req = {
+      user: { claims: { sub: "owner-123" } },
+      body: { ids: [1], extraProp: "should not be here" },
+    };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+    expect(res._json.errors).toBeDefined();
+  });
+
+  it("rejects filters with unexpected nested properties via strict schema", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+
+    const req = {
+      user: { claims: { sub: "owner-123" } },
+      body: { filters: { level: "error", unknownField: true } },
+    };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(400);
+    expect(res._json.message).toBe("Invalid request body");
+  });
+
+  it("returns 500 when database throws", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockSelectWhereFn.mockRejectedValue(new Error("DB error"));
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: { ids: [1] } };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(500);
+    expect(res._json).toEqual({ message: "Failed to batch delete error logs" });
+    errorSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/error-logs/restore
+// ---------------------------------------------------------------------------
+describe("POST /api/admin/error-logs/restore", () => {
+  const ENDPOINT = "/api/admin/error-logs/restore";
+
+  beforeEach(async () => {
+    await ensureRoutes();
+    vi.clearAllMocks();
+
+    // restore uses .where(...).orderBy(...).limit(500), so chain through mockOrderByFn/mockLimitFn
+    mockLimitFn.mockResolvedValue([]);
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ orderBy: mockOrderByFn, limit: mockLimitFn });
+    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn });
+    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+
+    mockUpdateWhereFn.mockResolvedValue(undefined);
+    mockUpdateSetFn.mockReturnValue({ where: mockUpdateWhereFn });
+    mockDbUpdate.mockReturnValue({ set: mockUpdateSetFn });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const req = { user: null, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(401);
+    expect(res._json).toEqual({ message: "Unauthorized" });
+  });
+
+  it("returns 403 when user is not power tier", async () => {
+    mockGetUser.mockResolvedValue({ tier: "free" });
+    const req = { user: { claims: { sub: "user-1" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Admin access required" });
+  });
+
+  it("restores authorized soft-deleted entries for app owner", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: null, deletedAt: new Date() },
+      { id: 2, context: null, deletedAt: new Date() },
+    ]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "2 entries restored", count: 2, hasMore: false });
+    expect(mockDbUpdate).toHaveBeenCalled();
+    expect(mockUpdateSetFn).toHaveBeenCalled();
+  });
+
+  it("excludes entries not owned by non-owner user", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 10 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 10 }, deletedAt: new Date() },
+      { id: 2, context: { monitorId: 99 }, deletedAt: new Date() },
+      { id: 3, context: null, deletedAt: new Date() },
+    ]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "1 entries restored", count: 1, hasMore: false });
+  });
+
+  it("returns count 0 when no soft-deleted entries exist", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "0 entries restored", count: 0, hasMore: false });
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when database throws", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockRejectedValue(new Error("DB error"));
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(500);
+    expect(res._json).toEqual({ message: "Failed to restore error logs" });
+    errorSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/error-logs/finalize
+// ---------------------------------------------------------------------------
+describe("POST /api/admin/error-logs/finalize", () => {
+  const ENDPOINT = "/api/admin/error-logs/finalize";
+
+  beforeEach(async () => {
+    await ensureRoutes();
+    vi.clearAllMocks();
+
+    // finalize uses .where(...).orderBy(...).limit(500), so chain through mockOrderByFn/mockLimitFn
+    mockLimitFn.mockResolvedValue([]);
+    mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ orderBy: mockOrderByFn, limit: mockLimitFn });
+    mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn });
+    mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
+
+    mockDeleteWhereFn.mockResolvedValue(undefined);
+    mockDbDelete.mockReturnValue({ where: mockDeleteWhereFn });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const req = { user: null, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(401);
+    expect(res._json).toEqual({ message: "Unauthorized" });
+  });
+
+  it("returns 403 when user is not power tier", async () => {
+    mockGetUser.mockResolvedValue({ tier: "pro" });
+    const req = { user: { claims: { sub: "user-1" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(403);
+    expect(res._json).toEqual({ message: "Admin access required" });
+  });
+
+  it("hard-deletes authorized soft-deleted entries for app owner", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: null, deletedAt: new Date() },
+      { id: 2, context: null, deletedAt: new Date() },
+    ]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "2 entries finalized", count: 2, hasMore: false });
+    expect(mockDbDelete).toHaveBeenCalled();
+    expect(mockDeleteWhereFn).toHaveBeenCalled();
+  });
+
+  it("excludes entries not owned by non-owner user", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 5 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 5 }, deletedAt: new Date() },
+      { id: 2, context: { monitorId: 99 }, deletedAt: new Date() },
+      { id: 3, context: null, deletedAt: new Date() },
+    ]);
+
+    const req = { user: { claims: { sub: "not-the-owner" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "1 entries finalized", count: 1, hasMore: false });
+  });
+
+  it("returns count 0 when no soft-deleted entries exist", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([]);
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ message: "0 entries finalized", count: 0, hasMore: false });
+    expect(mockDbDelete).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when database throws", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockRejectedValue(new Error("DB error"));
+
+    const req = { user: { claims: { sub: "owner-123" } }, body: {} };
+    const res = await callHandler("post", ENDPOINT, req);
+    expect(res._status).toBe(500);
+    expect(res._json).toEqual({ message: "Failed to finalize error logs" });
+    errorSpy.mockRestore();
+  });
+});
+
+describe("POST /api/test-email", () => {
+  it("is registered as POST, not GET", async () => {
+    await ensureRoutes();
+    expect(registeredRoutes["post"]?.["/api/test-email"]).toBeDefined();
+    expect(registeredRoutes["get"]?.["/api/test-email"]).toBeUndefined();
+  });
+});

--- a/server/routes.deleteErrorLog.test.ts
+++ b/server/routes.deleteErrorLog.test.ts
@@ -85,7 +85,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.deleteFailedCampaign.test.ts
+++ b/server/routes.deleteFailedCampaign.test.ts
@@ -92,6 +92,14 @@ vi.mock("./storage", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./services/scraper", () => ({
   checkMonitor: vi.fn(),
   extractWithBrowserless: vi.fn(),

--- a/server/routes.deleteFailedCampaign.test.ts
+++ b/server/routes.deleteFailedCampaign.test.ts
@@ -95,7 +95,6 @@ vi.mock("./storage", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.errorLogCount.test.ts
+++ b/server/routes.errorLogCount.test.ts
@@ -1,13 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
-
-const previousAppOwnerId = process.env.APP_OWNER_ID;
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock variables
 // ---------------------------------------------------------------------------
 const {
   mockGetUser,
-  mockDbExecute,
+  mockGetMonitors,
   mockDbSelect,
   mockLimitFn,
   mockSelectWhereFn,
@@ -19,11 +17,10 @@ const {
   const mockSelectWhereFn = vi.fn(() => ({ limit: mockLimitFn, orderBy: mockOrderByFn }));
   const mockSelectFromFn = vi.fn(() => ({ where: mockSelectWhereFn, orderBy: mockOrderByFn }));
   const mockDbSelect = vi.fn(() => ({ from: mockSelectFromFn }));
-  const mockDbExecute = vi.fn();
 
   return {
     mockGetUser: vi.fn(),
-    mockDbExecute,
+    mockGetMonitors: vi.fn(),
     mockDbSelect,
     mockLimitFn,
     mockSelectWhereFn,
@@ -33,7 +30,7 @@ const {
 });
 
 // ---------------------------------------------------------------------------
-// Module mocks
+// Module mocks (same pattern as deleteErrorLog test)
 // ---------------------------------------------------------------------------
 vi.mock("./replit_integrations/auth", () => ({
   setupAuth: vi.fn().mockResolvedValue(undefined),
@@ -50,21 +47,22 @@ vi.mock("./replit_integrations/auth/storage", () => ({
 vi.mock("./storage", () => ({
   storage: {
     getMonitor: vi.fn(),
-    getMonitors: vi.fn().mockResolvedValue([]),
+    getMonitors: (...args: any[]) => mockGetMonitors(...args),
     getAllActiveMonitors: vi.fn().mockResolvedValue([]),
     deleteMonitor: vi.fn(),
     createMonitor: vi.fn(),
     updateMonitor: vi.fn(),
+    getMonitorCount: vi.fn().mockResolvedValue(0),
   },
 }));
 
 vi.mock("./db", () => ({
   db: {
     select: (...args: any[]) => mockDbSelect(...args),
-    delete: vi.fn(() => ({ where: vi.fn() })),
+    delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
     insert: vi.fn().mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }),
-    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) })) })) })),
-    execute: (...args: any[]) => mockDbExecute(...args),
+    update: vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }) }),
+    execute: vi.fn().mockResolvedValue({ rows: [] }),
   },
 }));
 
@@ -118,16 +116,8 @@ vi.mock("./services/scheduler", () => ({
   startScheduler: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("./services/campaignEmail", () => ({
-  sendTestCampaignEmail: vi.fn(),
-  previewRecipients: vi.fn().mockResolvedValue({ count: 0, users: [] }),
-  resolveRecipients: vi.fn().mockResolvedValue([]),
-  triggerCampaignSend: vi.fn().mockResolvedValue({ totalRecipients: 0 }),
-  cancelCampaign: vi.fn().mockResolvedValue({ sentSoFar: 0, cancelled: 0 }),
-}));
-
 // ---------------------------------------------------------------------------
-// Helpers: capture route handlers from Express mock
+// Helpers
 // ---------------------------------------------------------------------------
 type RouteHandler = (req: any, res: any, next?: any) => Promise<any>;
 const registeredRoutes: Record<string, Record<string, RouteHandler[]>> = {};
@@ -177,26 +167,18 @@ let routesRegistered = false;
 async function ensureRoutes() {
   if (routesRegistered) return;
   process.env.APP_OWNER_ID = "owner-123";
+
   const { registerRoutes } = await import("./routes");
   const app = makeMockApp();
-  const mockHttpServer = {} as any;
-  await registerRoutes(mockHttpServer, app as any);
+  await registerRoutes(app as any, app as any);
   routesRegistered = true;
 }
 
-afterAll(() => {
-  if (previousAppOwnerId === undefined) {
-    delete process.env.APP_OWNER_ID;
-  } else {
-    process.env.APP_OWNER_ID = previousAppOwnerId;
-  }
-});
-
 // ---------------------------------------------------------------------------
-// Tests: GET /api/admin/campaigns/dashboard
+// Tests
 // ---------------------------------------------------------------------------
-describe("GET /api/admin/campaigns/dashboard", () => {
-  const ENDPOINT = "/api/admin/campaigns/dashboard";
+describe("GET /api/admin/error-logs/count", () => {
+  const ENDPOINT = "/api/admin/error-logs/count";
 
   beforeEach(async () => {
     await ensureRoutes();
@@ -204,159 +186,133 @@ describe("GET /api/admin/campaigns/dashboard", () => {
 
     // Reset chain mocks
     mockOrderByFn.mockReturnValue({ limit: mockLimitFn });
+    mockSelectWhereFn.mockReturnValue({ limit: mockLimitFn, orderBy: mockOrderByFn });
     mockSelectFromFn.mockReturnValue({ where: mockSelectWhereFn, orderBy: mockOrderByFn });
     mockDbSelect.mockReturnValue({ from: mockSelectFromFn });
   });
 
-  it("returns 401 when user is not authenticated", async () => {
+  it("returns 401 with count 0 when user is not authenticated", async () => {
     const req = { user: null };
     const res = await callHandler("get", ENDPOINT, req);
     expect(res._status).toBe(401);
-    expect(res._json).toEqual({ message: "Unauthorized" });
+    expect(res._json).toEqual({ count: 0 });
   });
 
-  it("returns 403 when user is not power tier", async () => {
+  it("returns 403 with count 0 when user is not power tier", async () => {
     mockGetUser.mockResolvedValue({ tier: "pro" });
     const req = { user: { claims: { sub: "user-1" } } };
     const res = await callHandler("get", ENDPOINT, req);
     expect(res._status).toBe(403);
-    expect(res._json).toEqual({ message: "Admin access required" });
+    expect(res._json).toEqual({ count: 0 });
   });
 
-  it("returns 403 when power user is not app owner", async () => {
-    mockGetUser.mockResolvedValue({ tier: "power" });
-    const req = { user: { claims: { sub: "not-the-owner" } } };
+  it("returns 403 with count 0 when user is null in database", async () => {
+    mockGetUser.mockResolvedValue(null);
+    const req = { user: { claims: { sub: "user-1" } } };
     const res = await callHandler("get", ENDPOINT, req);
     expect(res._status).toBe(403);
-    expect(res._json).toEqual({ message: "Owner access required" });
+    expect(res._json).toEqual({ count: 0 });
   });
 
-  it("returns dashboard stats with correct numeric conversion", async () => {
+  it("returns count of logs visible to app owner", async () => {
     mockGetUser.mockResolvedValue({ tier: "power" });
-    // Simulate PostgreSQL returning numeric types as strings (common with raw SQL)
-    mockDbExecute.mockResolvedValue({
-      rows: [{
-        totalCampaigns: "3",
-        totalSent: "150",
-        totalOpened: "45",
-        totalClicked: "12",
-        avgOpenRate: "32.5",
-        avgClickRate: "8.3",
-      }],
-    });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: null },
+      { id: 2, context: { monitorId: 10 } },
+      { id: 3, context: null },
+    ]);
+
+    const req = { user: { claims: { sub: "owner-123" } } };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    // Owner sees all 3: null context → owner-only, monitorId 10 → not in user monitors but fallback is owner
+    // Actually monitorId 10 is numeric and not in userMonitorIds (empty set), so it's excluded
+    // null context entries fall through to isAppOwner = true
+    expect(res._json).toEqual({ count: 2 });
+  });
+
+  it("returns count filtered to user's monitors for non-owner", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 5 }, { id: 10 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 5 } },
+      { id: 2, context: { monitorId: 10 } },
+      { id: 3, context: { monitorId: 99 } },
+      { id: 4, context: null },
+    ]);
+
+    const req = { user: { claims: { sub: "non-owner-user" } } };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    // Only monitors 5 and 10 match; monitorId 99 excluded, null context excluded (not owner)
+    expect(res._json).toEqual({ count: 2 });
+  });
+
+  it("returns count 0 when no unresolved logs exist", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
     mockLimitFn.mockResolvedValue([]);
 
     const req = { user: { claims: { sub: "owner-123" } } };
     const res = await callHandler("get", ENDPOINT, req);
-
     expect(res._status).toBe(200);
-    expect(res._json).toEqual({
-      totalCampaigns: 3,
-      totalSent: 150,
-      totalOpened: 45,
-      totalClicked: 12,
-      avgOpenRate: 32.5,
-      avgClickRate: 8.3,
-      recentCampaigns: [],
-    });
+    expect(res._json).toEqual({ count: 0 });
   });
 
-  it("returns zero rates when no campaigns exist", async () => {
-    mockGetUser.mockResolvedValue({ tier: "power" });
-    mockDbExecute.mockResolvedValue({
-      rows: [{
-        totalCampaigns: 0,
-        totalSent: 0,
-        totalOpened: 0,
-        totalClicked: 0,
-        avgOpenRate: "0.0",
-        avgClickRate: "0.0",
-      }],
-    });
-    mockLimitFn.mockResolvedValue([]);
-
-    const req = { user: { claims: { sub: "owner-123" } } };
-    const res = await callHandler("get", ENDPOINT, req);
-
-    expect(res._status).toBe(200);
-    expect(res._json.avgOpenRate).toBe(0);
-    expect(res._json.avgClickRate).toBe(0);
-  });
-
-  it("defaults to zero when stats row has null values", async () => {
-    mockGetUser.mockResolvedValue({ tier: "power" });
-    mockDbExecute.mockResolvedValue({
-      rows: [{ totalCampaigns: null, totalSent: null, totalOpened: null, totalClicked: null, avgOpenRate: null, avgClickRate: null }],
-    });
-    mockLimitFn.mockResolvedValue([]);
-
-    const req = { user: { claims: { sub: "owner-123" } } };
-    const res = await callHandler("get", ENDPOINT, req);
-
-    expect(res._status).toBe(200);
-    expect(res._json.totalCampaigns).toBe(0);
-    expect(res._json.totalSent).toBe(0);
-    expect(res._json.avgOpenRate).toBe(0);
-    expect(res._json.avgClickRate).toBe(0);
-  });
-
-  it("defaults to zero when stats row is undefined", async () => {
-    mockGetUser.mockResolvedValue({ tier: "power" });
-    mockDbExecute.mockResolvedValue({ rows: [undefined] });
-    mockLimitFn.mockResolvedValue([]);
-
-    const req = { user: { claims: { sub: "owner-123" } } };
-    const res = await callHandler("get", ENDPOINT, req);
-
-    expect(res._status).toBe(200);
-    expect(res._json.totalCampaigns).toBe(0);
-    expect(res._json.avgOpenRate).toBe(0);
-    expect(res._json.avgClickRate).toBe(0);
-  });
-
-  it("defaults to zero when rows array is empty", async () => {
-    mockGetUser.mockResolvedValue({ tier: "power" });
-    mockDbExecute.mockResolvedValue({ rows: [] });
-    mockLimitFn.mockResolvedValue([]);
-
-    const req = { user: { claims: { sub: "owner-123" } } };
-    const res = await callHandler("get", ENDPOINT, req);
-
-    expect(res._status).toBe(200);
-    expect(res._json.totalCampaigns).toBe(0);
-    expect(res._json.avgOpenRate).toBe(0);
-    expect(res._json.avgClickRate).toBe(0);
-  });
-
-  it("includes recent campaigns in response", async () => {
-    mockGetUser.mockResolvedValue({ tier: "power" });
-    mockDbExecute.mockResolvedValue({
-      rows: [{ totalCampaigns: 2, totalSent: 10, totalOpened: 5, totalClicked: 2, avgOpenRate: "50.0", avgClickRate: "20.0" }],
-    });
-    const mockCampaigns = [
-      { id: 1, name: "Campaign A", status: "sent", sentCount: 5, openedCount: 3, clickedCount: 1 },
-      { id: 2, name: "Campaign B", status: "sent", sentCount: 5, openedCount: 2, clickedCount: 1 },
-    ];
-    mockLimitFn.mockResolvedValue(mockCampaigns);
-
-    const req = { user: { claims: { sub: "owner-123" } } };
-    const res = await callHandler("get", ENDPOINT, req);
-
-    expect(res._status).toBe(200);
-    expect(res._json.recentCampaigns).toEqual(mockCampaigns);
-    expect(res._json.recentCampaigns).toHaveLength(2);
-  });
-
-  it("returns 500 when database throws an error", async () => {
+  it("returns count 0 when database throws an error", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mockGetUser.mockResolvedValue({ tier: "power" });
-    mockDbExecute.mockRejectedValue(new Error("DB connection lost"));
+    mockLimitFn.mockRejectedValue(new Error("DB connection lost"));
 
     const req = { user: { claims: { sub: "owner-123" } } };
     const res = await callHandler("get", ENDPOINT, req);
-
-    expect(res._status).toBe(500);
-    expect(res._json).toEqual({ message: "Failed to fetch campaign dashboard" });
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ count: 0 });
     errorSpy.mockRestore();
+  });
+
+  it("treats string monitorId as missing (non-owner gets 0)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 42 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: "42" } },
+    ]);
+
+    const req = { user: { claims: { sub: "non-owner" } } };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    // String "42" is not numeric, treated as absent, non-owner can't see
+    expect(res._json).toEqual({ count: 0 });
+  });
+
+  it("owner sees logs with string monitorId (treated as system log)", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: "injected" } },
+    ]);
+
+    const req = { user: { claims: { sub: "owner-123" } } };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ count: 1 });
+  });
+
+  it("correctly counts mixed context types", async () => {
+    mockGetUser.mockResolvedValue({ tier: "power" });
+    mockGetMonitors.mockResolvedValue([{ id: 5 }]);
+    mockLimitFn.mockResolvedValue([
+      { id: 1, context: { monitorId: 5 } },          // numeric, matches
+      { id: 2, context: { monitorId: "5" } },         // string → excluded
+      { id: 3, context: null },                        // null → excluded (non-owner)
+      { id: 4, context: { monitorId: 99 } },          // numeric, no match
+      { id: 5, context: { other: "data" } },           // no monitorId → excluded
+    ]);
+
+    const req = { user: { claims: { sub: "non-owner" } } };
+    const res = await callHandler("get", ENDPOINT, req);
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ count: 1 });
   });
 });

--- a/server/routes.errorLogCount.test.ts
+++ b/server/routes.errorLogCount.test.ts
@@ -69,7 +69,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.migration.test.ts
+++ b/server/routes.migration.test.ts
@@ -64,10 +64,25 @@ vi.mock("./db", () => ({
     insert: vi.fn().mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }),
     update: vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }) }),
     execute: (...args: any[]) => mockDbExecute(...args),
+    // Delegate tx.execute back to the same mockDbExecute so the
+    // ensureErrorLogColumns migration's in-transaction SQL (SET LOCAL,
+    // pg_advisory_xact_lock, dedup UPDATE, dedup DELETE) is actually
+    // exercised under the migration mock sequences below. Without this,
+    // db.transaction is undefined and the whole migration falls into its
+    // catch block — silently making the 9-call sequence assertions pass
+    // for the wrong reason.
     transaction: async (fn: (tx: any) => Promise<any>) => {
       const tx = { execute: (...args: any[]) => mockDbExecute(...args) };
       return fn(tx);
     },
+  },
+}));
+
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -139,7 +154,7 @@ function makeMockApp() {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-describe("registerRoutes DDL migrations at startup", () => {
+describe("error_logs dedup column migration at startup", () => {
   beforeEach(() => {
     // Clear registered routes for fresh registration
     for (const method of Object.keys(registeredRoutes)) {
@@ -189,6 +204,64 @@ describe("registerRoutes DDL migrations at startup", () => {
     expect(callStrings.some((s: string) => s.includes("notification_queue") && s.includes("permanently_failed"))).toBe(true);
     expect(callStrings.some((s: string) => s.includes("automated_campaign_configs"))).toBe(true);
     expect(callStrings.some((s: string) => s.includes("pending_retry_at"))).toBe(true);
+  });
+
+  it("still registers all route groups when migration succeeds", async () => {
+    vi.clearAllMocks();
+    mockDbExecute.mockResolvedValue({ rows: [] });
+    process.env.APP_OWNER_ID = "owner-123";
+
+    const { registerRoutes } = await import("./routes");
+    const app = makeMockApp();
+    await registerRoutes(app as any, app as any);
+
+    const getRoutes = Object.keys(registeredRoutes["get"] ?? {});
+    expect(getRoutes).toContain("/api/admin/error-logs");
+    expect(getRoutes).toContain("/api/admin/error-logs/count");
+  });
+
+  it("still registers routes when migration fails", async () => {
+    vi.clearAllMocks();
+    mockDbExecute.mockRejectedValue(new Error("relation \"error_logs\" does not exist"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.APP_OWNER_ID = "owner-123";
+
+    const { registerRoutes } = await import("./routes");
+    const app = makeMockApp();
+
+    // Should not throw even though migration failed
+    await registerRoutes(app as any, app as any);
+
+    // Routes should still be registered despite migration failure
+    const getRoutes = Object.keys(registeredRoutes["get"] ?? {});
+    expect(getRoutes).toContain("/api/admin/error-logs");
+    expect(getRoutes).toContain("/api/admin/error-logs/count");
+    const deleteRoutes = Object.keys(registeredRoutes["delete"] ?? {});
+    expect(deleteRoutes).toContain("/api/admin/error-logs/:id");
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("logs a warning when migration fails", async () => {
+    vi.clearAllMocks();
+    const migrationError = new Error("connection refused");
+    mockDbExecute.mockRejectedValue(migrationError);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.APP_OWNER_ID = "owner-123";
+
+    const { registerRoutes } = await import("./routes");
+    const app = makeMockApp();
+    await registerRoutes(app as any, app as any);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Could not ensure error_logs columns/index:",
+      migrationError,
+    );
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("does not throw when first execute succeeds but second fails", async () => {
@@ -341,12 +414,22 @@ describe("registerRoutes DDL migrations at startup", () => {
   it("logs error and continues when notification channel table creation fails", async () => {
     vi.clearAllMocks();
     const channelError = new Error("permission denied for schema public");
-    // monitor health ALTERs succeed (2), pending_retry_at (1), api_keys
-    // succeed (2), then channel tables fail
+    // monitor health ALTERs succeed (2), pending_retry_at (1), error_logs
+    // migration succeeds (3 ALTERs + 1 pg_indexes check + 4 in-tx + 1 CREATE
+    // INDEX CONCURRENTLY = 9), api_keys succeed (2), then channel tables fail
     mockDbExecute
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors health_alert_sent_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors last_healthy_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors pending_retry_at
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs first_occurrence
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs occurrence_count
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs deleted_at
+      .mockResolvedValueOnce({ rows: [] }) // pg_indexes check (no existing idx)
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL lock_timeout
+      .mockResolvedValueOnce({ rows: [] }) // pg_advisory_xact_lock
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE dedup
+      .mockResolvedValueOnce({ rows: [] }) // DELETE dedup
+      .mockResolvedValueOnce({ rows: [] }) // CREATE UNIQUE INDEX CONCURRENTLY
       .mockResolvedValueOnce({ rows: [] }) // CREATE api_keys
       .mockResolvedValueOnce({ rows: [] }) // CREATE INDEX api_keys
       .mockRejectedValueOnce(channelError); // notification_channels fails
@@ -370,6 +453,7 @@ describe("registerRoutes DDL migrations at startup", () => {
     // Routes should still be registered
     const getRoutes = Object.keys(registeredRoutes["get"] ?? {});
     expect(getRoutes.length).toBeGreaterThan(0);
+    expect(getRoutes).toContain("/api/admin/error-logs");
 
     errorSpy.mockRestore();
     warnSpy.mockRestore();
@@ -378,12 +462,22 @@ describe("registerRoutes DDL migrations at startup", () => {
   it("registers channel routes even when notification channel tables fail to create", async () => {
     vi.clearAllMocks();
     const channelError = new Error("connection timeout");
-    // monitor health ALTERs succeed (2), pending_retry_at (1), api_keys
-    // succeed (2), channel tables fail
+    // monitor health ALTERs succeed (2), pending_retry_at (1), error_logs
+    // migration succeeds (3 ALTERs + 1 pg_indexes check + 4 in-tx + 1 CREATE
+    // INDEX CONCURRENTLY = 9), api_keys succeed (2), channel tables fail
     mockDbExecute
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors health_alert_sent_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors last_healthy_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors pending_retry_at
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs first_occurrence
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs occurrence_count
+      .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs deleted_at
+      .mockResolvedValueOnce({ rows: [] }) // pg_indexes check (no existing idx)
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL lock_timeout
+      .mockResolvedValueOnce({ rows: [] }) // pg_advisory_xact_lock
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE dedup
+      .mockResolvedValueOnce({ rows: [] }) // DELETE dedup
+      .mockResolvedValueOnce({ rows: [] }) // CREATE UNIQUE INDEX CONCURRENTLY
       .mockResolvedValueOnce({ rows: [] }) // CREATE api_keys
       .mockResolvedValueOnce({ rows: [] }) // CREATE INDEX api_keys
       .mockRejectedValueOnce(channelError); // notification_channels fails

--- a/server/routes.migration.test.ts
+++ b/server/routes.migration.test.ts
@@ -81,7 +81,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.notificationChannels.test.ts
+++ b/server/routes.notificationChannels.test.ts
@@ -96,7 +96,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.notificationChannels.test.ts
+++ b/server/routes.notificationChannels.test.ts
@@ -93,6 +93,14 @@ vi.mock("./db", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./services/scraper", () => ({
   checkMonitor: vi.fn(),
   extractWithBrowserless: vi.fn(),

--- a/server/routes.notificationPreferences.test.ts
+++ b/server/routes.notificationPreferences.test.ts
@@ -54,6 +54,14 @@ vi.mock("./db", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./services/scraper", () => ({
   checkMonitor: vi.fn(),
   extractWithBrowserless: vi.fn(),

--- a/server/routes.notificationPreferences.test.ts
+++ b/server/routes.notificationPreferences.test.ts
@@ -57,7 +57,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.tags.test.ts
+++ b/server/routes.tags.test.ts
@@ -91,7 +91,6 @@ vi.mock("./db", () => ({
 vi.mock("./services/logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/server/routes.tags.test.ts
+++ b/server/routes.tags.test.ts
@@ -88,6 +88,14 @@ vi.mock("./db", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./services/scraper", () => ({
   checkMonitor: vi.fn(),
   extractWithBrowserless: vi.fn(),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1536,7 +1536,7 @@ export async function registerRoutes(
       const limitNum = Math.max(1, Math.min(Number(req.query.limit) || 100, 500));
 
       const conditions = [eq(errorLogs.resolved, false), isNull(errorLogs.deletedAt)];
-      if (level && ["error", "warning", "info"].includes(level)) {
+      if (level && ["error", "info"].includes(level)) {
         conditions.push(eq(errorLogs.level, level));
       }
       if (source && (ERROR_LOG_SOURCES as readonly string[]).includes(source)) {
@@ -1623,7 +1623,7 @@ export async function registerRoutes(
       const batchDeleteSchema = z.object({
         ids: z.array(z.number().int().positive()).min(1).max(500).optional(),
         filters: z.object({
-          level: z.enum(["error", "warning", "info"]).optional(),
+          level: z.enum(["error", "info"]).optional(),
           source: errorLogSourceSchema.optional(),
         }).strict().refine(
           (data) => data.level !== undefined || data.source !== undefined,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1495,10 +1495,14 @@ export async function registerRoutes(
 
       const isAppOwner = userId === APP_OWNER_ID;
 
+      // Filter to the same level set the UI dropdown offers so the badge
+      // count matches what the admin sees after clicking through. Legacy
+      // "warning" rows (from pre-deprecation writes) are still viewable via
+      // source-filtered queries but do not inflate the badge.
       const allResults = await db
         .select({ id: errorLogs.id, context: errorLogs.context })
         .from(errorLogs)
-        .where(and(eq(errorLogs.resolved, false), isNull(errorLogs.deletedAt)))
+        .where(and(eq(errorLogs.resolved, false), isNull(errorLogs.deletedAt), inArray(errorLogs.level, ["error", "info"])))
         .limit(500);
 
       const userMonitorIds = new Set(

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -44,7 +44,8 @@ import { renderRobotsTxt, renderSitemapXml } from "./services/seoFiles";
 // URL VALIDATION - SSRF PROTECTION (shared module)
 // ------------------------------------------------------------------
 import { isPrivateUrl, ssrfSafeFetch } from './utils/ssrf';
-import { checkFrequencyTier, safeHostname } from './services/monitorValidation';
+import { checkFrequencyTier } from './services/monitorValidation';
+import { safeHostname } from './utils/urlUtils';
 
 // ------------------------------------------------------------------
 // 1. CHECK MONITOR FUNCTION

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,7 @@ import { getResendClient } from "./services/resendClient";
 import type { Express, Request, Response, NextFunction } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { api, channelTypeSchema, webhookConfigInputSchema, slackConfigInputSchema, createTagSchema, updateTagSchema, setMonitorTagsSchema, createConditionSchema } from "@shared/routes";
+import { api, channelTypeSchema, webhookConfigInputSchema, slackConfigInputSchema, createTagSchema, updateTagSchema, setMonitorTagsSchema, createConditionSchema, ERROR_LOG_SOURCES, errorLogSourceSchema } from "@shared/routes";
 import { isSafeRegex } from "./services/conditions";
 import { z } from "zod";
 import { setupAuth, registerAuthRoutes, isAuthenticated } from "./replit_integrations/auth";
@@ -12,14 +12,15 @@ import { TIER_LIMITS, TAG_LIMITS, TAG_ASSIGNMENT_LIMITS, BROWSERLESS_CAPS, RESEN
 // startScheduler is called from index.ts after registerRoutes completes
 import * as cheerio from "cheerio";
 import { getUncachableStripeClient, getStripePublishableKey } from "./stripeClient";
-import { sql, desc, eq, and, isNull } from "drizzle-orm";
+import { sql, asc, desc, eq, and, isNull, isNotNull, inArray, notInArray } from "drizzle-orm";
 import { db } from "./db";
 import { sendNotificationEmail } from "./services/email";
+import { ErrorLogger } from "./services/logger";
 import { notificationTablesExist, channelTablesExist } from "./services/notificationReady";
 import { seedDefaultEmailChannel } from "./services/notification";
 import { BrowserlessUsageTracker, getMonthResetDate } from "./services/browserlessTracker";
 import { ResendUsageTracker, getResendResetDate } from "./services/resendTracker";
-import { monitorMetrics, monitors } from "@shared/schema";
+import { errorLogs, monitorMetrics, monitors } from "@shared/schema";
 import {
   generalRateLimiter,
   createMonitorRateLimiter,
@@ -35,7 +36,7 @@ import { encryptToken, decryptToken, isValidEncryptedToken } from "./utils/encry
 import { validateHost } from "./utils/hostValidation";
 import { createHmac } from "node:crypto";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
-import { ensureApiKeysTable, ensureChannelTables, ensureTagTables, ensureMonitorHealthColumns, ensureMonitorConditionsTable, ensureNotificationQueueColumns, ensureAutomatedCampaignConfigsTable, ensureMonitorPendingRetryColumn, ensureAutomationSubscriptionsTable, ensureMonitorChangesIndexes, ensureCampaignPartialIndexes } from "./services/ensureTables";
+import { ensureErrorLogColumns, ensureApiKeysTable, ensureChannelTables, ensureTagTables, ensureMonitorHealthColumns, ensureMonitorConditionsTable, ensureNotificationQueueColumns, ensureAutomatedCampaignConfigsTable, ensureMonitorPendingRetryColumn, ensureAutomationSubscriptionsTable, ensureMonitorChangesIndexes, ensureCampaignPartialIndexes } from "./services/ensureTables";
 import { renderRobotsTxt, renderSitemapXml } from "./services/seoFiles";
 
 
@@ -51,6 +52,16 @@ import { checkFrequencyTier, safeHostname } from './services/monitorValidation';
 async function checkMonitor(monitor: any) {
   console.log(`Checking monitor ${monitor.id}: ${safeHostname(monitor.url)}`);
   return scraperCheckMonitor(monitor);
+}
+
+let softDeleteCleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+/** Clear the soft-delete cleanup interval. Call during graceful shutdown. */
+export function stopRouteTimers(): void {
+  if (softDeleteCleanupInterval) {
+    clearInterval(softDeleteCleanupInterval);
+    softDeleteCleanupInterval = null;
+  }
 }
 
 // ------------------------------------------------------------------
@@ -76,6 +87,7 @@ export async function registerRoutes(
   if (!pendingRetryReady) {
     criticalSchemaFailures.push("monitors.pending_retry_at column");
   }
+  await ensureErrorLogColumns();
   const apiKeysReady = await ensureApiKeysTable();
   const channelTablesReady = await ensureChannelTables();
   if (!channelTablesReady) {
@@ -1461,11 +1473,334 @@ export async function registerRoutes(
     }
   });
 
-  // APP_OWNER_ID gates owner-only admin endpoints (users overview, Browserless/Resend usage).
+  // Admin error logs endpoint (restricted to Power tier users, scoped to own monitors)
   const APP_OWNER_ID = process.env.APP_OWNER_ID;
   if (!APP_OWNER_ID) {
     console.warn("APP_OWNER_ID not set; owner-only admin endpoints will be inaccessible.");
   }
+  // Lightweight count endpoint for notification badge.
+  // Returns { count: 0 } instead of { message, code } on auth errors so the
+  // client badge can consume every response shape uniformly without error handling.
+  app.get("/api/admin/error-logs/count", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user?.claims?.sub;
+      if (!userId) {
+        return res.status(401).json({ count: 0 });
+      }
+      const user = await authStorage.getUser(userId);
+      if (!user || user.tier !== "power") {
+        return res.status(403).json({ count: 0 });
+      }
+
+      const isAppOwner = userId === APP_OWNER_ID;
+
+      const allResults = await db
+        .select({ id: errorLogs.id, context: errorLogs.context })
+        .from(errorLogs)
+        .where(and(eq(errorLogs.resolved, false), isNull(errorLogs.deletedAt)))
+        .limit(500);
+
+      const userMonitorIds = new Set(
+        (await storage.getMonitors(userId)).map((m: any) => m.id)
+      );
+
+      const count = allResults.filter((log: any) => {
+        const ctx = log.context as Record<string, unknown> | null;
+        const monitorId = ctx && typeof ctx.monitorId === "number" ? ctx.monitorId : undefined;
+        if (monitorId !== undefined) {
+          return userMonitorIds.has(monitorId);
+        }
+        return isAppOwner;
+      }).length;
+
+      res.json({ count });
+    } catch (error: any) {
+      console.error("Error fetching error log count:", error);
+      res.json({ count: 0 });
+    }
+  });
+
+  app.get("/api/admin/error-logs", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user?.claims?.sub;
+      if (!userId) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+      const user = await authStorage.getUser(userId);
+      if (!user || user.tier !== "power") {
+        return res.status(403).json({ message: "Admin access required" });
+      }
+
+      const level = req.query.level as string | undefined;
+      const source = req.query.source as string | undefined;
+      const limitNum = Math.max(1, Math.min(Number(req.query.limit) || 100, 500));
+
+      const conditions = [eq(errorLogs.resolved, false), isNull(errorLogs.deletedAt)];
+      if (level && ["error", "warning", "info"].includes(level)) {
+        conditions.push(eq(errorLogs.level, level));
+      }
+      if (source && (ERROR_LOG_SOURCES as readonly string[]).includes(source)) {
+        conditions.push(eq(errorLogs.source, source));
+      }
+
+      let query = db.select().from(errorLogs).where(and(...conditions)).orderBy(desc(errorLogs.timestamp)).limit(limitNum);
+
+      const allResults = await query;
+
+      const isAppOwner = userId === APP_OWNER_ID;
+
+      const userMonitorIds = new Set(
+        (await storage.getMonitors(userId)).map((m: any) => m.id)
+      );
+
+      const filtered = allResults.filter((log: any) => {
+        const ctx = log.context as Record<string, unknown> | null;
+        const monitorId = ctx && typeof ctx.monitorId === "number" ? ctx.monitorId : undefined;
+        if (monitorId !== undefined) {
+          return userMonitorIds.has(monitorId);
+        }
+        return isAppOwner;
+      });
+
+      res.json(filtered);
+    } catch (error: any) {
+      console.error("Error fetching error logs:", error);
+      res.status(500).json({ message: "Failed to fetch error logs" });
+    }
+  });
+
+  app.delete("/api/admin/error-logs/:id", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user?.claims?.sub;
+      if (!userId) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+      const user = await authStorage.getUser(userId);
+      if (!user || user.tier !== "power") {
+        return res.status(403).json({ message: "Admin access required" });
+      }
+
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id) || id <= 0) {
+        return res.status(400).json({ message: "Invalid log ID" });
+      }
+
+      const [log] = await db.select().from(errorLogs).where(and(eq(errorLogs.id, id), isNull(errorLogs.deletedAt))).limit(1);
+      if (!log) {
+        return res.status(404).json({ message: "Log entry not found" });
+      }
+
+      const isAppOwner = userId === APP_OWNER_ID;
+      const userMonitorIds = new Set(
+        (await storage.getMonitors(userId)).map((m: any) => m.id)
+      );
+      const ctx = log.context as Record<string, unknown> | null;
+      const monitorId = ctx && typeof ctx.monitorId === "number" ? ctx.monitorId : undefined;
+      if (monitorId !== undefined ? !userMonitorIds.has(monitorId) : !isAppOwner) {
+        return res.status(403).json({ message: "Not authorized to delete this log entry" });
+      }
+
+      await db.update(errorLogs).set({ deletedAt: new Date() }).where(eq(errorLogs.id, id));
+      res.json({ message: "Deleted" });
+    } catch (error: any) {
+      console.error("Error deleting error log:", error);
+      res.status(500).json({ message: "Failed to delete error log" });
+    }
+  });
+
+  // Batch soft-delete error log entries
+  app.post("/api/admin/error-logs/batch-delete", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user?.claims?.sub;
+      if (!userId) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+      const user = await authStorage.getUser(userId);
+      if (!user || user.tier !== "power") {
+        return res.status(403).json({ message: "Admin access required" });
+      }
+
+      const batchDeleteSchema = z.object({
+        ids: z.array(z.number().int().positive()).min(1).max(500).optional(),
+        filters: z.object({
+          level: z.enum(["error", "warning", "info"]).optional(),
+          source: errorLogSourceSchema.optional(),
+        }).strict().refine(
+          (data) => data.level !== undefined || data.source !== undefined,
+          { message: "filters must include at least one of: level, source" },
+        ).optional(),
+        excludeIds: z.array(z.number().int().positive()).max(500).optional(),
+      }).strict().refine(
+        (data) => (data.ids !== undefined) !== (data.filters !== undefined),
+        { message: "Provide either ids or filters, not both" },
+      ).refine(
+        (data) => !(data.ids && data.excludeIds),
+        { message: "excludeIds cannot be used with ids" },
+      );
+
+      const parsed = batchDeleteSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ message: "Invalid request body", errors: parsed.error.flatten() });
+      }
+      const { ids, filters, excludeIds } = parsed.data;
+
+      const isAppOwner = userId === APP_OWNER_ID;
+      const userMonitorIds = new Set(
+        (await storage.getMonitors(userId)).map((m: any) => m.id)
+      );
+
+      const now = new Date();
+
+      if (ids) {
+        const entries = await db.select().from(errorLogs)
+          .where(and(inArray(errorLogs.id, ids), isNull(errorLogs.deletedAt)));
+
+        const authorized = entries.filter((log: any) => {
+          const ctx = log.context as Record<string, unknown> | null;
+          const monitorId = ctx && typeof ctx.monitorId === "number" ? ctx.monitorId : undefined;
+          if (monitorId !== undefined) return userMonitorIds.has(monitorId);
+          return isAppOwner;
+        });
+
+        if (authorized.length > 0) {
+          const authorizedIds = authorized.map((e: any) => e.id);
+          await db.update(errorLogs).set({ deletedAt: now }).where(inArray(errorLogs.id, authorizedIds));
+        }
+        res.json({ message: `${authorized.length} entries deleted`, count: authorized.length });
+      } else if (filters) {
+        const conditions = [isNull(errorLogs.deletedAt)];
+        if (filters.level) {
+          conditions.push(eq(errorLogs.level, filters.level));
+        }
+        if (filters.source) {
+          conditions.push(eq(errorLogs.source, filters.source));
+        }
+        const excludeList = excludeIds ?? [];
+        if (excludeList.length > 0) {
+          conditions.push(notInArray(errorLogs.id, excludeList));
+        }
+
+        const entries = await db.select().from(errorLogs).where(and(...conditions)).orderBy(asc(errorLogs.id)).limit(500);
+
+        const authorized = entries.filter((log: any) => {
+          const ctx = log.context as Record<string, unknown> | null;
+          const monitorId = ctx && typeof ctx.monitorId === "number" ? ctx.monitorId : undefined;
+          if (monitorId !== undefined) return userMonitorIds.has(monitorId);
+          return isAppOwner;
+        });
+
+        if (authorized.length > 0) {
+          const authorizedIds = authorized.map((e: any) => e.id);
+          await db.update(errorLogs).set({ deletedAt: now }).where(inArray(errorLogs.id, authorizedIds));
+        }
+        const hasMore = entries.length === 500;
+        res.json({ message: `${authorized.length} entries deleted`, count: authorized.length, hasMore });
+      }
+    } catch (error: any) {
+      console.error("Error batch deleting error logs:", error);
+      res.status(500).json({ message: "Failed to batch delete error logs" });
+    }
+  });
+
+  // Restore soft-deleted error log entries (undo)
+  app.post("/api/admin/error-logs/restore", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user?.claims?.sub;
+      if (!userId) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+      const user = await authStorage.getUser(userId);
+      if (!user || user.tier !== "power") {
+        return res.status(403).json({ message: "Admin access required" });
+      }
+
+      const isAppOwner = userId === APP_OWNER_ID;
+      const userMonitorIds = new Set(
+        (await storage.getMonitors(userId)).map((m: any) => m.id)
+      );
+
+      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).orderBy(asc(errorLogs.id)).limit(500);
+
+      const authorized = softDeleted.filter((log: any) => {
+        const ctx = log.context as Record<string, unknown> | null;
+        const monitorId = ctx && typeof ctx.monitorId === "number" ? ctx.monitorId : undefined;
+        if (monitorId !== undefined) return userMonitorIds.has(monitorId);
+        return isAppOwner;
+      });
+
+      if (authorized.length > 0) {
+        const authorizedIds = authorized.map((e: any) => e.id);
+        await db.update(errorLogs).set({ deletedAt: null }).where(inArray(errorLogs.id, authorizedIds));
+      }
+      const hasMore = softDeleted.length === 500;
+      res.json({ message: `${authorized.length} entries restored`, count: authorized.length, hasMore });
+    } catch (error: any) {
+      console.error("Error restoring error logs:", error);
+      res.status(500).json({ message: "Failed to restore error logs" });
+    }
+  });
+
+  // Finalize soft-deleted error log entries (hard-delete)
+  app.post("/api/admin/error-logs/finalize", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user?.claims?.sub;
+      if (!userId) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+      const user = await authStorage.getUser(userId);
+      if (!user || user.tier !== "power") {
+        return res.status(403).json({ message: "Admin access required" });
+      }
+
+      const isAppOwner = userId === APP_OWNER_ID;
+      const userMonitorIds = new Set(
+        (await storage.getMonitors(userId)).map((m: any) => m.id)
+      );
+
+      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).orderBy(asc(errorLogs.id)).limit(500);
+
+      const authorized = softDeleted.filter((log: any) => {
+        const ctx = log.context as Record<string, unknown> | null;
+        const monitorId = ctx && typeof ctx.monitorId === "number" ? ctx.monitorId : undefined;
+        if (monitorId !== undefined) return userMonitorIds.has(monitorId);
+        return isAppOwner;
+      });
+
+      if (authorized.length > 0) {
+        const authorizedIds = authorized.map((e: any) => e.id);
+        await db.delete(errorLogs).where(inArray(errorLogs.id, authorizedIds));
+      }
+      const hasMore = softDeleted.length === 500;
+      res.json({ message: `${authorized.length} entries finalized`, count: authorized.length, hasMore });
+    } catch (error: any) {
+      console.error("Error finalizing error logs:", error);
+      res.status(500).json({ message: "Failed to finalize error logs" });
+    }
+  });
+
+  // Server-side safety net: clean up orphaned soft-deleted entries older than 5 minutes
+  if (softDeleteCleanupInterval) {
+    clearInterval(softDeleteCleanupInterval);
+  }
+  softDeleteCleanupInterval = setInterval(async () => {
+    try {
+      const threshold = new Date(Date.now() - 5 * 60 * 1000);
+      // Batch-limit the delete to avoid materializing unbounded rows via .returning()
+      const rows = await db.delete(errorLogs).where(
+        and(
+          isNotNull(errorLogs.deletedAt),
+          sql`${errorLogs.deletedAt} < ${threshold}`,
+          sql`${errorLogs.id} IN (SELECT id FROM error_logs WHERE deleted_at IS NOT NULL AND deleted_at < ${threshold} LIMIT 1000)`,
+        )
+      ).returning({ id: errorLogs.id });
+      const count = rows.length;
+      if (count > 0) {
+        console.warn(`Safety net: cleaned up ${count} orphaned soft-deleted error log entries`);
+      }
+    } catch (error) {
+      console.error("Safety net cleanup error:", error);
+    }
+  }, 60 * 1000);
 
   // Admin users overview endpoint (owner-only)
   app.get("/api/admin/users-overview", isAuthenticated, async (req: any, res) => {
@@ -2711,26 +3046,12 @@ export async function registerRoutes(
 
   // Catch-all error handler
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const isErrObj = err !== null && err !== undefined && typeof err === "object";
-    const message = isErrObj && typeof err.message === "string" && err.message
-      ? err.message
-      : String(err ?? "Unhandled API error");
     // CORS rejections from the cors() middleware arrive as Error('Not allowed by CORS')
-    if (message === "Not allowed by CORS") {
+    if (err.message === "Not allowed by CORS") {
       return res.status(403).json({ message: "Not allowed by CORS", code: "CORS_FORBIDDEN" });
     }
-    // Log err.name + err.code + err.message + status; skip err.stack so DSNs,
-    // bearer tokens, and provider keys embedded in framework/library stack
-    // traces don't land in the Replit log stream. The removed ErrorLogger
-    // sanitized the stack via regex; the console sink has no sanitizer. name
-    // and code give most of the diagnostic signal without the secret-leak
-    // surface (they come from our code, not library internals).
-    const name = isErrObj && typeof err.name === "string" ? err.name : "NonErrorThrow";
-    const code = isErrObj && err.code ? String(err.code) : undefined;
-    const rawStatus = isErrObj ? Number(err.status ?? err.statusCode) : NaN;
-    const status = Number.isInteger(rawStatus) && rawStatus >= 400 && rawStatus <= 599 ? rawStatus : 500;
-    console.error(`[api] ${name}: ${message}`, { status, ...(code ? { code } : {}) });
-    res.status(status).json({ message: "Internal server error", code: "INTERNAL_SERVER_ERROR" });
+    ErrorLogger.error("api", err.message || "Unhandled API error", err instanceof Error ? err : null, { status: err.status || 500 });
+    res.status(err.status || 500).json({ message: "Internal server error" });
   });
 
   return { httpServer, campaignConfigsReady };

--- a/server/routes/extension.test.ts
+++ b/server/routes/extension.test.ts
@@ -19,11 +19,15 @@ vi.mock("../replit_integrations/auth/storage", () => ({
 const mockCheckMonitorLimit = vi.fn();
 const mockCheckFrequencyTier = vi.fn().mockReturnValue(null);
 const mockValidateMonitorInput = vi.fn();
-const mockSafeHostname = vi.fn().mockReturnValue("example.com");
 vi.mock("../services/monitorValidation", () => ({
   checkMonitorLimit: (...args: any[]) => mockCheckMonitorLimit(...args),
   checkFrequencyTier: (...args: any[]) => mockCheckFrequencyTier(...args),
   validateMonitorInput: (...args: any[]) => mockValidateMonitorInput(...args),
+}));
+
+// Mock urlUtils
+const mockSafeHostname = vi.fn().mockReturnValue("example.com");
+vi.mock("../utils/urlUtils", () => ({
   safeHostname: (...args: any[]) => mockSafeHostname(...args),
 }));
 

--- a/server/routes/extension.ts
+++ b/server/routes/extension.ts
@@ -12,8 +12,8 @@ import {
   checkMonitorLimit,
   checkFrequencyTier,
   validateMonitorInput,
-  safeHostname,
 } from "../services/monitorValidation";
+import { safeHostname } from "../utils/urlUtils";
 import { checkMonitor as scraperCheckMonitor } from "../services/scraper";
 import { seedDefaultEmailChannel } from "../services/notification";
 

--- a/server/routes/v1.integration.test.ts
+++ b/server/routes/v1.integration.test.ts
@@ -22,9 +22,12 @@ vi.mock("../replit_integrations/auth/storage", () => ({
 }));
 vi.mock("../utils/ssrf", () => ({ isPrivateUrl: vi.fn().mockResolvedValue(null) }));
 
-// Mock db to break the transitive dependency chain
-// (v1 → monitorValidation → scraper → db)
+// Mock db and logger to break the transitive dependency chain
+// (v1 → monitorValidation → scraper → logger → db)
 vi.mock("../db", () => ({ db: {}, pool: {} }));
+vi.mock("../services/logger", () => ({
+  ErrorLogger: { log: vi.fn(), getRecentErrors: vi.fn(), clearError: vi.fn() },
+}));
 
 // Mock apiKeyAuth to record execution order
 vi.mock("../middleware/apiKeyAuth", () => ({

--- a/server/routes/v1.ts
+++ b/server/routes/v1.ts
@@ -7,8 +7,8 @@ import {
   checkMonitorLimit,
   checkFrequencyTier,
   validateMonitorInput,
-  safeHostname,
 } from "../services/monitorValidation";
+import { safeHostname } from "../utils/urlUtils";
 import {
   apiV1PaginationSchema,
   apiV1ChangesPaginationSchema,

--- a/server/routes/zapier.test.ts
+++ b/server/routes/zapier.test.ts
@@ -22,6 +22,16 @@ vi.mock("../utils/encryption", () => ({
   hashUrl: (url: string) => `hash:${url}`,
 }));
 
+// Mock logger
+const mockLoggerInfo = vi.fn().mockResolvedValue(undefined);
+const mockLoggerWarning = vi.fn().mockResolvedValue(undefined);
+vi.mock("../services/logger", () => ({
+  ErrorLogger: {
+    info: (...args: any[]) => mockLoggerInfo(...args),
+    warning: (...args: any[]) => mockLoggerWarning(...args),
+  },
+}));
+
 // Mock db for /changes route
 const mockDbSelect = vi.fn();
 vi.mock("../db", () => ({

--- a/server/routes/zapier.test.ts
+++ b/server/routes/zapier.test.ts
@@ -24,11 +24,9 @@ vi.mock("../utils/encryption", () => ({
 
 // Mock logger
 const mockLoggerInfo = vi.fn().mockResolvedValue(undefined);
-const mockLoggerWarning = vi.fn().mockResolvedValue(undefined);
 vi.mock("../services/logger", () => ({
   ErrorLogger: {
     info: (...args: any[]) => mockLoggerInfo(...args),
-    warning: (...args: any[]) => mockLoggerWarning(...args),
   },
 }));
 

--- a/server/routes/zapier.ts
+++ b/server/routes/zapier.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import rateLimit from "express-rate-limit";
 import { storage } from "../storage";
 import { isPrivateUrl } from "../utils/ssrf";
+import { ErrorLogger } from "../services/logger";
 import {
   zapierSubscribeSchema,
   zapierUnsubscribeSchema,
@@ -72,7 +73,7 @@ router.post("/subscribe", subscribeRateLimit, async (req: any, res) => {
     const ssrfError = await isPrivateUrl(body.hookUrl);
     if (ssrfError) {
       const hostname = new URL(body.hookUrl).hostname;
-      console.warn("[api] SSRF blocked on Zapier subscribe", {
+      await ErrorLogger.warning("api", "SSRF blocked on Zapier subscribe", {
         userId: req.apiUser.id,
         hookUrlHostname: hostname,
       });
@@ -114,7 +115,7 @@ router.post("/subscribe", subscribeRateLimit, async (req: any, res) => {
       });
     }
 
-    console.log("[api] Automation subscription created", {
+    await ErrorLogger.info("api", "Automation subscription created", {
       userId: req.apiUser.id,
       platform: "zapier",
       monitorId: body.monitorId ?? "all",
@@ -143,7 +144,7 @@ router.delete("/unsubscribe", async (req: any, res) => {
     const deactivated = await storage.deactivateAutomationSubscription(body.id, req.apiUser.id);
 
     if (deactivated) {
-      console.log("[api] Automation subscription deactivated", {
+      await ErrorLogger.info("api", "Automation subscription deactivated", {
         id: body.id,
         userId: req.apiUser.id,
         platform: "zapier",

--- a/server/routes/zapier.ts
+++ b/server/routes/zapier.ts
@@ -73,7 +73,7 @@ router.post("/subscribe", subscribeRateLimit, async (req: any, res) => {
     const ssrfError = await isPrivateUrl(body.hookUrl);
     if (ssrfError) {
       const hostname = new URL(body.hookUrl).hostname;
-      await ErrorLogger.warning("api", "SSRF blocked on Zapier subscribe", {
+      console.warn("[api] SSRF blocked on Zapier subscribe", {
         userId: req.apiUser.id,
         hookUrlHostname: hostname,
       });

--- a/server/services/automatedCampaigns.test.ts
+++ b/server/services/automatedCampaigns.test.ts
@@ -18,6 +18,7 @@ const {
   mockDbDeleteWhere,
   mockTriggerCampaignSend,
   mockResolveRecipients,
+  mockErrorLoggerError,
 } = vi.hoisted(() => ({
   mockDbExecute: vi.fn(),
   mockDbSelect: vi.fn(),
@@ -33,6 +34,7 @@ const {
   mockDbDeleteWhere: vi.fn().mockResolvedValue(undefined),
   mockTriggerCampaignSend: vi.fn(),
   mockResolveRecipients: vi.fn(),
+  mockErrorLoggerError: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../db", () => ({
@@ -77,6 +79,12 @@ vi.mock("drizzle-orm", () => ({
 vi.mock("./campaignEmail", () => ({
   triggerCampaignSend: (...args: any[]) => mockTriggerCampaignSend(...args),
   resolveRecipients: (...args: any[]) => mockResolveRecipients(...args),
+}));
+
+vi.mock("./logger", () => ({
+  ErrorLogger: {
+    error: (...args: any[]) => mockErrorLoggerError(...args),
+  },
 }));
 
 import { computeNextRunAt, ensureWelcomeConfig, bootstrapWelcomeCampaign, patchWelcomeCampaignUrls, processAutomatedCampaigns, runWelcomeCampaign, WELCOME_CAMPAIGN_DEFAULTS } from "./automatedCampaigns";
@@ -770,6 +778,36 @@ describe("processAutomatedCampaigns", () => {
     expect(mockTriggerCampaignSend).toHaveBeenCalled();
   });
 
+  it("logs error and continues if one config fails", async () => {
+    const pastDate = new Date(Date.now() - 3600000);
+    const config = {
+      id: 1,
+      key: "welcome",
+      enabled: true,
+      lastRunAt: new Date("2025-03-20"),
+      nextRunAt: pastDate,
+      subject: "test",
+      htmlBody: "<html></html>",
+      textBody: null,
+      name: "Welcome",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockDbWhere.mockResolvedValue([config]);
+    // Make the inner select fail
+    mockDbLimit.mockRejectedValue(new Error("DB connection failed"));
+
+    // Should not throw
+    await processAutomatedCampaigns();
+
+    expect(mockErrorLoggerError).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("'welcome' failed"),
+      expect.any(Error),
+      expect.objectContaining({ configKey: "welcome" }),
+    );
+  });
+
   it("rolls back lastRunAt and nextRunAt when send fails after the run is claimed", async () => {
     const previousLastRunAt = new Date("2025-03-20T00:00:00Z");
     const previousNextRunAt = new Date(Date.now() - 3600000); // 1 hour ago — eligible
@@ -827,6 +865,13 @@ describe("processAutomatedCampaigns", () => {
     expect(rollbackSetArg.lastRunAt).toBe(previousLastRunAt);
     expect(rollbackSetArg.nextRunAt).toBe(previousNextRunAt);
     expect(rollbackSetArg.updatedAt).toBeInstanceOf(Date);
+
+    expect(mockErrorLoggerError).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("'welcome' failed"),
+      expect.any(Error),
+      expect.objectContaining({ configKey: "welcome" }),
+    );
   });
 
   it("does not roll back when the claim itself loses to a concurrent run", async () => {
@@ -865,5 +910,43 @@ describe("processAutomatedCampaigns", () => {
     expect(mockDbSet).toHaveBeenCalledTimes(1);
     expect(mockResolveRecipients).not.toHaveBeenCalled();
     expect(mockTriggerCampaignSend).not.toHaveBeenCalled();
+    expect(mockErrorLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("does not crash the loop when ErrorLogger itself throws", async () => {
+    const pastDate = new Date(Date.now() - 3600000);
+    const config = {
+      id: 1,
+      key: "welcome",
+      enabled: true,
+      lastRunAt: new Date("2025-03-20"),
+      nextRunAt: pastDate,
+      subject: "test",
+      htmlBody: "<html></html>",
+      textBody: null,
+      name: "Welcome",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    let whereCallCount = 0;
+    mockDbWhere.mockImplementation(() => {
+      whereCallCount++;
+      if (whereCallCount === 1) {
+        // initial config fetch in processAutomatedCampaigns
+        return Promise.resolve([config]);
+      }
+      // claim + inner config load chain — limit rejects to simulate DB failure
+      return {
+        returning: vi.fn().mockResolvedValue([config]),
+        limit: vi.fn().mockRejectedValue(new Error("DB connection failed")),
+      };
+    });
+    // Make ErrorLogger.error itself throw — the new try/catch should absorb it
+    mockErrorLoggerError.mockRejectedValue(new Error("Logger DB also down"));
+
+    // processAutomatedCampaigns must not throw — the loop continues
+    await processAutomatedCampaigns();
+
+    expect(mockErrorLoggerError).toHaveBeenCalled();
   });
 });

--- a/server/services/automatedCampaigns.ts
+++ b/server/services/automatedCampaigns.ts
@@ -1,6 +1,7 @@
 import { db } from "../db";
 import { campaigns, automatedCampaignConfigs, type AutomatedCampaignConfig } from "@shared/schema";
 import { triggerCampaignSend, resolveRecipients } from "./campaignEmail";
+import { ErrorLogger } from "./logger";
 import { eq, and, isNull } from "drizzle-orm";
 
 export const WELCOME_CAMPAIGN_DEFAULTS = {
@@ -335,15 +336,33 @@ export async function bootstrapWelcomeCampaign(): Promise<void> {
         )
         .returning();
       if (rolledBack.length === 0) {
+        // Optimistic guard did not match — either another instance
+        // claimed in between, or a PG timestamp-precision mismatch
+        // defeated the equality check. Route through ErrorLogger so
+        // this triggers alerting, not just a console warning.
         const msg = `Rollback WHERE guard matched zero rows for config ${config.id}; the config row may remain in a permanently advanced state. Recovery: UPDATE automated_campaign_configs SET last_run_at = NULL, next_run_at = NULL, updated_at = NOW() WHERE id = ${config.id};`;
-        console.error(`[scheduler] ${msg}`, { configId: config.id, configKey: config.key });
+        console.warn(`[Bootstrap] ${msg}`);
+        try {
+          await ErrorLogger.error("scheduler", msg, null, { configId: config.id, configKey: config.key });
+        } catch { /* already logged to console */ }
       }
     } catch (rollbackError) {
+      // Belt-and-suspenders: log to console too, in case ErrorLogger
+      // itself is failing because the DB is the root cause of both.
       console.error(
-        `[scheduler] Welcome campaign bootstrap rollback failed`,
+        `[Bootstrap] Welcome campaign bootstrap rollback failed:`,
         rollbackError instanceof Error ? rollbackError.message : rollbackError,
-        { configId: config.id, configKey: config.key },
       );
+      try {
+        await ErrorLogger.error(
+          "scheduler",
+          "Welcome campaign bootstrap rollback failed",
+          rollbackError instanceof Error ? rollbackError : null,
+          { configId: config.id, configKey: config.key }
+        );
+      } catch {
+        // Logger itself failed — already logged to console above.
+      }
     }
 
     // Re-throw so the caller (server startup) knows the bootstrap failed —
@@ -573,28 +592,58 @@ export async function processAutomatedCampaigns(): Promise<void> {
             )
             .returning();
           if (rolledBack.length === 0) {
+            // Optimistic guard did not match — either a concurrent instance
+            // claimed in between, or a PG timestamp-precision mismatch
+            // defeated the equality check. Route through ErrorLogger so
+            // this triggers alerting, not just a console warning.
             const msg = `Rollback WHERE guard matched zero rows for config '${config.key}' (id=${config.id}); the config row may remain in a permanently advanced state. Recovery: UPDATE automated_campaign_configs SET last_run_at = ${previousLastRunAt ? `'${previousLastRunAt.toISOString()}'` : 'NULL'}, next_run_at = ${previousNextRunAt ? `'${previousNextRunAt.toISOString()}'` : 'NULL'}, updated_at = NOW() WHERE id = ${config.id};`;
-            console.error(`[scheduler] ${msg}`, { configId: config.id, configKey: config.key });
+            console.warn(`[AutoCampaign] ${msg}`);
+            try {
+              await ErrorLogger.error("scheduler", msg, null, { configId: config.id, configKey: config.key });
+            } catch { /* already logged to console */ }
           }
         } catch (rollbackError) {
           console.error(
-            `[scheduler] Automated campaign '${config.key}' rollback failed`,
+            `[AutoCampaign] Automated campaign '${config.key}' rollback failed:`,
             rollbackError instanceof Error ? rollbackError.message : rollbackError,
-            {
-              configId: config.id,
-              configKey: config.key,
-              previousLastRunAt: previousLastRunAt?.toISOString() ?? null,
-              previousNextRunAt: previousNextRunAt?.toISOString() ?? null,
-            },
           );
+          try {
+            await ErrorLogger.error(
+              "scheduler",
+              `Automated campaign '${config.key}' rollback failed`,
+              rollbackError instanceof Error ? rollbackError : null,
+              {
+                configId: config.id,
+                configKey: config.key,
+                previousLastRunAt: previousLastRunAt?.toISOString() ?? null,
+                previousNextRunAt: previousNextRunAt?.toISOString() ?? null,
+              }
+            );
+          } catch {
+            // Logger itself failed — already logged to console above.
+          }
         }
       }
 
-      console.error(
-        `[scheduler] Automated campaign '${config.key}' failed`,
-        error instanceof Error ? error.message : String(error),
-        { configId: config.id, configKey: config.key, errorMessage: error instanceof Error ? error.message : String(error) }
-      );
+      // Wrap the outer error log in try/catch too: if the DB is the root
+      // cause of the send failure, ErrorLogger.error will also throw and
+      // abort this for-loop, preventing any remaining configs from being
+      // processed. console.error ensures the error is always surfaced.
+      try {
+        await ErrorLogger.error(
+          "scheduler",
+          `Automated campaign '${config.key}' failed`,
+          error instanceof Error ? error : null,
+          { configId: config.id, configKey: config.key, errorMessage: error instanceof Error ? error.message : String(error) }
+        );
+      } catch (logError) {
+        console.error(
+          `[AutoCampaign] Automated campaign '${config.key}' failed (and error logger also failed):`,
+          error instanceof Error ? error.message : error,
+          "log error:",
+          logError instanceof Error ? logError.message : logError,
+        );
+      }
     }
   }
 }

--- a/server/services/automationDelivery.test.ts
+++ b/server/services/automationDelivery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock storage
 const mockGetActiveAutomationSubscriptions = vi.fn();
@@ -24,11 +24,9 @@ vi.mock("../utils/ssrf", () => ({
 
 // Mock logger
 const mockLoggerInfo = vi.fn().mockResolvedValue(undefined);
-const mockLoggerWarning = vi.fn().mockResolvedValue(undefined);
 vi.mock("./logger", () => ({
   ErrorLogger: {
     info: (...args: any[]) => mockLoggerInfo(...args),
-    warning: (...args: any[]) => mockLoggerWarning(...args),
   },
 }));
 
@@ -85,9 +83,16 @@ function makeSub(overrides?: Partial<AutomationSubscription>): AutomationSubscri
 }
 
 describe("deliverToAutomationSubscriptions", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockIncrementAutomationSubscriptionFailures.mockResolvedValue(1);
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
   });
 
   it("returns immediately when no active subscriptions", async () => {
@@ -230,8 +235,7 @@ describe("deliverToAutomationSubscriptions", () => {
     await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
 
     expect(mockDeactivateAutomationSubscription).toHaveBeenCalledWith(9, "user1");
-    expect(mockLoggerWarning).toHaveBeenCalledWith(
-      "scheduler",
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining("auto-deactivated"),
       expect.objectContaining({ consecutiveFailures: 15 }),
     );

--- a/server/services/automationDelivery.test.ts
+++ b/server/services/automationDelivery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock storage
 const mockGetActiveAutomationSubscriptions = vi.fn();
@@ -20,6 +20,16 @@ vi.mock("../storage", () => ({
 const mockSsrfSafeFetch = vi.fn();
 vi.mock("../utils/ssrf", () => ({
   ssrfSafeFetch: (...args: any[]) => mockSsrfSafeFetch(...args),
+}));
+
+// Mock logger
+const mockLoggerInfo = vi.fn().mockResolvedValue(undefined);
+const mockLoggerWarning = vi.fn().mockResolvedValue(undefined);
+vi.mock("./logger", () => ({
+  ErrorLogger: {
+    info: (...args: any[]) => mockLoggerInfo(...args),
+    warning: (...args: any[]) => mockLoggerWarning(...args),
+  },
 }));
 
 import { deliverToAutomationSubscriptions } from "./automationDelivery";
@@ -75,19 +85,9 @@ function makeSub(overrides?: Partial<AutomationSubscription>): AutomationSubscri
 }
 
 describe("deliverToAutomationSubscriptions", () => {
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
-  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
     vi.clearAllMocks();
     mockIncrementAutomationSubscriptionFailures.mockResolvedValue(1);
-    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    consoleWarnSpy.mockRestore();
-    consoleLogSpy.mockRestore();
   });
 
   it("returns immediately when no active subscriptions", async () => {
@@ -131,15 +131,18 @@ describe("deliverToAutomationSubscriptions", () => {
     expect(mockTouchAndResetAutomationSubscription).toHaveBeenCalledWith(7);
   });
 
-  it("logs success via console.log", async () => {
+  it("logs success via console.log, not ErrorLogger", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     mockGetActiveAutomationSubscriptions.mockResolvedValue([makeSub()]);
     mockSsrfSafeFetch.mockResolvedValue({ ok: true, status: 200 });
 
     await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
 
-    expect(consoleLogSpy).toHaveBeenCalledWith(
+    expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("[Automation] Delivered successfully"),
     );
+    expect(mockLoggerInfo).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 
   it("queues durable retry on transient 5xx response (does NOT bump failure counter)", async () => {
@@ -227,7 +230,8 @@ describe("deliverToAutomationSubscriptions", () => {
     await deliverToAutomationSubscriptions(makeMonitor(), makeChange());
 
     expect(mockDeactivateAutomationSubscription).toHaveBeenCalledWith(9, "user1");
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
+    expect(mockLoggerWarning).toHaveBeenCalledWith(
+      "scheduler",
       expect.stringContaining("auto-deactivated"),
       expect.objectContaining({ consecutiveFailures: 15 }),
     );

--- a/server/services/automationDelivery.ts
+++ b/server/services/automationDelivery.ts
@@ -3,6 +3,7 @@ import { AUTOMATION_SUBSCRIPTION_LIMITS } from "@shared/models/auth";
 import { storage } from "../storage";
 import { ssrfSafeFetch } from "../utils/ssrf";
 import { buildWebhookPayload } from "./webhookDelivery";
+import { ErrorLogger } from "./logger";
 
 export type AutomationDeliveryOutcome =
   | { kind: "success"; statusCode: number }
@@ -142,7 +143,7 @@ async function handleDeliveryFailure(
 
   if (failures >= AUTOMATION_SUBSCRIPTION_LIMITS.failureThreshold) {
     await storage.deactivateAutomationSubscription(subscriptionId, monitor.userId);
-    console.warn(`[scheduler] Automation subscription auto-deactivated after ${failures} consecutive failures for monitor "${monitor.name}"`, {
+    await ErrorLogger.warning("scheduler", `Automation subscription auto-deactivated after ${failures} consecutive failures for monitor "${monitor.name}"`, {
       subscriptionId,
       monitorId: monitor.id,
       platform,
@@ -150,7 +151,7 @@ async function handleDeliveryFailure(
       error,
     });
   } else {
-    console.warn(`[scheduler] Automation delivery failed for monitor "${monitor.name}"`, {
+    await ErrorLogger.warning("scheduler", `Automation delivery failed for monitor "${monitor.name}"`, {
       subscriptionId,
       monitorId: monitor.id,
       platform,

--- a/server/services/automationDelivery.ts
+++ b/server/services/automationDelivery.ts
@@ -3,7 +3,6 @@ import { AUTOMATION_SUBSCRIPTION_LIMITS } from "@shared/models/auth";
 import { storage } from "../storage";
 import { ssrfSafeFetch } from "../utils/ssrf";
 import { buildWebhookPayload } from "./webhookDelivery";
-import { ErrorLogger } from "./logger";
 
 export type AutomationDeliveryOutcome =
   | { kind: "success"; statusCode: number }
@@ -143,7 +142,7 @@ async function handleDeliveryFailure(
 
   if (failures >= AUTOMATION_SUBSCRIPTION_LIMITS.failureThreshold) {
     await storage.deactivateAutomationSubscription(subscriptionId, monitor.userId);
-    await ErrorLogger.warning("scheduler", `Automation subscription auto-deactivated after ${failures} consecutive failures for monitor "${monitor.name}"`, {
+    console.warn(`[scheduler] Automation subscription auto-deactivated after ${failures} consecutive failures for monitor "${monitor.name}"`, {
       subscriptionId,
       monitorId: monitor.id,
       platform,
@@ -151,7 +150,7 @@ async function handleDeliveryFailure(
       error,
     });
   } else {
-    await ErrorLogger.warning("scheduler", `Automation delivery failed for monitor "${monitor.name}"`, {
+    console.warn(`[scheduler] Automation delivery failed for monitor "${monitor.name}"`, {
       subscriptionId,
       monitorId: monitor.id,
       platform,

--- a/server/services/browserlessTracker.ts
+++ b/server/services/browserlessTracker.ts
@@ -1,24 +1,9 @@
 import { format } from "date-fns";
 import { db } from "../db";
 import { getResendClient } from "./resendClient";
-import { browserlessUsage } from "@shared/schema";
+import { browserlessUsage, errorLogs } from "@shared/schema";
 import { BROWSERLESS_CAPS, users, type UserTier } from "@shared/models/auth";
 import { sql, eq, and, gte, count, desc } from "drizzle-orm";
-
-// In-memory cooldown tracking for threshold alert emails. The 6h cooldown
-// was previously enforced via error_logs rows that persisted across deploys
-// and were shared across replicas; that table is gone. Tradeoffs now:
-//   - RESTART-RESET: two deploys within 6h while usage is already >80%
-//     can re-fire the same threshold email because the Map is per-process
-//     and starts empty on each boot.
-//   - AUTOSCALE FAN-OUT: Replit autoscale may run multiple replicas; each
-//     holds its own Map, so a threshold crossing during a traffic spike
-//     can send up to one alert email per replica instead of a single
-//     global alert.
-// Both are accepted: alert emails are coarse operational signals, burst
-// duplication is annoying but not harmful, and persisting cooldown to a
-// new alert_state table is scope creep for this removal branch.
-const recentThresholdAlerts = new Map<string, number>();
 
 function getMonthStart(): Date {
   const now = new Date();
@@ -108,11 +93,27 @@ export class BrowserlessUsageTracker {
       if (pct >= t.pct) {
         const alertKey = `browserless_alert_${t.key}`;
         const cooldownMs = 6 * 60 * 60 * 1000;
-        const lastAlertAt = recentThresholdAlerts.get(alertKey) ?? 0;
+        const cooldownStart = new Date(Date.now() - cooldownMs);
 
-        if (Date.now() - lastAlertAt >= cooldownMs) {
-          recentThresholdAlerts.set(alertKey, Date.now());
-          console.log(`[browserless] threshold ${t.label} reached`, { threshold: t.label, usage: systemUsage, cap: systemCap });
+        const recentAlert = await db
+          .select({ id: errorLogs.id })
+          .from(errorLogs)
+          .where(
+            and(
+              eq(errorLogs.source, "browserless"),
+              eq(errorLogs.message, alertKey),
+              gte(errorLogs.timestamp, cooldownStart)
+            )
+          )
+          .limit(1);
+
+        if (recentAlert.length === 0) {
+          await db.insert(errorLogs).values({
+            level: "info",
+            source: "browserless",
+            message: alertKey,
+            context: { threshold: t.label, usage: systemUsage, cap: systemCap },
+          });
           await this.sendThresholdEmail(t.label, systemUsage, systemCap);
         }
         break;

--- a/server/services/browserlessTracker.ts
+++ b/server/services/browserlessTracker.ts
@@ -4,6 +4,7 @@ import { getResendClient } from "./resendClient";
 import { browserlessUsage, errorLogs } from "@shared/schema";
 import { BROWSERLESS_CAPS, users, type UserTier } from "@shared/models/auth";
 import { sql, eq, and, gte, count, desc } from "drizzle-orm";
+import { ErrorLogger } from "./logger";
 
 function getMonthStart(): Date {
   const now = new Date();
@@ -108,12 +109,12 @@ export class BrowserlessUsageTracker {
           .limit(1);
 
         if (recentAlert.length === 0) {
-          await db.insert(errorLogs).values({
-            level: "info",
-            source: "browserless",
-            message: alertKey,
-            context: { threshold: t.label, usage: systemUsage, cap: systemCap },
-          });
+          // Use ErrorLogger.info so the dedup upsert (ON CONFLICT) handles the
+          // case where an unresolved alert row for the same bucket already
+          // exists beyond the 6h cooldown window — raw `db.insert` would throw
+          // on the partial unique index and the alert email would silently
+          // fail to fire.
+          await ErrorLogger.info("browserless", alertKey, { threshold: t.label, usage: systemUsage, cap: systemCap });
           await this.sendThresholdEmail(t.label, systemUsage, systemCap);
         }
         break;

--- a/server/services/campaignEmail.test.ts
+++ b/server/services/campaignEmail.test.ts
@@ -65,6 +65,12 @@ vi.mock("./resendTracker", () => ({
   },
 }));
 
+vi.mock("./logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 import {
   resolveRecipients,
   previewRecipients,

--- a/server/services/campaignEmail.ts
+++ b/server/services/campaignEmail.ts
@@ -3,6 +3,7 @@ import { db } from "../db";
 import { getResendClient } from "./resendClient";
 import { users, campaigns, campaignRecipients, monitors } from "@shared/schema";
 import { ResendUsageTracker } from "./resendTracker";
+import { ErrorLogger } from "./logger";
 import { eq, and, inArray, gte, lte, sql, count, SQL } from "drizzle-orm";
 import { getAppUrl } from "../utils/appUrl";
 
@@ -404,7 +405,7 @@ export async function triggerCampaignSend(campaignId: number): Promise<{ totalRe
   const sendControl = { cancelled: false };
   activeSends.set(campaignId, sendControl);
   sendCampaignBatch(campaignId, campaign, sendControl).catch(async (err) => {
-    console.error(`[email] Campaign ${campaignId} batch send error`, err instanceof Error ? err.message : String(err), { campaignId });
+    await ErrorLogger.error("email", `Campaign ${campaignId} batch send error`, err instanceof Error ? err : null, { campaignId });
     await finalizeCampaign(campaignId, "partially_sent");
     activeSends.delete(campaignId);
   });

--- a/server/services/email.test.ts
+++ b/server/services/email.test.ts
@@ -21,6 +21,14 @@ vi.mock("../replit_integrations/auth/storage", () => ({
   },
 }));
 
+vi.mock("./logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./resendTracker", () => ({
   ResendUsageTracker: {
     canSendEmail: vi.fn().mockResolvedValue({ allowed: true }),
@@ -41,6 +49,7 @@ vi.mock("drizzle-orm", () => ({
 import { sendNotificationEmail, sendAutoPauseEmail, sendDigestEmail, sendHealthWarningEmail, sendRecoveryEmail, sendTierDowngradeEmail } from "./email";
 import { authStorage } from "../replit_integrations/auth/storage";
 import { ResendUsageTracker } from "./resendTracker";
+import { ErrorLogger } from "./logger";
 import { db } from "../db";
 import type { Monitor, MonitorChange } from "@shared/schema";
 
@@ -224,6 +233,12 @@ describe("sendAutoPauseEmail", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("Network error");
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "email",
+      expect.stringContaining("auto-pause email failed"),
+      expect.any(Error),
+      expect.objectContaining({ monitorId: 1 })
+    );
   });
 
   it("sanitizes monitor name in subject to prevent header injection", async () => {
@@ -495,6 +510,12 @@ describe("sendNotificationEmail", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("Connection failed");
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "email",
+      expect.stringContaining("notification email failed"),
+      expect.any(Error),
+      expect.objectContaining({ monitorId: 1 })
+    );
   });
 
   it("uses notificationEmail when available", async () => {
@@ -981,6 +1002,11 @@ describe("sendHealthWarningEmail", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("Network error");
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "email",
+      expect.stringContaining("Health warning email failed"),
+      expect.objectContaining({ monitorId: 1 })
+    );
   });
 });
 
@@ -1189,6 +1215,11 @@ describe("sendRecoveryEmail", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("Connection reset");
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "email",
+      expect.stringContaining("Recovery email failed"),
+      expect.objectContaining({ monitorId: 1 })
+    );
   });
 });
 
@@ -1326,5 +1357,11 @@ describe("sendTierDowngradeEmail", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("Connection reset");
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "email",
+      expect.stringContaining("Tier downgrade email failed"),
+      expect.any(Error),
+      expect.objectContaining({ userId: "user1" })
+    );
   });
 });

--- a/server/services/email.test.ts
+++ b/server/services/email.test.ts
@@ -24,7 +24,6 @@ vi.mock("../replit_integrations/auth/storage", () => ({
 vi.mock("./logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -997,16 +996,19 @@ describe("sendHealthWarningEmail", () => {
   it("handles thrown exceptions gracefully", async () => {
     vi.mocked(authStorage.getUser).mockResolvedValueOnce(powerUser() as any);
     mockSend.mockRejectedValueOnce(new Error("Network error"));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await sendHealthWarningEmail(makeMonitor(), 5, 5, "error");
 
-    const result = await sendHealthWarningEmail(makeMonitor(), 5, 5, "error");
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("Network error");
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "email",
-      expect.stringContaining("Health warning email failed"),
-      expect.objectContaining({ monitorId: 1 })
-    );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Network error");
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[email] Health warning email failed"),
+        expect.objectContaining({ monitorId: 1 })
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 });
 
@@ -1210,16 +1212,19 @@ describe("sendRecoveryEmail", () => {
   it("handles thrown exceptions gracefully", async () => {
     vi.mocked(authStorage.getUser).mockResolvedValueOnce(powerUser() as any);
     mockSend.mockRejectedValueOnce(new Error("Connection reset"));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await sendRecoveryEmail(makeMonitor(), "value");
 
-    const result = await sendRecoveryEmail(makeMonitor(), "value");
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("Connection reset");
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "email",
-      expect.stringContaining("Recovery email failed"),
-      expect.objectContaining({ monitorId: 1 })
-    );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Connection reset");
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[email] Recovery email failed"),
+        expect.objectContaining({ monitorId: 1 })
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 });
 

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -9,6 +9,14 @@ import { db } from "../db";
 import { sql } from "drizzle-orm";
 import { getAppUrl } from "../utils/appUrl";
 
+function safeHostname(urlString: string): string {
+  try {
+    return new URL(urlString).hostname;
+  } catch {
+    return "unknown";
+  }
+}
+
 export interface EmailResult {
   success: boolean;
   id?: string;
@@ -181,7 +189,7 @@ export async function sendNotificationEmail(monitor: Monitor, oldValue: string |
     console.log(`[Email] Sent to ${recipientEmail} for monitor ${monitor.id}, id: ${response.data?.id}`);
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    await ErrorLogger.error("email", `"${monitor.name}" — notification email failed to send. Check that your email address is valid. If this keeps happening, contact support.`, error instanceof Error ? error : null, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url });
+    await ErrorLogger.error("email", `"${monitor.name}" — notification email failed to send. Check that your email address is valid. If this keeps happening, contact support.`, error instanceof Error ? error : null, { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url) });
     return { success: false, error: error.message };
   }
 }

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -316,7 +316,7 @@ FetchTheChange Team`,
 
     if (response.error) {
       await ResendUsageTracker.recordUsage(monitor.userId, monitor.id, recipientEmail, undefined, false).catch(() => {});
-      await ErrorLogger.warning("email", `Health warning email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: response.error.message });
+      console.warn(`[email] Health warning email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: response.error.message });
       return { success: false, error: response.error.message, to: recipientEmail, from: fromAddress };
     }
 
@@ -324,7 +324,7 @@ FetchTheChange Team`,
     await ErrorLogger.info("email", `Health warning email sent`, { monitorId: monitor.id, monitorName: monitor.name, consecutiveFailures, tier });
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    await ErrorLogger.warning("email", `Health warning email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: error.message });
+    console.warn(`[email] Health warning email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: error.message });
     return { success: false, error: error.message };
   }
 }
@@ -405,7 +405,7 @@ FetchTheChange Team`,
 
     if (response.error) {
       await ResendUsageTracker.recordUsage(monitor.userId, monitor.id, recipientEmail, undefined, false).catch(() => {});
-      await ErrorLogger.warning("email", `Recovery email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: response.error.message });
+      console.warn(`[email] Recovery email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: response.error.message });
       return { success: false, error: response.error.message, to: recipientEmail, from: fromAddress };
     }
 
@@ -413,7 +413,7 @@ FetchTheChange Team`,
     await ErrorLogger.info("email", `Recovery email sent`, { monitorId: monitor.id, monitorName: monitor.name, recoveredValue: displayValue, degradedForMs });
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    await ErrorLogger.warning("email", `Recovery email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: error.message });
+    console.warn(`[email] Recovery email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: error.message });
     return { success: false, error: error.message };
   }
 }

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -3,6 +3,7 @@ import { getResendClient } from "./resendClient";
 import { type Monitor, type MonitorChange } from "@shared/schema";
 import { authStorage } from "../replit_integrations/auth/storage";
 import { type UserTier } from "@shared/models/auth";
+import { ErrorLogger } from "./logger";
 import { ResendUsageTracker } from "./resendTracker";
 import { db } from "../db";
 import { sql } from "drizzle-orm";
@@ -180,7 +181,7 @@ export async function sendNotificationEmail(monitor: Monitor, oldValue: string |
     console.log(`[Email] Sent to ${recipientEmail} for monitor ${monitor.id}, id: ${response.data?.id}`);
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    console.error(`[email] "${monitor.name}" — notification email failed to send. Check that your email address is valid. If this keeps happening, contact support.`, error instanceof Error ? error.message : String(error), { monitorId: monitor.id, monitorName: monitor.name });
+    await ErrorLogger.error("email", `"${monitor.name}" — notification email failed to send. Check that your email address is valid. If this keeps happening, contact support.`, error instanceof Error ? error : null, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url });
     return { success: false, error: error.message };
   }
 }
@@ -233,7 +234,7 @@ FetchTheChange Team`,
     console.log(`[Email] Sent auto-pause notification to ${recipientEmail} for monitor ${monitor.id}`);
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    console.error(`[email] "${monitor.name}" — auto-pause email failed to send.`, error instanceof Error ? error.message : String(error), { monitorId: monitor.id, monitorName: monitor.name });
+    await ErrorLogger.error("email", `"${monitor.name}" — auto-pause email failed to send.`, error instanceof Error ? error : null, { monitorId: monitor.id, monitorName: monitor.name });
     return { success: false, error: error.message };
   }
 }
@@ -315,15 +316,15 @@ FetchTheChange Team`,
 
     if (response.error) {
       await ResendUsageTracker.recordUsage(monitor.userId, monitor.id, recipientEmail, undefined, false).catch(() => {});
-      console.warn(`[email] Health warning email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: response.error.message });
+      await ErrorLogger.warning("email", `Health warning email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: response.error.message });
       return { success: false, error: response.error.message, to: recipientEmail, from: fromAddress };
     }
 
     await ResendUsageTracker.recordUsage(monitor.userId, monitor.id, recipientEmail, response.data?.id, true).catch(() => {});
-    console.log(`[email] Health warning email sent`, { monitorId: monitor.id, monitorName: monitor.name, consecutiveFailures, tier });
+    await ErrorLogger.info("email", `Health warning email sent`, { monitorId: monitor.id, monitorName: monitor.name, consecutiveFailures, tier });
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    console.warn(`[email] Health warning email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: error.message });
+    await ErrorLogger.warning("email", `Health warning email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: error.message });
     return { success: false, error: error.message };
   }
 }
@@ -404,15 +405,15 @@ FetchTheChange Team`,
 
     if (response.error) {
       await ResendUsageTracker.recordUsage(monitor.userId, monitor.id, recipientEmail, undefined, false).catch(() => {});
-      console.warn(`[email] Recovery email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: response.error.message });
+      await ErrorLogger.warning("email", `Recovery email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: response.error.message });
       return { success: false, error: response.error.message, to: recipientEmail, from: fromAddress };
     }
 
     await ResendUsageTracker.recordUsage(monitor.userId, monitor.id, recipientEmail, response.data?.id, true).catch(() => {});
-    console.log(`[email] Recovery email sent`, { monitorId: monitor.id, monitorName: monitor.name, recoveredValue: displayValue, degradedForMs });
+    await ErrorLogger.info("email", `Recovery email sent`, { monitorId: monitor.id, monitorName: monitor.name, recoveredValue: displayValue, degradedForMs });
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    console.warn(`[email] Recovery email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: error.message });
+    await ErrorLogger.warning("email", `Recovery email failed to send for monitor ${monitor.id}`, { monitorId: monitor.id, error: error.message });
     return { success: false, error: error.message };
   }
 }
@@ -478,7 +479,7 @@ FetchTheChange Team`,
     console.log(`[Email] Sent tier downgrade notification to ${recipientEmail} for user ${userId}`);
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    console.error(`[email] Tier downgrade email failed for user ${userId}`, error instanceof Error ? error.message : String(error), { userId });
+    await ErrorLogger.error("email", `Tier downgrade email failed for user ${userId}`, error instanceof Error ? error : null, { userId });
     return { success: false, error: String(error?.message ?? error) };
   }
 }
@@ -567,7 +568,7 @@ FetchTheChange Team`,
     console.log(`[Email] Sent digest to ${recipientEmail} for monitor ${monitor.id} (${changes.length} changes), id: ${response.data?.id}`);
     return { success: true, id: response.data?.id, to: recipientEmail, from: fromAddress };
   } catch (error: any) {
-    console.error(`[email] "${monitor.name}" — digest email failed to send.`, error instanceof Error ? error.message : String(error), { monitorId: monitor.id, monitorName: monitor.name });
+    await ErrorLogger.error("email", `"${monitor.name}" — digest email failed to send.`, error instanceof Error ? error : null, { monitorId: monitor.id, monitorName: monitor.name });
     return { success: false, error: error.message };
   }
 }

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -8,14 +8,7 @@ import { ResendUsageTracker } from "./resendTracker";
 import { db } from "../db";
 import { sql } from "drizzle-orm";
 import { getAppUrl } from "../utils/appUrl";
-
-function safeHostname(urlString: string): string {
-  try {
-    return new URL(urlString).hostname;
-  } catch {
-    return "unknown";
-  }
-}
+import { safeHostname } from "../utils/urlUtils";
 
 export interface EmailResult {
   success: boolean;

--- a/server/services/ensureTables.test.ts
+++ b/server/services/ensureTables.test.ts
@@ -24,7 +24,7 @@ vi.mock("../utils/encryption", () => ({
   isEncryptionAvailable: () => true,
 }));
 
-import { ensureMonitorHealthColumns, ensureApiKeysTable, ensureChannelTables, ensureMonitorConditionsTable, ensureNotificationQueueColumns, ensureAutomatedCampaignConfigsTable, ensureMonitorPendingRetryColumn, ensureAutomationSubscriptionsTable, ensureMonitorChangesIndexes } from "./ensureTables";
+import { ensureMonitorHealthColumns, ensureErrorLogColumns, ensureApiKeysTable, ensureChannelTables, ensureMonitorConditionsTable, ensureNotificationQueueColumns, ensureAutomatedCampaignConfigsTable, ensureMonitorPendingRetryColumn, ensureAutomationSubscriptionsTable, ensureMonitorChangesIndexes } from "./ensureTables";
 
 describe("ensureMonitorHealthColumns", () => {
   beforeEach(() => {
@@ -65,6 +65,125 @@ describe("ensureMonitorHealthColumns", () => {
       expect.any(Error),
     );
     errorSpy.mockRestore();
+  });
+});
+
+describe("ensureErrorLogColumns", () => {
+  beforeEach(() => {
+    mockExecute.mockReset();
+  });
+
+  it("executes ALTERs, pg_indexes check, dedup tx, and CONCURRENTLY index creation without throwing", async () => {
+    // Default empty rows → no existing valid index, proceed to dedup + create.
+    mockExecute.mockResolvedValue({ rows: [] });
+    await ensureErrorLogColumns();
+    // 3 ALTER TABLE + 1 pg_indexes check + 4 in-tx (SET LOCAL, advisory
+    // lock, UPDATE, DELETE) + 1 CREATE UNIQUE INDEX CONCURRENTLY = 9
+    expect(mockExecute).toHaveBeenCalledTimes(9);
+    const stmts = mockExecute.mock.calls.map(([arg]: any) => {
+      try { return JSON.stringify(arg); } catch { return String(arg); }
+    });
+    expect(stmts.some((s: string) => s.includes("first_occurrence"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("occurrence_count"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("pg_indexes"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("pg_advisory_xact_lock"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("CREATE UNIQUE INDEX") && s.includes("CONCURRENTLY") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
+  });
+
+  it("skips DDL entirely when a valid, unique, correctly-shaped index already exists", async () => {
+    // pg_indexes check returns a row that passes all three validity gates
+    // (indisvalid, indisunique, indexdef includes both the expected column
+    // tuple and the partial predicate) → fast-path return.
+    mockExecute
+      .mockResolvedValueOnce({ rows: [] }) // ALTER first_occurrence
+      .mockResolvedValueOnce({ rows: [] }) // ALTER occurrence_count
+      .mockResolvedValueOnce({ rows: [] }) // ALTER deleted_at
+      .mockResolvedValueOnce({ rows: [{
+        indisvalid: true,
+        indisunique: true,
+        indexdef: "CREATE UNIQUE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source, message) WHERE (resolved = false)",
+      }] });
+    await ensureErrorLogColumns();
+    expect(mockExecute).toHaveBeenCalledTimes(4); // ALTERs + pg_indexes only
+  });
+
+  it("drops and rebuilds when existing index is INVALID", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExecute
+      .mockResolvedValueOnce({ rows: [] }) // ALTER first_occurrence
+      .mockResolvedValueOnce({ rows: [] }) // ALTER occurrence_count
+      .mockResolvedValueOnce({ rows: [] }) // ALTER deleted_at
+      .mockResolvedValueOnce({ rows: [{
+        indisvalid: false,
+        indisunique: true,
+        indexdef: "CREATE UNIQUE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source, message) WHERE (resolved = false)",
+      }] })
+      .mockResolvedValue({ rows: [] }); // DROP + tx statements + CREATE
+    await ensureErrorLogColumns();
+    const stmts = mockExecute.mock.calls.map(([arg]: any) => {
+      try { return JSON.stringify(arg); } catch { return String(arg); }
+    });
+    expect(stmts.some((s: string) => s.includes("DROP INDEX") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("drops and rebuilds when existing index is non-unique (wrong definition)", async () => {
+    // A stale index with the same name but non-unique type would otherwise
+    // pass the old bare `indisvalid` check and silently break ON CONFLICT.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExecute
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{
+        indisvalid: true,
+        indisunique: false, // ← the drift we're guarding against
+        indexdef: "CREATE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source, message) WHERE (resolved = false)",
+      }] })
+      .mockResolvedValue({ rows: [] });
+    await ensureErrorLogColumns();
+    const stmts = mockExecute.mock.calls.map(([arg]: any) => {
+      try { return JSON.stringify(arg); } catch { return String(arg); }
+    });
+    expect(stmts.some((s: string) => s.includes("DROP INDEX") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("drops and rebuilds when existing index has wrong columns or missing predicate", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExecute
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{
+        indisvalid: true,
+        indisunique: true,
+        // Wrong column tuple — missing message, no WHERE predicate.
+        indexdef: "CREATE UNIQUE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source)",
+      }] })
+      .mockResolvedValue({ rows: [] });
+    await ensureErrorLogColumns();
+    const stmts = mockExecute.mock.calls.map(([arg]: any) => {
+      try { return JSON.stringify(arg); } catch { return String(arg); }
+    });
+    expect(stmts.some((s: string) => s.includes("DROP INDEX") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("catches errors and does not throw", async () => {
+    mockExecute.mockRejectedValue(new Error("permission denied"));
+    await expect(ensureErrorLogColumns()).resolves.toBeUndefined();
+  });
+
+  it("logs a warning when an error occurs", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExecute.mockRejectedValue(new Error("permission denied"));
+    await ensureErrorLogColumns();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Could not ensure error_logs columns/index:",
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
   });
 });
 

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -3,28 +3,124 @@ import { sql } from "drizzle-orm";
 import { encryptUrl, decryptToken, hashUrl, isValidEncryptedToken, isEncryptionAvailable } from "../utils/encryption";
 
 /**
- * Drops the legacy `error_logs` table. The admin error logging feature
- * was removed, but this drop is NOT wired into registerRoutes because a
- * rolling deploy of this PR would leave old replicas still writing to
- * the table via the old ErrorLogger code path while the new replica
- * DROPs it, producing a flood of failed INSERTs on the old replicas.
+ * Ensures error_logs deduplication columns and the partial unique index used
+ * by ErrorLogger's atomic upsert (see GitHub issue #448) exist.
  *
- * Operator runbook: after this PR fully rolls out and no replica is
- * running the old code anymore, drop the table manually — either by
- * `psql $DATABASE_URL -c 'DROP TABLE IF EXISTS error_logs'` or by
- * invoking this helper from a one-shot script. Idempotent. The table
- * is inert (zero writers) once the new code is everywhere, so leaving
- * it a few hours past cutover is harmless.
+ * Without the index, `INSERT … ON CONFLICT (level, source, message) WHERE
+ * resolved = false` fails at runtime with "there is no unique or exclusion
+ * constraint matching the ON CONFLICT specification", which ErrorLogger's
+ * catch block at server/services/logger.ts swallows to `console.error` —
+ * silently disabling DB-backed error logging for the entire deploy window
+ * between code ship and `npm run schema:push`.
+ *
+ * Migration strategy:
+ * 1. Fast-path idempotency: if a VALID unique index already exists, skip the
+ *    whole migration. If an INVALID one exists (leftover from an interrupted
+ *    CREATE CONCURRENTLY), drop it so we can rebuild.
+ * 2. Dedup pre-existing duplicate unresolved rows (the bug being fixed!) in
+ *    a transaction gated by a pg_advisory_xact_lock so concurrent instances
+ *    in a rolling deploy don't race on overlapping DELETEs. Cap the rolled-
+ *    up `occurrence_count` at INT32_MAX to avoid an overflow-rollback loop
+ *    on busy tables.
+ * 3. CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS — outside the tx so we
+ *    don't take a SHARE lock that would block every ErrorLogger.log caller
+ *    on the entire app during index build. Mirrors the pattern established
+ *    by ensureMonitorChangesIndexes below.
  */
-export async function dropLegacyErrorLogsTable(): Promise<void> {
-  // Propagate errors so the one-shot operator script sees the failure
-  // instead of a silent `console.error`. This is a manual utility, not
-  // a boot hook, so throwing is the right posture.
-  await db.execute(sql`DROP TABLE IF EXISTS error_logs`);
-  const check = await db.execute(sql`SELECT to_regclass('error_logs') AS exists`);
-  const stillExists = (check as any).rows?.[0]?.exists;
-  if (stillExists) {
-    throw new Error(`DROP TABLE error_logs completed but to_regclass still resolves — table survived (value=${String(stillExists)})`);
+export async function ensureErrorLogColumns(): Promise<void> {
+  try {
+    await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS first_occurrence TIMESTAMP NOT NULL DEFAULT NOW()`);
+    await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS occurrence_count INTEGER NOT NULL DEFAULT 1`);
+    await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP`);
+
+    // Check if a VALID, UNIQUE, correctly-shaped index already exists — skip
+    // DDL entirely if so. Validates four invariants simultaneously:
+    //   1. `indisvalid` — not a leftover INVALID build
+    //   2. `indisunique` — ON CONFLICT inference requires uniqueness
+    //   3. `pg_get_indexdef` exposes the column tuple + predicate so we can
+    //      assert the index covers (level, source, message) with the
+    //      `WHERE resolved = false` partial predicate
+    // A stale index with the same name but a different definition (wrong
+    // columns, non-unique, missing predicate) fails this check and is
+    // dropped and rebuilt. Without the definition check, a drifted index
+    // would pass the fast path and ON CONFLICT would fail silently at
+    // runtime, swallowed by ErrorLogger.log's catch block.
+    const existing = await db.execute(sql`
+      SELECT i.indisvalid, i.indisunique, pg_get_indexdef(i.indexrelid) AS indexdef
+      FROM pg_indexes ix
+      JOIN pg_class c ON c.relname = ix.indexname
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE ix.indexname = 'error_logs_unresolved_dedup_idx'
+    `);
+    const rows = (existing as any).rows as Array<{ indisvalid: boolean; indisunique: boolean; indexdef: string }> | undefined;
+    if (rows && rows.length > 0) {
+      const { indisvalid, indisunique, indexdef } = rows[0];
+      const defIsCorrect =
+        indexdef.includes("(level, source, message)") &&
+        /WHERE\s+\(?resolved\s*=\s*false\)?/i.test(indexdef);
+      if (indisvalid && indisunique && defIsCorrect) return;
+      console.warn(
+        `[ensureTables] Dropping existing error_logs_unresolved_dedup_idx (valid=${indisvalid} unique=${indisunique} defMatch=${defIsCorrect}) so it can be rebuilt with the expected shape`,
+      );
+      await db.execute(sql`DROP INDEX IF EXISTS error_logs_unresolved_dedup_idx`);
+    }
+
+    // Dedupe pre-existing unresolved rows produced by the old racy
+    // SELECT-then-INSERT path. Keep the newest row per
+    // (level, source, message) group and roll up `occurrence_count` into it
+    // so the dedup bucket's total event count is preserved. The advisory
+    // xact lock serializes concurrent boots in a rolling deploy so only one
+    // instance performs the dedup at a time; follow-up boots find nothing
+    // to merge and fall through to the idempotent CONCURRENTLY step below.
+    // LEAST(INT32_MAX, SUM) caps the rolled-up count so a site with many
+    // already-huge duplicate rows doesn't blow past integer range and
+    // rollback the whole transaction.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL lock_timeout = '10s'`);
+      // Advisory lock key is a stable 64-bit hash of the migration identifier.
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended('error_logs_unresolved_dedup_migration', 0))`);
+      await tx.execute(sql`
+        WITH dups AS (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY level, source, message
+                   ORDER BY timestamp DESC, id DESC
+                 ) AS rn,
+                 LEAST(2147483647, SUM(occurrence_count) OVER (
+                   PARTITION BY level, source, message
+                 ))::int AS total_count
+          FROM error_logs
+          WHERE resolved = false
+        )
+        UPDATE error_logs
+        SET occurrence_count = dups.total_count
+        FROM dups
+        WHERE error_logs.id = dups.id AND dups.rn = 1
+      `);
+      await tx.execute(sql`
+        DELETE FROM error_logs
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT id, ROW_NUMBER() OVER (
+              PARTITION BY level, source, message
+              ORDER BY timestamp DESC, id DESC
+            ) AS rn
+            FROM error_logs WHERE resolved = false
+          ) d WHERE rn > 1
+        )
+      `);
+    });
+
+    // CONCURRENTLY cannot run inside a transaction. IF NOT EXISTS makes this
+    // safe if another rolling-deploy instance beat us to it between the
+    // dedup tx above and this statement.
+    await db.execute(sql`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS error_logs_unresolved_dedup_idx
+      ON error_logs(level, source, message)
+      WHERE resolved = false
+    `);
+  } catch (e) {
+    console.warn("Could not ensure error_logs columns/index:", e);
   }
 }
 
@@ -335,9 +431,8 @@ export async function ensureCampaignPartialIndexes(): Promise<void> {
   try {
     // campaigns_type_automated_idx — also check pg_get_indexdef so a stale
     // same-name index with wrong columns/predicate gets dropped and rebuilt
-    // (CREATE INDEX CONCURRENTLY IF NOT EXISTS is name-based only). Mirrors
-    // the pg_get_indexdef-based validation pattern used elsewhere in this
-    // file — see CodeRabbit review on PR #455.
+    // (CREATE INDEX CONCURRENTLY IF NOT EXISTS is name-based only). Matches
+    // the ensureErrorLogColumns pattern — see CodeRabbit review on PR #455.
     const existingCampaignIdx = await db.execute(sql`
       SELECT i.indisvalid, pg_get_indexdef(i.indexrelid) AS indexdef
       FROM pg_indexes ix

--- a/server/services/logger.test.ts
+++ b/server/services/logger.test.ts
@@ -81,7 +81,7 @@ describe("ErrorLogger atomic upsert", () => {
   });
 
   it("configures onConflictDoUpdate against the partial unique index", async () => {
-    await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: 1 });
+    await ErrorLogger.error("scraper", "Browserless service unavailable — preserving last known values", null, { monitorId: 1 });
 
     const conflictConfig = mockOnConflictDoUpdateFn.mock.calls[0][0];
     // target must be the three-column tuple matching the unique index
@@ -160,13 +160,6 @@ describe("ErrorLogger atomic upsert", () => {
   it("convenience methods call log with correct level", async () => {
     await ErrorLogger.error("stripe", "error msg");
     expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("error");
-
-    vi.clearAllMocks();
-    mockInsertValuesFn.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdateFn });
-    mockDbInsert.mockReturnValue({ values: mockInsertValuesFn });
-
-    await ErrorLogger.warning("email", "warning msg");
-    expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("warning");
 
     vi.clearAllMocks();
     mockInsertValuesFn.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdateFn });

--- a/server/services/logger.test.ts
+++ b/server/services/logger.test.ts
@@ -168,4 +168,23 @@ describe("ErrorLogger atomic upsert", () => {
     await ErrorLogger.info("scheduler", "info msg");
     expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("info");
   });
+
+  // Regression guard: warning-level was removed to silence the Browserless
+  // infra-noise flood from bubbling into the admin Event Log. All former
+  // warning call sites now use console.warn and stay out of the DB.
+  it("does not expose a warning() method — warning-level is console-only", () => {
+    expect((ErrorLogger as any).warning).toBeUndefined();
+  });
+
+  it("info path writes to console.log (not console.warn/console.error)", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await ErrorLogger.info("scheduler", "hello");
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[INFO][scheduler] hello"));
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });

--- a/server/services/logger.test.ts
+++ b/server/services/logger.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock variables
+//
+// After GitHub issue #448, ErrorLogger.log uses a single atomic
+// `INSERT … ON CONFLICT (level, source, message) WHERE resolved = false
+// DO UPDATE SET …` upsert instead of the prior SELECT-then-INSERT/UPDATE
+// flow. The mock chain tracks `.insert(table).values(row).onConflictDoUpdate(cfg)`.
+// ---------------------------------------------------------------------------
+const {
+  mockDbInsert,
+  mockInsertValuesFn,
+  mockOnConflictDoUpdateFn,
+} = vi.hoisted(() => {
+  const mockOnConflictDoUpdateFn = vi.fn().mockResolvedValue(undefined);
+  const mockInsertValuesFn = vi.fn(() => ({ onConflictDoUpdate: mockOnConflictDoUpdateFn }));
+  const mockDbInsert = vi.fn(() => ({ values: mockInsertValuesFn }));
+
+  return {
+    mockDbInsert,
+    mockInsertValuesFn,
+    mockOnConflictDoUpdateFn,
+  };
+});
+
+vi.mock("../db", () => ({
+  db: {
+    insert: (...args: any[]) => mockDbInsert(...args),
+  },
+}));
+
+import { ErrorLogger } from "./logger";
+
+describe("ErrorLogger atomic upsert", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    mockOnConflictDoUpdateFn.mockResolvedValue(undefined);
+    mockInsertValuesFn.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdateFn });
+    mockDbInsert.mockReturnValue({ values: mockInsertValuesFn });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  it("issues a single atomic insert+onConflictDoUpdate per log call", async () => {
+    await ErrorLogger.error("stripe", "Webhook signature validation failed", null, { ip: "1.2.3.4" });
+
+    expect(mockDbInsert).toHaveBeenCalledTimes(1);
+    expect(mockInsertValuesFn).toHaveBeenCalledTimes(1);
+    expect(mockOnConflictDoUpdateFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("inserts values with correct fields on first call", async () => {
+    await ErrorLogger.error("stripe", "Webhook signature validation failed", null, { ip: "1.2.3.4" });
+
+    const insertedValues = mockInsertValuesFn.mock.calls[0][0];
+    expect(insertedValues.level).toBe("error");
+    expect(insertedValues.source).toBe("stripe");
+    expect(insertedValues.message).toBe("Webhook signature validation failed");
+    expect(insertedValues.occurrenceCount).toBe(1);
+    expect(insertedValues.firstOccurrence).toBeInstanceOf(Date);
+    expect(insertedValues.timestamp).toBeInstanceOf(Date);
+    // null error → errorType/stackTrace must be null (not undefined) so the
+    // COALESCE(EXCLUDED.*, current.*) clause in the conflict update keeps
+    // prior non-null values on subsequent racing writes.
+    expect(insertedValues.errorType).toBeNull();
+    expect(insertedValues.stackTrace).toBeNull();
+  });
+
+  it("configures onConflictDoUpdate against the partial unique index", async () => {
+    await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: 1 });
+
+    const conflictConfig = mockOnConflictDoUpdateFn.mock.calls[0][0];
+    // target must be the three-column tuple matching the unique index
+    expect(Array.isArray(conflictConfig.target)).toBe(true);
+    expect(conflictConfig.target).toHaveLength(3);
+    // targetWhere must encode the `resolved = false` partial predicate —
+    // without it Postgres rejects the ON CONFLICT on a partial index.
+    expect(conflictConfig.targetWhere).toBeDefined();
+    // set must bump timestamp and occurrenceCount; stack/context use COALESCE
+    expect(conflictConfig.set.timestamp).toBeInstanceOf(Date);
+    expect(conflictConfig.set.occurrenceCount).toBeDefined();
+    expect(conflictConfig.set.stackTrace).toBeDefined();
+    expect(conflictConfig.set.context).toBeDefined();
+  });
+
+  it("inserts new entry with correct fields for info level", async () => {
+    await ErrorLogger.info("scheduler", "Scheduler run completed");
+
+    const insertedValues = mockInsertValuesFn.mock.calls[0][0];
+    expect(insertedValues.level).toBe("info");
+    expect(insertedValues.source).toBe("scheduler");
+    expect(insertedValues.errorType).toBeNull();
+    expect(insertedValues.stackTrace).toBeNull();
+    expect(insertedValues.context).toBeNull();
+  });
+
+  it("includes error type and sanitized stack trace when error is provided", async () => {
+    const err = new Error("Something went wrong");
+    await ErrorLogger.error("api", "Unhandled error", err, { route: "/test" });
+
+    const insertedValues = mockInsertValuesFn.mock.calls[0][0];
+    expect(insertedValues.errorType).toBe("Error");
+    expect(insertedValues.stackTrace).toContain("Something went wrong");
+    expect(insertedValues.context).toEqual({ route: "/test" });
+  });
+
+  it("sanitizes sensitive data in the message", async () => {
+    await ErrorLogger.error("api", "Failed connecting to postgres://user:pass@host/db");
+
+    const insertedValues = mockInsertValuesFn.mock.calls[0][0];
+    expect(insertedValues.message).not.toContain("postgres://");
+    expect(insertedValues.message).toContain("[REDACTED]");
+  });
+
+  it("sanitizes sensitive context keys", async () => {
+    await ErrorLogger.error("api", "Auth error", null, { password: "secret123", userId: "user-1" });
+
+    const insertedValues = mockInsertValuesFn.mock.calls[0][0];
+    expect(insertedValues.context.password).toBe("[REDACTED]");
+    expect(insertedValues.context.userId).toBe("user-1");
+  });
+
+  it("handles database error gracefully without throwing", async () => {
+    mockOnConflictDoUpdateFn.mockRejectedValueOnce(new Error("DB connection lost"));
+
+    await expect(
+      ErrorLogger.error("api", "Some error")
+    ).resolves.toBeUndefined();
+  });
+
+  it("Browserless warnings use monitor-agnostic message for infra failures so dedup aggregates across monitors", async () => {
+    // Contract test: infra-wide failures (service unavailable, circuit breaker open)
+    // emit a monitor-agnostic message so every affected monitor dedups into a single
+    // row in the admin UI via the partial unique index. Site-specific failures still
+    // name the monitor.
+    const infraMsg = "Browserless service unavailable — preserving last known values";
+    const circuitMsg = "Browserless circuit breaker open — preserving last known values";
+    const siteSpecificMsg = `"My Monitor" — site blocking automated access`;
+
+    expect(infraMsg).not.toMatch(/"My Monitor"/);
+    expect(circuitMsg).not.toMatch(/"My Monitor"/);
+    expect(siteSpecificMsg).toMatch(/"My Monitor"/);
+    expect(siteSpecificMsg).not.toMatch(/preserving last known value/);
+  });
+
+  it("convenience methods call log with correct level", async () => {
+    await ErrorLogger.error("stripe", "error msg");
+    expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("error");
+
+    vi.clearAllMocks();
+    mockInsertValuesFn.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdateFn });
+    mockDbInsert.mockReturnValue({ values: mockInsertValuesFn });
+
+    await ErrorLogger.warning("email", "warning msg");
+    expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("warning");
+
+    vi.clearAllMocks();
+    mockInsertValuesFn.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdateFn });
+    mockDbInsert.mockReturnValue({ values: mockInsertValuesFn });
+
+    await ErrorLogger.info("scheduler", "info msg");
+    expect(mockInsertValuesFn.mock.calls[0][0].level).toBe("info");
+  });
+});

--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -3,7 +3,7 @@ import { errorLogs } from "@shared/schema";
 import { sql } from "drizzle-orm";
 import type { ERROR_LOG_SOURCES } from "@shared/routes";
 
-type LogLevel = "error" | "warning" | "info";
+type LogLevel = "error" | "info";
 type LogSource = (typeof ERROR_LOG_SOURCES)[number];
 
 const SENSITIVE_KEYS = [
@@ -65,8 +65,6 @@ export class ErrorLogger {
 
     if (level === "error") {
       console.error(logMsg, error?.message || "");
-    } else if (level === "warning") {
-      console.warn(logMsg);
     } else {
       console.log(logMsg);
     }
@@ -133,10 +131,6 @@ export class ErrorLogger {
 
   static async error(source: LogSource, message: string, error?: Error | null, context?: Record<string, any> | null) {
     return ErrorLogger.log("error", source, message, error, context);
-  }
-
-  static async warning(source: LogSource, message: string, context?: Record<string, any> | null) {
-    return ErrorLogger.log("warning", source, message, null, context);
   }
 
   static async info(source: LogSource, message: string, context?: Record<string, any> | null) {

--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -1,0 +1,145 @@
+import { db } from "../db";
+import { errorLogs } from "@shared/schema";
+import { sql } from "drizzle-orm";
+import type { ERROR_LOG_SOURCES } from "@shared/routes";
+
+type LogLevel = "error" | "warning" | "info";
+type LogSource = (typeof ERROR_LOG_SOURCES)[number];
+
+const SENSITIVE_KEYS = [
+  "password", "token", "apikey", "api_key", "secret", "authorization",
+  "cookie", "session", "credential", "private_key", "privatekey",
+  "access_key", "accesskey", "connection_string", "connectionstring",
+  "database_url", "databaseurl", "dsn", "bearer",
+];
+
+const SENSITIVE_VALUE_PATTERNS = [
+  /postgres(ql)?:\/\/[^\s"']+/gi,
+  /mysql:\/\/[^\s"']+/gi,
+  /mongodb(\+srv)?:\/\/[^\s"']+/gi,
+  /redis:\/\/[^\s"']+/gi,
+  /Bearer\s+[A-Za-z0-9\-._~+/]+=*/gi,
+  /\b(sk|pk|rk|whsec)[-_](?:live|test)[-_][A-Za-z0-9]{10,}\b/g,
+  /\bre_[A-Za-z0-9]{10,}\b/g,
+  /\bghp_[A-Za-z0-9]{36,}\b/g,
+  /\bxox[bprsao]-[A-Za-z0-9\-]{10,}\b/g,
+  /\b[A-Za-z0-9+/]{40,}={0,2}\b/g,
+];
+
+function sanitizeString(str: string): string {
+  let result = str;
+  for (const pattern of SENSITIVE_VALUE_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[REDACTED]");
+  }
+  return result.length > 1000 ? result.substring(0, 1000) + "...[truncated]" : result;
+}
+
+function sanitizeContext(obj: any): any {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj === "string") return sanitizeString(obj);
+  if (typeof obj !== "object") return obj;
+  if (Array.isArray(obj)) return obj.map(sanitizeContext);
+
+  const sanitized: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (SENSITIVE_KEYS.some(s => key.toLowerCase().includes(s))) {
+      sanitized[key] = "[REDACTED]";
+    } else {
+      sanitized[key] = sanitizeContext(value);
+    }
+  }
+  return sanitized;
+}
+
+export class ErrorLogger {
+  static async log(
+    level: LogLevel,
+    source: LogSource,
+    message: string,
+    error?: Error | null,
+    context?: Record<string, any> | null
+  ): Promise<void> {
+    const prefix = `[${level.toUpperCase()}][${source}]`;
+    const logMsg = `${prefix} ${message}`;
+
+    if (level === "error") {
+      console.error(logMsg, error?.message || "");
+    } else if (level === "warning") {
+      console.warn(logMsg);
+    } else {
+      console.log(logMsg);
+    }
+
+    const sanitizedMessage = sanitizeString(message);
+    const sanitizedStack = error?.stack ? sanitizeString(error.stack) : null;
+    const sanitizedContext = context ? sanitizeContext(context) : null;
+    const errorType = error?.constructor?.name || null;
+
+    try {
+      // Atomic upsert against the partial unique index
+      // `error_logs_unresolved_dedup_idx` (level, source, message) WHERE
+      // resolved = false. Collapses the read-modify-write window of the old
+      // SELECT-then-INSERT dedup path so concurrent writers with the same
+      // (level, source, message) deterministically land in a single row with
+      // `occurrence_count` bumped by every caller. Without this index +
+      // upsert, concurrent writers with shared messages (e.g. the compacted
+      // "Browserless service unavailable" warning) both miss the SELECT and
+      // both INSERT, producing duplicate rows in the admin UI. See GitHub
+      // issue #448.
+      //
+      // Stack/context semantics: `COALESCE(EXCLUDED.col, currentTable.col)`
+      // is last-writer-wins when the incoming call supplies a non-null value,
+      // and preserves the prior value when the incoming call doesn't. The
+      // admin UI therefore shows the most recent caller's stack/context for
+      // a dedup bucket, not the first-observed one. `firstOccurrence` is set
+      // only on INSERT — the conflict update path deliberately does not
+      // touch it, preserving the original event time.
+      const now = new Date();
+      await db
+        .insert(errorLogs)
+        .values({
+          level,
+          source,
+          message: sanitizedMessage,
+          errorType,
+          stackTrace: sanitizedStack,
+          context: sanitizedContext,
+          firstOccurrence: now,
+          timestamp: now,
+          occurrenceCount: 1,
+        })
+        .onConflictDoUpdate({
+          target: [errorLogs.level, errorLogs.source, errorLogs.message],
+          targetWhere: sql`resolved = false`,
+          set: {
+            timestamp: now,
+            // Clamp at INT32_MAX to match the ensureErrorLogColumns dedup
+            // migration's rollup cap. Without this, a hot error bucket that
+            // accumulates past 2,147,483,647 occurrences would overflow the
+            // `integer` column on the next increment, Postgres would reject
+            // the UPDATE, and the catch block below would silently disable
+            // logging for this dedup key. Cast via bigint so the arithmetic
+            // stays in range until the LEAST reduces it back to int.
+            occurrenceCount: sql`LEAST(2147483647::bigint, ${errorLogs.occurrenceCount}::bigint + 1)::int`,
+            stackTrace: sql`COALESCE(EXCLUDED.stack_trace, ${errorLogs.stackTrace})`,
+            context: sql`COALESCE(EXCLUDED.context, ${errorLogs.context})`,
+          },
+        });
+    } catch (dbError) {
+      console.error(`[ErrorLogger] Failed to write log to database:`, dbError);
+    }
+  }
+
+  static async error(source: LogSource, message: string, error?: Error | null, context?: Record<string, any> | null) {
+    return ErrorLogger.log("error", source, message, error, context);
+  }
+
+  static async warning(source: LogSource, message: string, context?: Record<string, any> | null) {
+    return ErrorLogger.log("warning", source, message, null, context);
+  }
+
+  static async info(source: LogSource, message: string, context?: Record<string, any> | null) {
+    return ErrorLogger.log("info", source, message, null, context);
+  }
+}

--- a/server/services/monitorValidation.ts
+++ b/server/services/monitorValidation.ts
@@ -91,13 +91,4 @@ export async function validateMonitorInput(
   return null;
 }
 
-/**
- * Safely extract hostname from a URL string for logging.
- */
-export function safeHostname(urlString: string): string {
-  try {
-    return new URL(urlString).hostname;
-  } catch {
-    return "unknown";
-  }
-}
+export { safeHostname } from "../utils/urlUtils";

--- a/server/services/monitorValidation.ts
+++ b/server/services/monitorValidation.ts
@@ -91,4 +91,3 @@ export async function validateMonitorInput(
   return null;
 }
 
-export { safeHostname } from "../utils/urlUtils";

--- a/server/services/notification.test.ts
+++ b/server/services/notification.test.ts
@@ -51,7 +51,6 @@ vi.mock("./email", () => ({
 vi.mock("./logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -729,14 +728,17 @@ describe("processQueuedNotifications edge cases", () => {
     mockGetReadyQueueEntries.mockResolvedValueOnce([]);
     const staleEntry = { id: 7, monitorId: 3, changeId: 5, reason: "quiet_hours", scheduledFor: new Date(), delivered: false, deliveredAt: null, createdAt: new Date() };
     mockGetStaleQueueEntries.mockResolvedValueOnce([staleEntry]);
-
-    await processQueuedNotifications();
-    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(7);
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      expect.stringContaining("1 stale notification queue entries"),
-      expect.objectContaining({ count: 1, monitorIds: [3], entryIds: [7] })
-    );
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await processQueuedNotifications();
+      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(7);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[scheduler] Marked 1 stale notification queue entries"),
+        expect.objectContaining({ count: 1, monitorIds: [3], entryIds: [7] })
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("marks multiple stale entries as permanently failed with single summary log", async () => {
@@ -746,18 +748,24 @@ describe("processQueuedNotifications edge cases", () => {
       { id: 8, monitorId: 4, changeId: 6, reason: "quiet_hours", scheduledFor: new Date(), delivered: false, deliveredAt: null, createdAt: new Date() },
     ];
     mockGetStaleQueueEntries.mockResolvedValueOnce(staleEntries);
-
-    await processQueuedNotifications();
-    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledTimes(2);
-    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(7);
-    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(8);
-    // Only one summary warning, not one per entry
-    expect(ErrorLogger.warning).toHaveBeenCalledTimes(1);
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      expect.stringContaining("2 stale notification queue entries"),
-      expect.objectContaining({ count: 2, monitorIds: expect.arrayContaining([3, 4]) })
-    );
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await processQueuedNotifications();
+      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledTimes(2);
+      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(7);
+      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(8);
+      // Only one summary warning, not one per entry
+      const summaryCalls = consoleWarnSpy.mock.calls.filter((c) =>
+        typeof c[0] === "string" && c[0].includes("stale notification queue entries")
+      );
+      expect(summaryCalls).toHaveLength(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[scheduler] Marked 2 stale notification queue entries"),
+        expect.objectContaining({ count: 2, monitorIds: expect.arrayContaining([3, 4]) })
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("groups multiple entries by monitor and processes each", async () => {
@@ -1408,19 +1416,22 @@ describe("orphaned queue entry handling", () => {
 
     const monitor = makeMonitor();
     const prefs = makePrefs({ digestMode: true });
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await processDigestBatch(monitor, prefs);
 
-    await processDigestBatch(monitor, prefs);
-
-    // Should log warning about 2 orphaned entries
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      expect.stringContaining("2 queue entries reference deleted changes"),
-      expect.objectContaining({ monitorId: 1, orphanedChangeIds: [11, 12] })
-    );
-    // Orphaned entries should be marked delivered
-    expect(mockMarkQueueEntriesDelivered).toHaveBeenCalledWith([2, 3]);
-    // The valid entry should also be marked delivered (in a separate call after successful delivery)
-    expect(mockMarkQueueEntriesDelivered).toHaveBeenCalledWith([1]);
+      // Should log warning about 2 orphaned entries
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("2 queue entries reference deleted changes"),
+        expect.objectContaining({ monitorId: 1, orphanedChangeIds: [11, 12] })
+      );
+      // Orphaned entries should be marked delivered
+      expect(mockMarkQueueEntriesDelivered).toHaveBeenCalledWith([2, 3]);
+      // The valid entry should also be marked delivered (in a separate call after successful delivery)
+      expect(mockMarkQueueEntriesDelivered).toHaveBeenCalledWith([1]);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("processDigestBatch only marks valid entries as delivered on success (not orphaned ones again)", async () => {
@@ -1446,15 +1457,18 @@ describe("orphaned queue entry handling", () => {
     mockGetMonitor.mockResolvedValueOnce(makeMonitor());
     mockGetNotificationPreferences.mockResolvedValueOnce(makePrefs());
     mockGetMonitorChangesByIds.mockResolvedValueOnce([]);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await processQueuedNotifications();
 
-    await processQueuedNotifications();
-
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      expect.stringContaining("change 999 not found"),
-      expect.objectContaining({ monitorId: 1, changeId: 999, notificationQueueId: 3 })
-    );
-    expect(mockMarkQueueEntryDelivered).toHaveBeenCalledWith(3);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("change 999 not found"),
+        expect.objectContaining({ monitorId: 1, changeId: 999, notificationQueueId: 3 })
+      );
+      expect(mockMarkQueueEntryDelivered).toHaveBeenCalledWith(3);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 });
 
@@ -1488,15 +1502,18 @@ describe("max-retry limit on failed queue entries", () => {
     mockGetMonitor.mockResolvedValueOnce(makeMonitor());
     mockGetNotificationPreferences.mockResolvedValueOnce(makePrefs());
     mockGetMonitorChangesByIds.mockResolvedValueOnce([makeChange({ id: 10 })]);
-
-    await processQueuedNotifications();
-    expect(mockIncrementQueueEntryAttempts).toHaveBeenCalledWith(1);
-    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(1);
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      expect.stringContaining("permanently failed after 5 attempts"),
-      expect.objectContaining({ monitorId: 1, notificationQueueId: 1, attempts: 5 })
-    );
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await processQueuedNotifications();
+      expect(mockIncrementQueueEntryAttempts).toHaveBeenCalledWith(1);
+      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("permanently failed after 5 attempts"),
+        expect.objectContaining({ monitorId: 1, notificationQueueId: 1, attempts: 5 })
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("processQueuedNotifications does not increment attempts on successful delivery", async () => {
@@ -1533,15 +1550,18 @@ describe("max-retry limit on failed queue entries", () => {
     ];
     mockGetPendingDigestEntries.mockResolvedValueOnce(entries);
     mockGetMonitorChangesByIds.mockResolvedValueOnce([makeChange({ id: 10 })]);
-
-    await processDigestBatch(makeMonitor(), makePrefs({ digestMode: true }));
-    expect(mockIncrementQueueEntryAttempts).toHaveBeenCalledWith(1);
-    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(1);
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      expect.stringContaining("permanently failed after 5 attempts"),
-      expect.objectContaining({ monitorId: 1, notificationQueueId: 1, attempts: 5 })
-    );
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await processDigestBatch(makeMonitor(), makePrefs({ digestMode: true }));
+      expect(mockIncrementQueueEntryAttempts).toHaveBeenCalledWith(1);
+      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("permanently failed after 5 attempts"),
+        expect.objectContaining({ monitorId: 1, notificationQueueId: 1, attempts: 5 })
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 });
 

--- a/server/services/notification.test.ts
+++ b/server/services/notification.test.ts
@@ -48,6 +48,14 @@ vi.mock("./email", () => ({
   sendDigestEmail: (...args: any[]) => mockSendDigestEmail(...args),
 }));
 
+vi.mock("./logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 const mockWebhookDeliver = vi.fn().mockResolvedValue({ success: true, statusCode: 200 });
 vi.mock("./webhookDelivery", () => ({
   deliver: (...args: any[]) => mockWebhookDeliver(...args),
@@ -78,6 +86,8 @@ import {
   getQuietHoursEndDate,
   getNextDigestTime,
 } from "./notification";
+
+import { ErrorLogger } from "./logger";
 
 import type { Monitor, MonitorChange, NotificationPreference } from "@shared/schema";
 
@@ -722,6 +732,11 @@ describe("processQueuedNotifications edge cases", () => {
 
     await processQueuedNotifications();
     expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(7);
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("1 stale notification queue entries"),
+      expect.objectContaining({ count: 1, monitorIds: [3], entryIds: [7] })
+    );
   });
 
   it("marks multiple stale entries as permanently failed with single summary log", async () => {
@@ -732,26 +747,17 @@ describe("processQueuedNotifications edge cases", () => {
     ];
     mockGetStaleQueueEntries.mockResolvedValueOnce(staleEntries);
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    try {
-      await processQueuedNotifications();
-      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledTimes(2);
-      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(7);
-      expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(8);
-      // Only one summary warning, not one per entry — protects the intent
-      // that the stale-queue path emits a single aggregated log line.
-      const summaryCalls = warnSpy.mock.calls.filter((c) =>
-        String(c[0]).includes("stale notification queue entries"),
-      );
-      expect(summaryCalls.length).toBe(1);
-      expect(String(summaryCalls[0][0])).toContain("2 stale notification queue entries");
-      expect(summaryCalls[0][1]).toEqual(
-        expect.objectContaining({ count: 2, monitorIds: expect.arrayContaining([3, 4]) }),
-      );
-    } finally {
-      warnSpy.mockRestore();
-    }
+    await processQueuedNotifications();
+    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledTimes(2);
+    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(7);
+    expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(8);
+    // Only one summary warning, not one per entry
+    expect(ErrorLogger.warning).toHaveBeenCalledTimes(1);
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("2 stale notification queue entries"),
+      expect.objectContaining({ count: 2, monitorIds: expect.arrayContaining([3, 4]) })
+    );
   });
 
   it("groups multiple entries by monitor and processes each", async () => {
@@ -788,6 +794,20 @@ describe("processQueuedNotifications edge cases", () => {
     expect(mockMarkQueueEntryDelivered).not.toHaveBeenCalled();
   });
 
+  it("handles errors in individual monitor processing gracefully", async () => {
+    const entry = { id: 1, monitorId: 1, changeId: 10, reason: "quiet_hours", scheduledFor: new Date(), delivered: false, deliveredAt: null, createdAt: new Date() };
+    mockGetReadyQueueEntries.mockResolvedValueOnce([entry]);
+    mockGetStaleQueueEntries.mockResolvedValueOnce([]);
+    mockGetMonitor.mockRejectedValueOnce(new Error("DB connection lost"));
+
+    await processQueuedNotifications();
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("Failed to process queued notifications"),
+      expect.any(Error),
+      expect.objectContaining({ monitorId: 1 })
+    );
+  });
 });
 
 describe("processDigestCron", () => {
@@ -834,6 +854,20 @@ describe("processDigestCron", () => {
     expect(mockGetPendingDigestEntries).not.toHaveBeenCalled();
   });
 
+  it("logs errors for individual monitor digest failures without crashing", async () => {
+    mockGetAllDigestMonitorPreferences.mockResolvedValueOnce([
+      makePrefs({ monitorId: 1, digestMode: true, timezone: "UTC" }),
+    ]);
+    mockGetMonitor.mockRejectedValueOnce(new Error("DB error"));
+
+    await processDigestCron();
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("Failed to process digest"),
+      expect.any(Error),
+      expect.objectContaining({ monitorId: 1 })
+    );
+  });
 });
 
 describe("multi-channel delivery", () => {
@@ -1167,6 +1201,16 @@ describe("processChangeNotification with conditions", () => {
     expect(result).toEqual({ success: true });
   });
 
+  it("logs info when conditions block notification", async () => {
+    mockGetMonitorConditions.mockResolvedValue([
+      { id: 1, monitorId: 1, type: "numeric_lt", value: "0", groupIndex: 0, createdAt: new Date() },
+    ]);
+    const monitor = makeMonitor({ emailEnabled: true });
+    const change = makeChange({ oldValue: "$49/mo", newValue: "$59/mo" });
+    await processChangeNotification(monitor, change, false);
+    expect(ErrorLogger.info).toHaveBeenCalled();
+  });
+
   it("proceeds with notification when getMonitorConditions throws", async () => {
     mockGetMonitorConditions.mockRejectedValue(new Error("DB connection failed"));
     const monitor = makeMonitor({ emailEnabled: true });
@@ -1174,6 +1218,7 @@ describe("processChangeNotification with conditions", () => {
     mockSendNotificationEmail.mockResolvedValue({ success: true });
     const result = await processChangeNotification(monitor, change, false);
     expect(result).toEqual({ success: true });
+    expect(ErrorLogger.error).toHaveBeenCalled();
     expect(mockSendNotificationEmail).toHaveBeenCalled();
   });
 });
@@ -1366,6 +1411,12 @@ describe("orphaned queue entry handling", () => {
 
     await processDigestBatch(monitor, prefs);
 
+    // Should log warning about 2 orphaned entries
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("2 queue entries reference deleted changes"),
+      expect.objectContaining({ monitorId: 1, orphanedChangeIds: [11, 12] })
+    );
     // Orphaned entries should be marked delivered
     expect(mockMarkQueueEntriesDelivered).toHaveBeenCalledWith([2, 3]);
     // The valid entry should also be marked delivered (in a separate call after successful delivery)
@@ -1398,6 +1449,11 @@ describe("orphaned queue entry handling", () => {
 
     await processQueuedNotifications();
 
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("change 999 not found"),
+      expect.objectContaining({ monitorId: 1, changeId: 999, notificationQueueId: 3 })
+    );
     expect(mockMarkQueueEntryDelivered).toHaveBeenCalledWith(3);
   });
 });
@@ -1436,6 +1492,11 @@ describe("max-retry limit on failed queue entries", () => {
     await processQueuedNotifications();
     expect(mockIncrementQueueEntryAttempts).toHaveBeenCalledWith(1);
     expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(1);
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("permanently failed after 5 attempts"),
+      expect.objectContaining({ monitorId: 1, notificationQueueId: 1, attempts: 5 })
+    );
   });
 
   it("processQueuedNotifications does not increment attempts on successful delivery", async () => {
@@ -1476,6 +1537,11 @@ describe("max-retry limit on failed queue entries", () => {
     await processDigestBatch(makeMonitor(), makePrefs({ digestMode: true }));
     expect(mockIncrementQueueEntryAttempts).toHaveBeenCalledWith(1);
     expect(mockMarkQueueEntryPermanentlyFailed).toHaveBeenCalledWith(1);
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("permanently failed after 5 attempts"),
+      expect.objectContaining({ monitorId: 1, notificationQueueId: 1, attempts: 5 })
+    );
   });
 });
 

--- a/server/services/notification.ts
+++ b/server/services/notification.ts
@@ -4,6 +4,7 @@ import { sendNotificationEmail, sendDigestEmail, type EmailResult } from "./emai
 import { deliver as deliverWebhook, type WebhookConfig } from "./webhookDelivery";
 import { deliver as deliverSlack } from "./slackDelivery";
 import { decryptToken } from "../utils/encryption";
+import { ErrorLogger } from "./logger";
 import { evaluateConditions } from "./conditions";
 import { deliverToAutomationSubscriptions } from "./automationDelivery";
 
@@ -320,7 +321,7 @@ async function deliverToChannels(
       } else if (ch.channel === "slack" && !result.slack) {
         result.slack = { success: false, error: msg };
       }
-      console.error(`[notification] Channel delivery failed for ${ch.channel} on monitor ${monitor.id}`, err instanceof Error ? err.message : String(err), { monitorId: monitor.id, channel: ch.channel });
+      await ErrorLogger.error("email", `Channel delivery failed for ${ch.channel} on monitor ${monitor.id}`, err instanceof Error ? err : null, { monitorId: monitor.id, channel: ch.channel });
     }
   });
 
@@ -480,7 +481,7 @@ async function deliverDigestToChannels(
       } else if (ch.channel === "slack" && !result.slack) {
         result.slack = { success: false, error: msg };
       }
-      console.error(`[notification] Digest channel delivery failed for ${ch.channel}`, err instanceof Error ? err.message : String(err), { monitorId: monitor.id, channel: ch.channel });
+      await ErrorLogger.error("email", `Digest channel delivery failed for ${ch.channel}`, err instanceof Error ? err : null, { monitorId: monitor.id, channel: ch.channel });
     }
   });
 
@@ -521,17 +522,21 @@ export async function processChangeNotification(
   try {
     conditions = await storage.getMonitorConditions(monitor.id);
   } catch (err) {
-    console.error(
-      `[scheduler] Failed to load conditions for monitor ${monitor.id}, proceeding with notification`,
-      err instanceof Error ? err.message : String(err),
+    await ErrorLogger.error(
+      "scheduler",
+      `Failed to load conditions for monitor ${monitor.id}, proceeding with notification`,
+      err instanceof Error ? err : new Error(String(err)),
     );
     // Fall through — send notification when conditions cannot be checked
   }
   if (conditions.length > 0) {
     const passes = evaluateConditions(conditions, change.oldValue, change.newValue);
     if (!passes) {
-      console.log(
-        `[scheduler] Conditions blocked notification for monitor "${monitor.name}" (ID ${monitor.id}) — automation subscriptions (Zapier) also skipped`,
+      // Log with monitor name and explicit mention that automation (Zapier) delivery
+      // was also blocked so users investigating silent Zaps can find this entry.
+      await ErrorLogger.info(
+        "scheduler",
+        `Conditions blocked notification for monitor "${monitor.name}" (ID ${monitor.id}) — automation subscriptions (Zapier) also skipped`,
         { monitorId: monitor.id, monitorName: monitor.name, conditionCount: conditions.length, automationBlocked: true },
       );
       return null;
@@ -542,7 +547,7 @@ export async function processChangeNotification(
   // This runs independently of channel checks so Zapier still fires even when
   // all traditional channels (email/webhook/slack) are disabled.
   deliverToAutomationSubscriptions(monitor, change).catch((err) => {
-    console.warn(`[scheduler] Automation delivery failed for monitor "${monitor.name}"`, { monitorId: monitor.id, error: err instanceof Error ? err.message : String(err) });
+    ErrorLogger.warning("scheduler", `Automation delivery failed for monitor "${monitor.name}"`, { monitorId: monitor.id, error: err instanceof Error ? err.message : String(err) }).catch(() => {});
   });
 
   // Check if any traditional channel is active (backwards compat: falls back to emailEnabled)
@@ -603,7 +608,7 @@ export async function processDigestBatch(
   const foundIds = new Set(changes.map((c) => c.id));
   const orphanedEntries = entries.filter((e) => !foundIds.has(e.changeId));
   if (orphanedEntries.length > 0) {
-    console.warn(`[scheduler] Digest batch for monitor ${monitor.id}: ${orphanedEntries.length} queue entries reference deleted changes`, { monitorId: monitor.id, orphanedChangeIds: orphanedEntries.map((e) => e.changeId) });
+    await ErrorLogger.warning("scheduler", `Digest batch for monitor ${monitor.id}: ${orphanedEntries.length} queue entries reference deleted changes`, { monitorId: monitor.id, orphanedChangeIds: orphanedEntries.map((e) => e.changeId) });
     await storage.markQueueEntriesDelivered(orphanedEntries.map((e) => e.id));
   }
 
@@ -623,7 +628,7 @@ export async function processDigestBatch(
       const newAttempts = await storage.incrementQueueEntryAttempts(entry.id);
       if (newAttempts >= MAX_QUEUE_ATTEMPTS) {
         await storage.markQueueEntryPermanentlyFailed(entry.id);
-        console.warn(`[scheduler] Digest queue entry ${entry.id} for monitor ${monitor.id} permanently failed after ${newAttempts} attempts`, { monitorId: monitor.id, notificationQueueId: entry.id, attempts: newAttempts });
+        await ErrorLogger.warning("scheduler", `Digest queue entry ${entry.id} for monitor ${monitor.id} permanently failed after ${newAttempts} attempts`, { monitorId: monitor.id, notificationQueueId: entry.id, attempts: newAttempts });
       }
     }
   }
@@ -668,7 +673,7 @@ export async function processQueuedNotifications(): Promise<void> {
       for (const entry of entries) {
         const change = changesById.get(entry.changeId);
         if (!change) {
-          console.warn(`[scheduler] Queued notification for monitor ${monitorId}: change ${entry.changeId} not found, marking entry ${entry.id} as delivered`, { monitorId, changeId: entry.changeId, notificationQueueId: entry.id });
+          await ErrorLogger.warning("scheduler", `Queued notification for monitor ${monitorId}: change ${entry.changeId} not found, marking entry ${entry.id} as delivered`, { monitorId, changeId: entry.changeId, notificationQueueId: entry.id });
           await storage.markQueueEntryDelivered(entry.id);
           continue;
         }
@@ -680,12 +685,12 @@ export async function processQueuedNotifications(): Promise<void> {
           const newAttempts = await storage.incrementQueueEntryAttempts(entry.id);
           if (newAttempts >= MAX_QUEUE_ATTEMPTS) {
             await storage.markQueueEntryPermanentlyFailed(entry.id);
-            console.warn(`[scheduler] Notification queue entry ${entry.id} for monitor ${monitorId} permanently failed after ${newAttempts} attempts`, { monitorId, notificationQueueId: entry.id, attempts: newAttempts });
+            await ErrorLogger.warning("scheduler", `Notification queue entry ${entry.id} for monitor ${monitorId} permanently failed after ${newAttempts} attempts`, { monitorId, notificationQueueId: entry.id, attempts: newAttempts });
           }
         }
       }
     } catch (error) {
-      console.error(`[scheduler] Failed to process queued notifications for monitor ${monitorId}`, error instanceof Error ? error.message : String(error), { monitorId });
+      await ErrorLogger.error("scheduler", `Failed to process queued notifications for monitor ${monitorId}`, error instanceof Error ? error : null, { monitorId });
     }
   }
 
@@ -697,7 +702,7 @@ export async function processQueuedNotifications(): Promise<void> {
       await storage.markQueueEntryPermanentlyFailed(entry.id);
     }
     const monitorIds = Array.from(new Set(staleEntries.map(e => e.monitorId)));
-    console.warn(`[scheduler] Marked ${staleEntries.length} stale notification queue entries as permanently failed (older than 48 hours)`, { count: staleEntries.length, monitorIds, entryIds: staleEntries.map(e => e.id) });
+    await ErrorLogger.warning("scheduler", `Marked ${staleEntries.length} stale notification queue entries as permanently failed (older than 48 hours)`, { count: staleEntries.length, monitorIds, entryIds: staleEntries.map(e => e.id) });
   }
 }
 
@@ -739,7 +744,7 @@ export async function processDigestCron(): Promise<void> {
         emailsSent++;
       }
     } catch (error) {
-      console.error(`[scheduler] Failed to process digest for monitor ${prefs.monitorId}`, error instanceof Error ? error.message : String(error), { monitorId: prefs.monitorId });
+      await ErrorLogger.error("scheduler", `Failed to process digest for monitor ${prefs.monitorId}`, error instanceof Error ? error : null, { monitorId: prefs.monitorId });
     }
   }
 
@@ -748,6 +753,6 @@ export async function processDigestCron(): Promise<void> {
     console.log(`[Digest] Processed ${monitorsProcessed} monitors, sent ${emailsSent} emails in ${duration}ms`);
   }
   if (duration > 30000) {
-    console.warn(`[scheduler] Digest batch processing slow (${duration}ms)`, { batchSize: digestPrefs.length, duration });
+    await ErrorLogger.warning("scheduler", `Digest batch processing slow (${duration}ms)`, { batchSize: digestPrefs.length, duration });
   }
 }

--- a/server/services/notification.ts
+++ b/server/services/notification.ts
@@ -547,7 +547,7 @@ export async function processChangeNotification(
   // This runs independently of channel checks so Zapier still fires even when
   // all traditional channels (email/webhook/slack) are disabled.
   deliverToAutomationSubscriptions(monitor, change).catch((err) => {
-    ErrorLogger.warning("scheduler", `Automation delivery failed for monitor "${monitor.name}"`, { monitorId: monitor.id, error: err instanceof Error ? err.message : String(err) }).catch(() => {});
+    console.warn(`[scheduler] Automation delivery failed for monitor "${monitor.name}"`, { monitorId: monitor.id, error: err instanceof Error ? err.message : String(err) });
   });
 
   // Check if any traditional channel is active (backwards compat: falls back to emailEnabled)
@@ -608,7 +608,7 @@ export async function processDigestBatch(
   const foundIds = new Set(changes.map((c) => c.id));
   const orphanedEntries = entries.filter((e) => !foundIds.has(e.changeId));
   if (orphanedEntries.length > 0) {
-    await ErrorLogger.warning("scheduler", `Digest batch for monitor ${monitor.id}: ${orphanedEntries.length} queue entries reference deleted changes`, { monitorId: monitor.id, orphanedChangeIds: orphanedEntries.map((e) => e.changeId) });
+    console.warn(`[scheduler] Digest batch for monitor ${monitor.id}: ${orphanedEntries.length} queue entries reference deleted changes`, { monitorId: monitor.id, orphanedChangeIds: orphanedEntries.map((e) => e.changeId) });
     await storage.markQueueEntriesDelivered(orphanedEntries.map((e) => e.id));
   }
 
@@ -628,7 +628,7 @@ export async function processDigestBatch(
       const newAttempts = await storage.incrementQueueEntryAttempts(entry.id);
       if (newAttempts >= MAX_QUEUE_ATTEMPTS) {
         await storage.markQueueEntryPermanentlyFailed(entry.id);
-        await ErrorLogger.warning("scheduler", `Digest queue entry ${entry.id} for monitor ${monitor.id} permanently failed after ${newAttempts} attempts`, { monitorId: monitor.id, notificationQueueId: entry.id, attempts: newAttempts });
+        console.warn(`[scheduler] Digest queue entry ${entry.id} for monitor ${monitor.id} permanently failed after ${newAttempts} attempts`, { monitorId: monitor.id, notificationQueueId: entry.id, attempts: newAttempts });
       }
     }
   }
@@ -673,7 +673,7 @@ export async function processQueuedNotifications(): Promise<void> {
       for (const entry of entries) {
         const change = changesById.get(entry.changeId);
         if (!change) {
-          await ErrorLogger.warning("scheduler", `Queued notification for monitor ${monitorId}: change ${entry.changeId} not found, marking entry ${entry.id} as delivered`, { monitorId, changeId: entry.changeId, notificationQueueId: entry.id });
+          console.warn(`[scheduler] Queued notification for monitor ${monitorId}: change ${entry.changeId} not found, marking entry ${entry.id} as delivered`, { monitorId, changeId: entry.changeId, notificationQueueId: entry.id });
           await storage.markQueueEntryDelivered(entry.id);
           continue;
         }
@@ -685,7 +685,7 @@ export async function processQueuedNotifications(): Promise<void> {
           const newAttempts = await storage.incrementQueueEntryAttempts(entry.id);
           if (newAttempts >= MAX_QUEUE_ATTEMPTS) {
             await storage.markQueueEntryPermanentlyFailed(entry.id);
-            await ErrorLogger.warning("scheduler", `Notification queue entry ${entry.id} for monitor ${monitorId} permanently failed after ${newAttempts} attempts`, { monitorId, notificationQueueId: entry.id, attempts: newAttempts });
+            console.warn(`[scheduler] Notification queue entry ${entry.id} for monitor ${monitorId} permanently failed after ${newAttempts} attempts`, { monitorId, notificationQueueId: entry.id, attempts: newAttempts });
           }
         }
       }
@@ -702,7 +702,7 @@ export async function processQueuedNotifications(): Promise<void> {
       await storage.markQueueEntryPermanentlyFailed(entry.id);
     }
     const monitorIds = Array.from(new Set(staleEntries.map(e => e.monitorId)));
-    await ErrorLogger.warning("scheduler", `Marked ${staleEntries.length} stale notification queue entries as permanently failed (older than 48 hours)`, { count: staleEntries.length, monitorIds, entryIds: staleEntries.map(e => e.id) });
+    console.warn(`[scheduler] Marked ${staleEntries.length} stale notification queue entries as permanently failed (older than 48 hours)`, { count: staleEntries.length, monitorIds, entryIds: staleEntries.map(e => e.id) });
   }
 }
 
@@ -753,6 +753,6 @@ export async function processDigestCron(): Promise<void> {
     console.log(`[Digest] Processed ${monitorsProcessed} monitors, sent ${emailsSent} emails in ${duration}ms`);
   }
   if (duration > 30000) {
-    await ErrorLogger.warning("scheduler", `Digest batch processing slow (${duration}ms)`, { batchSize: digestPrefs.length, duration });
+    console.warn(`[scheduler] Digest batch processing slow (${duration}ms)`, { batchSize: digestPrefs.length, duration });
   }
 }

--- a/server/services/resendTracker.ts
+++ b/server/services/resendTracker.ts
@@ -1,20 +1,8 @@
 import { format, parseISO } from "date-fns";
 import { db } from "../db";
-import { resendUsage } from "@shared/schema";
+import { resendUsage, errorLogs } from "@shared/schema";
 import { RESEND_CAPS } from "@shared/models/auth";
 import { sql, eq, and, gte, count, desc } from "drizzle-orm";
-
-// In-memory cooldown tracking for threshold alert logs. Previously persisted
-// via error_logs; now kept in-memory with a 6h cooldown per alert key.
-// Tradeoffs mirror browserlessTracker:
-//   - RESTART-RESET: two deploys within 6h during an already-elevated usage
-//     window can re-fire the same threshold warn, because the Map is
-//     per-process and starts empty on each boot.
-//   - AUTOSCALE FAN-OUT: Replit autoscale replicas each hold their own
-//     Map, so a threshold crossing during scale-out can emit up to one
-//     console.warn per replica instead of a single global alert.
-// Both are accepted as documented tradeoffs for the removal branch.
-const recentResendAlerts = new Map<string, number>();
 
 function getMonthStart(): Date {
   const now = new Date();
@@ -99,15 +87,32 @@ export class ResendUsageTracker {
       { key: "80", pct: 0.80, label: "80%" },
     ];
 
-    const cooldownMs = 6 * 60 * 60 * 1000;
-
     for (const t of thresholds) {
       if (pct >= t.pct) {
         const alertKey = `resend_alert_${t.key}`;
-        const lastAlertAt = recentResendAlerts.get(alertKey) ?? 0;
-        if (Date.now() - lastAlertAt >= cooldownMs) {
-          recentResendAlerts.set(alertKey, Date.now());
-          console.warn(`[resend] Monthly usage at ${t.label}: ${monthlyUsage}/${monthlyCap}`, { threshold: t.label, usage: monthlyUsage, cap: monthlyCap });
+        const cooldownMs = 6 * 60 * 60 * 1000;
+        const cooldownStart = new Date(Date.now() - cooldownMs);
+
+        const recentAlert = await db
+          .select({ id: errorLogs.id })
+          .from(errorLogs)
+          .where(
+            and(
+              eq(errorLogs.source, "resend"),
+              eq(errorLogs.message, alertKey),
+              gte(errorLogs.timestamp, cooldownStart)
+            )
+          )
+          .limit(1);
+
+        if (recentAlert.length === 0) {
+          await db.insert(errorLogs).values({
+            level: "warning",
+            source: "resend",
+            message: alertKey,
+            context: { threshold: t.label, usage: monthlyUsage, cap: monthlyCap },
+          });
+          console.log(`[ResendTracker] Monthly usage at ${t.label}: ${monthlyUsage}/${monthlyCap}`);
         }
         break;
       }
@@ -118,10 +123,29 @@ export class ResendUsageTracker {
     const dailyPct = dailyUsage / dailyCap;
     if (dailyPct >= 0.9) {
       const alertKey = `resend_daily_alert_90`;
-      const lastAlertAt = recentResendAlerts.get(alertKey) ?? 0;
-      if (Date.now() - lastAlertAt >= cooldownMs) {
-        recentResendAlerts.set(alertKey, Date.now());
-        console.warn(`[resend] Daily usage at 90%: ${dailyUsage}/${dailyCap}`, { threshold: "90% daily", usage: dailyUsage, cap: dailyCap });
+      const cooldownMs = 6 * 60 * 60 * 1000;
+      const cooldownStart = new Date(Date.now() - cooldownMs);
+
+      const recentAlert = await db
+        .select({ id: errorLogs.id })
+        .from(errorLogs)
+        .where(
+          and(
+            eq(errorLogs.source, "resend"),
+            eq(errorLogs.message, alertKey),
+            gte(errorLogs.timestamp, cooldownStart)
+          )
+        )
+        .limit(1);
+
+      if (recentAlert.length === 0) {
+        await db.insert(errorLogs).values({
+          level: "warning",
+          source: "resend",
+          message: alertKey,
+          context: { threshold: "90% daily", usage: dailyUsage, cap: dailyCap },
+        });
+        console.log(`[ResendTracker] Daily usage at 90%: ${dailyUsage}/${dailyCap}`);
       }
     }
   }

--- a/server/services/resendTracker.ts
+++ b/server/services/resendTracker.ts
@@ -3,6 +3,7 @@ import { db } from "../db";
 import { resendUsage, errorLogs } from "@shared/schema";
 import { RESEND_CAPS } from "@shared/models/auth";
 import { sql, eq, and, gte, count, desc } from "drizzle-orm";
+import { ErrorLogger } from "./logger";
 
 function getMonthStart(): Date {
   const now = new Date();
@@ -106,12 +107,7 @@ export class ResendUsageTracker {
           .limit(1);
 
         if (recentAlert.length === 0) {
-          await db.insert(errorLogs).values({
-            level: "warning",
-            source: "resend",
-            message: alertKey,
-            context: { threshold: t.label, usage: monthlyUsage, cap: monthlyCap },
-          });
+          await ErrorLogger.info("resend", alertKey, { threshold: t.label, usage: monthlyUsage, cap: monthlyCap });
           console.log(`[ResendTracker] Monthly usage at ${t.label}: ${monthlyUsage}/${monthlyCap}`);
         }
         break;
@@ -139,12 +135,7 @@ export class ResendUsageTracker {
         .limit(1);
 
       if (recentAlert.length === 0) {
-        await db.insert(errorLogs).values({
-          level: "warning",
-          source: "resend",
-          message: alertKey,
-          context: { threshold: "90% daily", usage: dailyUsage, cap: dailyCap },
-        });
+        await ErrorLogger.info("resend", alertKey, { threshold: "90% daily", usage: dailyUsage, cap: dailyCap });
         console.log(`[ResendTracker] Daily usage at 90%: ${dailyUsage}/${dailyCap}`);
       }
     }

--- a/server/services/resendWebhook.test.ts
+++ b/server/services/resendWebhook.test.ts
@@ -45,6 +45,12 @@ vi.mock("drizzle-orm", () => {
   };
 });
 
+vi.mock("./logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 import { verifyResendWebhook, handleResendWebhookEvent } from "./resendWebhook";
 
 function makeEvent(type: string, emailId = "email_abc123") {

--- a/server/services/resendWebhook.ts
+++ b/server/services/resendWebhook.ts
@@ -1,6 +1,7 @@
 import { db } from "../db";
 import { campaignRecipients, campaigns } from "@shared/schema";
 import { and, eq, isNull, sql } from "drizzle-orm";
+import { ErrorLogger } from "./logger";
 
 interface ResendWebhookEvent {
   type: string;

--- a/server/services/scheduler.test.ts
+++ b/server/services/scheduler.test.ts
@@ -70,6 +70,13 @@ vi.mock("./automationDelivery", () => ({
   finalizeAutomationRetry: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("../db", () => ({
   db: {
     execute: (...args: any[]) => mockDbExecute(...args),
@@ -132,6 +139,7 @@ vi.mock("node-cron", () => ({
 
 import { startScheduler, stopScheduler, retryBackoff, _resetSchedulerStarted, _resetActiveChecks } from "./scheduler";
 import { processQueuedNotifications, processDigestCron } from "./notification";
+import { ErrorLogger } from "./logger";
 import { _resetCache } from "./notificationReady";
 import cron from "node-cron";
 import { storage } from "../storage";
@@ -238,6 +246,11 @@ describe("startScheduler", () => {
 
     await startScheduler();
 
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      "cleanupPollutedValues failed (non-fatal)",
+      expect.objectContaining({ errorMessage: "DB connection lost" })
+    );
     // Cron jobs should still be registered despite the failure
     expect(hasCron("* * * * *")).toBe(true);
     expect(hasCron("*/1 * * * *")).toBe(true);
@@ -328,6 +341,59 @@ describe("startScheduler", () => {
     expect(mockCheckMonitor).not.toHaveBeenCalled();
   });
 
+  it("logs error when checkMonitor throws (does not crash scheduler)", async () => {
+    const monitor = makeMonitor({ lastChecked: null });
+    mockGetAllActiveMonitors.mockResolvedValueOnce([monitor]);
+    mockCheckMonitor.mockRejectedValueOnce(new Error("Unexpected crash"));
+
+    await startScheduler();
+    await runCron("* * * * *");
+    await vi.advanceTimersByTimeAsync(31000);
+
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("scheduled check failed"),
+      expect.any(Error),
+      expect.objectContaining({ monitorId: 1 })
+    );
+  });
+
+  it("logs error when getAllActiveMonitors throws", async () => {
+    mockGetAllActiveMonitors.mockRejectedValueOnce(new Error("DB down"));
+
+    await startScheduler();
+    await runCron("* * * * *");
+
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Scheduler iteration failed",
+      expect.any(Error),
+      expect.objectContaining({
+        errorMessage: "DB down",
+        activeChecks: 0,
+        phase: "fetching active monitors",
+      })
+    );
+  });
+
+  it("handles non-Error thrown in scheduler iteration (uses String coercion)", async () => {
+    mockGetAllActiveMonitors.mockRejectedValueOnce("connection reset");
+
+    await startScheduler();
+    await runCron("* * * * *");
+
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Scheduler iteration failed",
+      null,
+      expect.objectContaining({
+        errorMessage: "connection reset",
+        activeChecks: 0,
+        phase: "fetching active monitors",
+      })
+    );
+  });
+
   it("reports activeChecks > 0 when prior checks are still in-flight", async () => {
     // First iteration: start a check that never resolves (stays in-flight)
     const monitor = makeMonitor({ id: 1, lastChecked: null });
@@ -347,6 +413,16 @@ describe("startScheduler", () => {
     // Second iteration: getAllActiveMonitors fails while check is still running
     mockGetAllActiveMonitors.mockRejectedValueOnce(new Error("DB pool exhausted"));
     await runCron("* * * * *");
+
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Scheduler iteration failed",
+      expect.any(Error),
+      expect.objectContaining({
+        errorMessage: "DB pool exhausted",
+        activeChecks: 1,
+      })
+    );
 
     // Clean up: resolve the hanging check and flush microtask so .finally() decrements activeChecks
     resolver!();
@@ -695,6 +771,67 @@ describe("daily metrics cleanup", () => {
     consoleSpy.mockRestore();
   });
 
+  it("logs error when cleanup fails with non-transient DB error", async () => {
+    await startScheduler();
+    mockDbExecute.mockRejectedValueOnce(new Error('relation "monitor_metrics" does not exist'));
+    await runCron("0 3 * * *");
+
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "monitor_metrics cleanup failed",
+      expect.any(Error),
+      expect.objectContaining({
+        errorMessage: 'relation "monitor_metrics" does not exist',
+        retentionDays: 90,
+        table: "monitor_metrics",
+      })
+    );
+  });
+
+  it("logs warning when cleanup fails with transient DB error", async () => {
+    await startScheduler();
+    mockDbExecute
+      .mockRejectedValueOnce(new Error("Connection terminated"))
+      .mockRejectedValueOnce(new Error("Connection terminated"));
+    const cronPromise = runCron("0 3 * * *");
+    await vi.advanceTimersByTimeAsync(2000);
+    await cronPromise;
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      "monitor_metrics cleanup failed",
+      expect.objectContaining({
+        errorMessage: "Connection terminated",
+        retentionDays: 90,
+        table: "monitor_metrics",
+      })
+    );
+    // Verify the monitor_metrics cleanup itself didn't log an error (other cleanup tasks may)
+    expect(ErrorLogger.error).not.toHaveBeenCalledWith(
+      "scheduler",
+      "monitor_metrics cleanup failed",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("handles non-Error thrown in cleanup (uses String coercion)", async () => {
+    await startScheduler();
+    mockDbExecute.mockRejectedValueOnce("disk full");
+    await runCron("0 3 * * *");
+
+    // Non-Error values are not transient, so logged as error
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "monitor_metrics cleanup failed",
+      null,
+      expect.objectContaining({
+        errorMessage: "disk full",
+        retentionDays: 90,
+        table: "monitor_metrics",
+      })
+    );
+  });
 });
 
 describe("notification queue and digest cron (*/1 * * * *)", () => {
@@ -734,7 +871,125 @@ describe("notification queue and digest cron (*/1 * * * *)", () => {
     await startScheduler();
     await runCron("*/1 * * * *");
 
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Queued notification processing failed",
+      expect.any(Error),
+      expect.objectContaining({
+        errorMessage: "Queue DB error",
+      })
+    );
     expect(mockProcessDigestCron).toHaveBeenCalledOnce();
+  });
+
+  it("logs error when processDigestCron throws", async () => {
+    mockProcessDigestCron.mockRejectedValueOnce(new Error("Digest error"));
+
+    await startScheduler();
+    await runCron("*/1 * * * *");
+
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Digest processing failed",
+      expect.any(Error),
+      expect.objectContaining({
+        errorMessage: "Digest error",
+      })
+    );
+  });
+
+  it("handles non-Error thrown in notification processing (uses String coercion)", async () => {
+    mockProcessQueuedNotifications.mockRejectedValueOnce(42);
+
+    await startScheduler();
+    await runCron("*/1 * * * *");
+
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Queued notification processing failed",
+      null,
+      expect.objectContaining({
+        errorMessage: "42",
+      })
+    );
+  });
+
+  it("handles non-Error thrown in digest processing (uses String coercion)", async () => {
+    mockProcessDigestCron.mockRejectedValueOnce({ code: "TIMEOUT" });
+
+    await startScheduler();
+    await runCron("*/1 * * * *");
+
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Digest processing failed",
+      null,
+      expect.objectContaining({
+        errorMessage: "[object Object]",
+      })
+    );
+  });
+
+  it("logs both errors when both processQueuedNotifications and processDigestCron throw", async () => {
+    mockProcessQueuedNotifications.mockRejectedValueOnce(new Error("Queue error"));
+    mockProcessDigestCron.mockRejectedValueOnce(new Error("Digest error"));
+
+    await startScheduler();
+    await runCron("*/1 * * * *");
+
+    expect(ErrorLogger.error).toHaveBeenCalledTimes(2);
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Queued notification processing failed",
+      expect.any(Error),
+      expect.objectContaining({
+        errorMessage: "Queue error",
+      })
+    );
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Digest processing failed",
+      expect.any(Error),
+      expect.objectContaining({
+        errorMessage: "Digest error",
+      })
+    );
+  });
+
+  it("logs warning (not error) when processQueuedNotifications fails with transient DB error", async () => {
+    // Not wrapped in withDbRetry (to prevent duplicate deliveries), but
+    // logSchedulerError still classifies transient errors as warnings.
+    mockProcessQueuedNotifications
+      .mockRejectedValueOnce(new Error("Connection terminated"));
+
+    await startScheduler();
+    await runCron("*/1 * * * *");
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      "Queued notification processing failed",
+      expect.objectContaining({
+        errorMessage: "Connection terminated",
+      })
+    );
+    expect(ErrorLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("logs warning (not error) when processDigestCron fails with transient DB error", async () => {
+    mockProcessDigestCron
+      .mockRejectedValueOnce(new Error("Connection terminated"));
+
+    await startScheduler();
+    await runCron("*/1 * * * *");
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      "Digest processing failed",
+      expect.objectContaining({
+        errorMessage: "Connection terminated",
+      })
+    );
+    expect(ErrorLogger.error).not.toHaveBeenCalled();
   });
 });
 
@@ -839,6 +1094,12 @@ describe("withDbRetry and re-entrancy guards", () => {
     await runCron("* * * * *");
 
     expect(mockGetAllActiveMonitors).toHaveBeenCalledTimes(1);
+    expect(ErrorLogger.error).toHaveBeenCalledWith(
+      "scheduler",
+      "Scheduler iteration failed",
+      expect.any(Error),
+      expect.objectContaining({ phase: "fetching active monitors" })
+    );
   });
 
   it("logs warning when retry also fails on transient error", async () => {
@@ -853,6 +1114,11 @@ describe("withDbRetry and re-entrancy guards", () => {
 
     expect(mockGetAllActiveMonitors).toHaveBeenCalledTimes(2);
     // Transient DB errors are downgraded to warnings via logSchedulerError helper
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      "Scheduler iteration failed",
+      expect.objectContaining({ activeChecks: 0 })
+    );
   });
 
   it("skips main cron iteration when previous iteration is still running", async () => {
@@ -922,6 +1188,12 @@ describe("withDbRetry and re-entrancy guards", () => {
 
     expect(mockStorage.getPendingWebhookRetries).toHaveBeenCalledTimes(2);
     // Should NOT have logged an error since retry succeeded
+    expect(ErrorLogger.error).not.toHaveBeenCalledWith(
+      "scheduler",
+      "Webhook retry processing failed",
+      expect.anything(),
+      expect.anything()
+    );
   });
 
   it("skips webhook cron when previous iteration is still running", async () => {
@@ -950,6 +1222,33 @@ describe("withDbRetry and re-entrancy guards", () => {
     await firstRun;
   });
 
+  it("logs warning (not error) when webhook processing fails with transient DB error", async () => {
+    // Both withDbRetry attempts fail with transient error
+    mockStorage.getPendingWebhookRetries
+      .mockRejectedValueOnce(new Error("Connection terminated"))
+      .mockRejectedValueOnce(new Error("Connection terminated"));
+
+    await startScheduler();
+    const callbacks = cronCallbacks["*/1 * * * *"];
+    await callbacks[0](); // notification cron
+    const webhookPromise = callbacks[1]();
+    await vi.advanceTimersByTimeAsync(2000);
+    await webhookPromise;
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scheduler",
+      "Webhook retry processing failed",
+      expect.objectContaining({
+        errorMessage: "Connection terminated",
+      })
+    );
+    expect(ErrorLogger.error).not.toHaveBeenCalledWith(
+      "scheduler",
+      expect.stringContaining("Webhook"),
+      expect.anything(),
+      expect.anything()
+    );
+  });
 });
 
 describe("webhook retry cumulative backoff", () => {

--- a/server/services/scheduler.test.ts
+++ b/server/services/scheduler.test.ts
@@ -73,7 +73,6 @@ vi.mock("./automationDelivery", () => ({
 vi.mock("./logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -243,18 +242,21 @@ describe("startScheduler", () => {
 
   it("continues startup and registers cron jobs when cleanupPollutedValues throws", async () => {
     mockCleanupPollutedValues.mockRejectedValueOnce(new Error("DB connection lost"));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await startScheduler();
 
-    await startScheduler();
-
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      "cleanupPollutedValues failed (non-fatal)",
-      expect.objectContaining({ errorMessage: "DB connection lost" })
-    );
-    // Cron jobs should still be registered despite the failure
-    expect(hasCron("* * * * *")).toBe(true);
-    expect(hasCron("*/1 * * * *")).toBe(true);
-    expect(hasCron("0 3 * * *")).toBe(true);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scheduler] cleanupPollutedValues failed (non-fatal)",
+        expect.objectContaining({ errorMessage: "DB connection lost" })
+      );
+      // Cron jobs should still be registered despite the failure
+      expect(hasCron("* * * * *")).toBe(true);
+      expect(hasCron("*/1 * * * *")).toBe(true);
+      expect(hasCron("0 3 * * *")).toBe(true);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("registers all cron schedules (every-minute, notification queue, and daily cleanup)", async () => {
@@ -793,26 +795,30 @@ describe("daily metrics cleanup", () => {
     mockDbExecute
       .mockRejectedValueOnce(new Error("Connection terminated"))
       .mockRejectedValueOnce(new Error("Connection terminated"));
-    const cronPromise = runCron("0 3 * * *");
-    await vi.advanceTimersByTimeAsync(2000);
-    await cronPromise;
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const cronPromise = runCron("0 3 * * *");
+      await vi.advanceTimersByTimeAsync(2000);
+      await cronPromise;
 
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      "monitor_metrics cleanup failed",
-      expect.objectContaining({
-        errorMessage: "Connection terminated",
-        retentionDays: 90,
-        table: "monitor_metrics",
-      })
-    );
-    // Verify the monitor_metrics cleanup itself didn't log an error (other cleanup tasks may)
-    expect(ErrorLogger.error).not.toHaveBeenCalledWith(
-      "scheduler",
-      "monitor_metrics cleanup failed",
-      expect.anything(),
-      expect.anything()
-    );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scheduler] monitor_metrics cleanup failed",
+        expect.objectContaining({
+          errorMessage: "Connection terminated",
+          retentionDays: 90,
+          table: "monitor_metrics",
+        })
+      );
+      // Verify the monitor_metrics cleanup itself didn't log an error (other cleanup tasks may)
+      expect(ErrorLogger.error).not.toHaveBeenCalledWith(
+        "scheduler",
+        "monitor_metrics cleanup failed",
+        expect.anything(),
+        expect.anything()
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("handles non-Error thrown in cleanup (uses String coercion)", async () => {
@@ -961,35 +967,41 @@ describe("notification queue and digest cron (*/1 * * * *)", () => {
     // logSchedulerError still classifies transient errors as warnings.
     mockProcessQueuedNotifications
       .mockRejectedValueOnce(new Error("Connection terminated"));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await startScheduler();
+      await runCron("*/1 * * * *");
 
-    await startScheduler();
-    await runCron("*/1 * * * *");
-
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      "Queued notification processing failed",
-      expect.objectContaining({
-        errorMessage: "Connection terminated",
-      })
-    );
-    expect(ErrorLogger.error).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scheduler] Queued notification processing failed",
+        expect.objectContaining({
+          errorMessage: "Connection terminated",
+        })
+      );
+      expect(ErrorLogger.error).not.toHaveBeenCalled();
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("logs warning (not error) when processDigestCron fails with transient DB error", async () => {
     mockProcessDigestCron
       .mockRejectedValueOnce(new Error("Connection terminated"));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await startScheduler();
+      await runCron("*/1 * * * *");
 
-    await startScheduler();
-    await runCron("*/1 * * * *");
-
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      "Digest processing failed",
-      expect.objectContaining({
-        errorMessage: "Connection terminated",
-      })
-    );
-    expect(ErrorLogger.error).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scheduler] Digest processing failed",
+        expect.objectContaining({
+          errorMessage: "Connection terminated",
+        })
+      );
+      expect(ErrorLogger.error).not.toHaveBeenCalled();
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 });
 
@@ -1106,19 +1118,22 @@ describe("withDbRetry and re-entrancy guards", () => {
     mockGetAllActiveMonitors
       .mockRejectedValueOnce(new Error("Connection terminated"))
       .mockRejectedValueOnce(new Error("Connection terminated again"));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await startScheduler();
+      const cronPromise = runCron("* * * * *");
+      await vi.advanceTimersByTimeAsync(2000);
+      await cronPromise;
 
-    await startScheduler();
-    const cronPromise = runCron("* * * * *");
-    await vi.advanceTimersByTimeAsync(2000);
-    await cronPromise;
-
-    expect(mockGetAllActiveMonitors).toHaveBeenCalledTimes(2);
-    // Transient DB errors are downgraded to warnings via logSchedulerError helper
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      "Scheduler iteration failed",
-      expect.objectContaining({ activeChecks: 0 })
-    );
+      expect(mockGetAllActiveMonitors).toHaveBeenCalledTimes(2);
+      // Transient DB errors are downgraded to console.warn via logSchedulerError helper
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scheduler] Scheduler iteration failed",
+        expect.objectContaining({ activeChecks: 0 })
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("skips main cron iteration when previous iteration is still running", async () => {
@@ -1227,27 +1242,30 @@ describe("withDbRetry and re-entrancy guards", () => {
     mockStorage.getPendingWebhookRetries
       .mockRejectedValueOnce(new Error("Connection terminated"))
       .mockRejectedValueOnce(new Error("Connection terminated"));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await startScheduler();
+      const callbacks = cronCallbacks["*/1 * * * *"];
+      await callbacks[0](); // notification cron
+      const webhookPromise = callbacks[1]();
+      await vi.advanceTimersByTimeAsync(2000);
+      await webhookPromise;
 
-    await startScheduler();
-    const callbacks = cronCallbacks["*/1 * * * *"];
-    await callbacks[0](); // notification cron
-    const webhookPromise = callbacks[1]();
-    await vi.advanceTimersByTimeAsync(2000);
-    await webhookPromise;
-
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scheduler",
-      "Webhook retry processing failed",
-      expect.objectContaining({
-        errorMessage: "Connection terminated",
-      })
-    );
-    expect(ErrorLogger.error).not.toHaveBeenCalledWith(
-      "scheduler",
-      expect.stringContaining("Webhook"),
-      expect.anything(),
-      expect.anything()
-    );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scheduler] Webhook retry processing failed",
+        expect.objectContaining({
+          errorMessage: "Connection terminated",
+        })
+      );
+      expect(ErrorLogger.error).not.toHaveBeenCalledWith(
+        "scheduler",
+        expect.stringContaining("Webhook"),
+        expect.anything(),
+        expect.anything()
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 });
 

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -4,12 +4,12 @@ import { checkMonitor, monitorsNeedingRetry } from "./scraper";
 import { processQueuedNotifications, processDigestCron } from "./notification";
 import { deliver as deliverWebhook, type WebhookConfig, buildWebhookPayload } from "./webhookDelivery";
 import { performAutomationDelivery, finalizeAutomationRetry } from "./automationDelivery";
+import { ErrorLogger } from "./logger";
 import { notificationTablesExist } from "./notificationReady";
 import { browserlessCircuitBreaker } from "./browserlessCircuitBreaker";
 import { ensureMonitorConditionsTable } from "./ensureTables";
 import { processAutomatedCampaigns } from "./automatedCampaigns";
 import { isTransientDbError } from "../utils/dbErrors";
-import { safeHostname } from "./monitorValidation";
 import { AUTOMATION_SUBSCRIPTION_LIMITS } from "@shared/models/auth";
 import { db } from "../db";
 import { eq, sql } from "drizzle-orm";
@@ -46,16 +46,26 @@ async function withDbRetry<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 /** Log a caught error as warning (transient) or error (non-transient) based on isTransientDbError. */
-function logSchedulerError(
+async function logSchedulerError(
   message: string,
   error: unknown,
   context?: Record<string, any>,
-): void {
-  const errorMessage = error instanceof Error ? error.message : String(error);
-  if (isTransientDbError(error)) {
-    console.warn(`[scheduler] ${message}`, { errorMessage, ...context });
-  } else {
-    console.error(`[scheduler] ${message}`, errorMessage, context ?? {});
+): Promise<void> {
+  try {
+    if (isTransientDbError(error)) {
+      await ErrorLogger.warning("scheduler", message, {
+        errorMessage: error instanceof Error ? error.message : String(error),
+        ...context,
+      });
+    } else {
+      await ErrorLogger.error("scheduler", message, error instanceof Error ? error : null, {
+        errorMessage: error instanceof Error ? error.message : String(error),
+        ...context,
+      });
+    }
+  } catch {
+    // If logging itself fails (e.g., logging DB also down), don't mask the original error
+    console.error(`[Scheduler] Failed to log error: ${message}`, error instanceof Error ? error.message : error);
   }
 }
 
@@ -128,10 +138,11 @@ async function runCheckWithLimit(monitor: Parameters<typeof checkMonitor>[0]): P
     }
     return true;
   } catch (error) {
-    console.error(`[scheduler] "${monitor.name}" — scheduled check failed. This is usually a temporary issue. If it persists, verify the URL is still valid and the selector matches the page.`, error instanceof Error ? error.message : String(error), {
+    await ErrorLogger.error("scheduler", `"${monitor.name}" — scheduled check failed. This is usually a temporary issue. If it persists, verify the URL is still valid and the selector matches the page.`, error instanceof Error ? error : null, {
       monitorId: monitor.id,
       monitorName: monitor.name,
-      hostname: safeHostname(monitor.url),
+      url: monitor.url,
+      selector: monitor.selector,
     });
     return true;
   } finally {
@@ -178,7 +189,7 @@ export async function startScheduler() {
   try {
     await storage.cleanupPollutedValues();
   } catch (error) {
-    console.warn("[scheduler] cleanupPollutedValues failed (non-fatal)", { errorMessage: error instanceof Error ? error.message : String(error) });
+    await ErrorLogger.warning("scheduler", "cleanupPollutedValues failed (non-fatal)", { errorMessage: error instanceof Error ? error.message : String(error) });
   }
 
   // Wire circuit breaker recovery: immediately retry pending monitors when Browserless comes back
@@ -261,7 +272,7 @@ export async function startScheduler() {
         }
       }
     } catch (error) {
-      logSchedulerError("Scheduler iteration failed", error, { activeChecks, phase: "fetching active monitors" });
+      await logSchedulerError("Scheduler iteration failed", error, { activeChecks, phase: "fetching active monitors" });
     } finally {
       mainCronRunning = false;
     }
@@ -284,12 +295,12 @@ export async function startScheduler() {
           // could cause duplicate email/webhook/Slack deliveries.
           await processQueuedNotifications();
         } catch (error) {
-          logSchedulerError("Queued notification processing failed", error);
+          await logSchedulerError("Queued notification processing failed", error);
         }
         try {
           await processDigestCron();
         } catch (error) {
-          logSchedulerError("Digest processing failed", error);
+          await logSchedulerError("Digest processing failed", error);
         }
       } finally {
         notificationCronRunning = false;
@@ -414,7 +425,7 @@ export async function startScheduler() {
           }
         }
       } catch (error) {
-        logSchedulerError("Webhook retry processing failed", error);
+        await logSchedulerError("Webhook retry processing failed", error);
       } finally {
         webhookCronRunning = false;
       }
@@ -536,7 +547,7 @@ export async function startScheduler() {
         console.log(`[Cleanup] Pruned ${deleted} monitor_metrics rows older than 90 days`);
       }
     } catch (error) {
-      logSchedulerError("monitor_metrics cleanup failed", error, { retentionDays: 90, table: "monitor_metrics" });
+      await logSchedulerError("monitor_metrics cleanup failed", error, { retentionDays: 90, table: "monitor_metrics" });
     }
 
     // Delivery log cleanup: prune entries older than 30 days
@@ -547,7 +558,7 @@ export async function startScheduler() {
         console.log(`[Cleanup] Pruned ${entriesDeleted} delivery_log rows older than 30 days`);
       }
     } catch (error) {
-      logSchedulerError("delivery_log cleanup failed", error, { retentionDays: 30, table: "delivery_log" });
+      await logSchedulerError("delivery_log cleanup failed", error, { retentionDays: 30, table: "delivery_log" });
     }
 
     // Notification queue cleanup: prune permanently failed entries older than 7 days
@@ -559,7 +570,7 @@ export async function startScheduler() {
         console.log(`[Cleanup] Pruned ${deleted} permanently failed notification_queue rows older than 7 days`);
       }
     } catch (error) {
-      logSchedulerError("notification_queue cleanup failed", error, { retentionDays: 7, table: "notification_queue" });
+      await logSchedulerError("notification_queue cleanup failed", error, { retentionDays: 7, table: "notification_queue" });
     }
 
     // Automation subscriptions cleanup: hard-delete inactive subscriptions older than retention period
@@ -571,7 +582,7 @@ export async function startScheduler() {
         console.log(`[Cleanup] Pruned ${deleted} inactive automation_subscriptions rows older than ${retentionDays} days`);
       }
     } catch (error) {
-      logSchedulerError("automation_subscriptions cleanup failed", error, { retentionDays: AUTOMATION_SUBSCRIPTION_LIMITS.cleanupRetentionDays, table: "automation_subscriptions" });
+      await logSchedulerError("automation_subscriptions cleanup failed", error, { retentionDays: AUTOMATION_SUBSCRIPTION_LIMITS.cleanupRetentionDays, table: "automation_subscriptions" });
     }
   }));
 
@@ -580,7 +591,7 @@ export async function startScheduler() {
     try {
       await processAutomatedCampaigns();
     } catch (error) {
-      logSchedulerError("Automated campaign processing failed", error);
+      await logSchedulerError("Automated campaign processing failed", error);
     }
   }, { timezone: "UTC" }));
 

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -10,7 +10,7 @@ import { browserlessCircuitBreaker } from "./browserlessCircuitBreaker";
 import { ensureMonitorConditionsTable } from "./ensureTables";
 import { processAutomatedCampaigns } from "./automatedCampaigns";
 import { isTransientDbError } from "../utils/dbErrors";
-import { safeHostname } from "./monitorValidation";
+import { safeHostname } from "../utils/urlUtils";
 import { AUTOMATION_SUBSCRIPTION_LIMITS } from "@shared/models/auth";
 import { db } from "../db";
 import { eq, sql } from "drizzle-orm";

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -10,6 +10,7 @@ import { browserlessCircuitBreaker } from "./browserlessCircuitBreaker";
 import { ensureMonitorConditionsTable } from "./ensureTables";
 import { processAutomatedCampaigns } from "./automatedCampaigns";
 import { isTransientDbError } from "../utils/dbErrors";
+import { safeHostname } from "./monitorValidation";
 import { AUTOMATION_SUBSCRIPTION_LIMITS } from "@shared/models/auth";
 import { db } from "../db";
 import { eq, sql } from "drizzle-orm";
@@ -141,7 +142,7 @@ async function runCheckWithLimit(monitor: Parameters<typeof checkMonitor>[0]): P
     await ErrorLogger.error("scheduler", `"${monitor.name}" — scheduled check failed. This is usually a temporary issue. If it persists, verify the URL is still valid and the selector matches the page.`, error instanceof Error ? error : null, {
       monitorId: monitor.id,
       monitorName: monitor.name,
-      url: monitor.url,
+      hostname: safeHostname(monitor.url),
       selector: monitor.selector,
     });
     return true;

--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -45,7 +45,7 @@ async function withDbRetry<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-/** Log a caught error as warning (transient) or error (non-transient) based on isTransientDbError. */
+/** Log a caught error: console.warn if transient, ErrorLogger.error otherwise. Warning-level no longer persists to the admin Event Log. */
 async function logSchedulerError(
   message: string,
   error: unknown,
@@ -53,7 +53,7 @@ async function logSchedulerError(
 ): Promise<void> {
   try {
     if (isTransientDbError(error)) {
-      await ErrorLogger.warning("scheduler", message, {
+      console.warn(`[scheduler] ${message}`, {
         errorMessage: error instanceof Error ? error.message : String(error),
         ...context,
       });
@@ -189,7 +189,7 @@ export async function startScheduler() {
   try {
     await storage.cleanupPollutedValues();
   } catch (error) {
-    await ErrorLogger.warning("scheduler", "cleanupPollutedValues failed (non-fatal)", { errorMessage: error instanceof Error ? error.message : String(error) });
+    console.warn("[scheduler] cleanupPollutedValues failed (non-fatal)", { errorMessage: error instanceof Error ? error.message : String(error) });
   }
 
   // Wire circuit breaker recovery: immediately retry pending monitors when Browserless comes back

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -125,6 +125,7 @@ import {
   BASE_RETRY_MS,
   JITTER_CAP_MS,
   extractWithBrowserless,
+  _resetInfraWarnThrottleForTests,
 } from "./scraper";
 import { storage } from "../storage";
 import { sendNotificationEmail, sendAutoPauseEmail, sendHealthWarningEmail, sendRecoveryEmail } from "./email";
@@ -137,6 +138,12 @@ import type { Monitor } from "@shared/schema";
 // Drain browser pool after every test to prevent cross-test pollution
 afterEach(async () => {
   await browserPool.drain();
+});
+
+// Reset the infra-warning throttle before each test so the module-level
+// cooldown map doesn't suppress a warning the test expects to observe.
+beforeEach(() => {
+  _resetInfraWarnThrottleForTests();
 });
 
 // ---------------------------------------------------------------------------
@@ -4378,7 +4385,7 @@ describe("checkMonitor outer catch resilience", () => {
     expect(vi.mocked(processChangeNotification)).toHaveBeenCalledTimes(1);
   });
 
-  it("logs extractedValue and previousValue when both save attempts fail", async () => {
+  it("does not leak extractedValue/previousValue on transient save failure (console.warn path)", async () => {
     const html = `<html><body><span class="price">$49.99</span></body></html>`;
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(html, { status: 200 }));
 
@@ -4397,18 +4404,26 @@ describe("checkMonitor outer catch resilience", () => {
       expect(result.currentValue).toBe("$49.99");
       expect(result.changed).toBe(true);
       expect(result.error).toContain("server error prevented saving");
-      // Transient DB errors are downgraded to console.warn (will retry via accelerated retry)
+      // Transient DB errors are downgraded to console.warn (will retry via accelerated retry).
+      // console.warn bypasses ErrorLogger's sanitization, so extractedValue/previousValue
+      // (user-scraped page content — can carry API tokens, PII, internal URLs) MUST be
+      // omitted from the payload. The non-transient path keeps them because ErrorLogger.error
+      // runs sanitizeContext.
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining("check succeeded but failed to save result"),
         expect.objectContaining({
           monitorId: 1,
-          extractedValue: "$49.99",
-          previousValue: "$39.99",
+          monitorName: "Test Monitor",
           changed: true,
           dbError: "connection terminated",
           retryError: "connection terminated",
         }),
       );
+      const transientCall = consoleWarnSpy.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("check succeeded but failed to save result"),
+      );
+      expect(transientCall?.[1]).not.toHaveProperty("extractedValue");
+      expect(transientCall?.[1]).not.toHaveProperty("previousValue");
       expect(ErrorLogger.error).not.toHaveBeenCalled();
     } finally {
       consoleWarnSpy.mockRestore();

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -2016,9 +2016,14 @@ describe("failure tracking and auto-pause", () => {
           monitorId: 1,
           monitorName: "My Watch",
           classifiedReason: "page timeout",
-          rawBrowserlessMsg: expect.stringContaining("Navigation timeout"),
         }),
       );
+      // rawBrowserlessMsg must not leak — upstream errors can echo back the
+      // requested URL with credentials in the query string.
+      const siteSpecificCall = consoleWarnSpy.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("page timeout"),
+      );
+      expect(siteSpecificCall?.[1]).not.toHaveProperty("rawBrowserlessMsg");
     } finally {
       consoleWarnSpy.mockRestore();
     }

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -27,6 +27,14 @@ vi.mock("./notification", () => ({
   processChangeNotification: vi.fn().mockResolvedValue({ success: true }),
 }));
 
+vi.mock("./logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+    warning: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./browserlessTracker", () => ({
   BrowserlessUsageTracker: {
     canUseBrowserless: vi.fn().mockResolvedValue({ allowed: false, reason: "free_tier" }),
@@ -123,6 +131,7 @@ import { storage } from "../storage";
 import { sendNotificationEmail, sendAutoPauseEmail, sendHealthWarningEmail, sendRecoveryEmail } from "./email";
 import { processChangeNotification } from "./notification";
 import { browserlessCircuitBreaker } from "./browserlessCircuitBreaker";
+import { ErrorLogger } from "./logger";
 import { db } from "../db";
 import type { Monitor } from "@shared/schema";
 
@@ -1933,6 +1942,112 @@ describe("failure tracking and auto-pause", () => {
     delete process.env.BROWSERLESS_TOKEN;
   });
 
+  it("Browserless infrastructure failures emit a monitor-agnostic warning so affected monitors dedup into one row", async () => {
+    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
+
+    process.env.BROWSERLESS_TOKEN = "test-token";
+    const { BrowserlessUsageTracker } = await import("./browserlessTracker");
+    (BrowserlessUsageTracker.canUseBrowserless as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ allowed: true });
+    mockConnectOverCDP.mockRejectedValue(new Error("connectOverCDP failed: ECONNREFUSED"));
+
+    mockDbUpdate(1, true);
+    mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
+
+    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+    await runWithTimers(monitor);
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      "Browserless service unavailable — preserving last known values",
+      expect.objectContaining({
+        monitorId: 1,
+        monitorName: "My Watch",
+        classifiedReason: expect.stringContaining("connection refused"),
+      }),
+    );
+    // Every infra-warning call must omit the monitor name so dedup aggregates across monitors.
+    const infraCalls = (ErrorLogger.warning as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c) => c[0] === "scraper" && String(c[1]).includes("Browserless service unavailable"));
+    expect(infraCalls.length).toBeGreaterThanOrEqual(1);
+    for (const c of infraCalls) {
+      expect(c[1]).not.toContain("My Watch");
+    }
+
+    delete process.env.BROWSERLESS_TOKEN;
+  });
+
+  it("Browserless site-specific failures include the monitor name for per-site drill-down", async () => {
+    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
+
+    process.env.BROWSERLESS_TOKEN = "test-token";
+    const { BrowserlessUsageTracker } = await import("./browserlessTracker");
+    (BrowserlessUsageTracker.canUseBrowserless as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ allowed: true });
+    // Timeout message matches classifyBrowserlessError's "timeout" branch but not
+    // any isInfra pattern — so the site-specific warning path fires.
+    mockConnectOverCDP.mockRejectedValue(new Error("Navigation timeout of 30000ms exceeded"));
+
+    mockDbUpdate(1, true);
+    mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
+
+    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+    // Non-infra failures retry once with BASE_RETRY_MS + jitter (up to ~3.5s).
+    // Bound to 10s so future refactors adding recursive setTimeout in this path
+    // produce a test timeout rather than an infinite loop.
+    const promise = checkMonitor(monitor);
+    await vi.advanceTimersByTimeAsync(10000);
+    await promise;
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      `"My Watch" — page timeout`,
+      expect.objectContaining({
+        monitorId: 1,
+        monitorName: "My Watch",
+        classifiedReason: "page timeout",
+        rawBrowserlessMsg: expect.stringContaining("Navigation timeout"),
+      }),
+    );
+
+    delete process.env.BROWSERLESS_TOKEN;
+  });
+
+  it("Browserless circuit-breaker-open warning is monitor-agnostic", async () => {
+    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
+
+    process.env.BROWSERLESS_TOKEN = "test-token";
+    (browserlessCircuitBreaker.isAvailable as ReturnType<typeof vi.fn>).mockReturnValueOnce(false);
+
+    mockDbUpdate(1, true);
+    mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
+
+    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+    await runWithTimers(monitor);
+
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      "Browserless circuit breaker open — preserving last known values",
+      expect.objectContaining({ monitorId: 1, monitorName: "My Watch" }),
+    );
+    const circuitCalls = (ErrorLogger.warning as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c) => c[0] === "scraper" && String(c[1]).includes("circuit breaker open"));
+    for (const c of circuitCalls) {
+      expect(c[1]).not.toContain("My Watch");
+    }
+
+    delete process.env.BROWSERLESS_TOKEN;
+  });
+
   it("falls back to free tier threshold when user tier is unknown", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("timeout"));
     // free threshold: DB returns active=false to indicate SQL CASE triggered
@@ -1971,51 +2086,6 @@ describe("failure tracking and auto-pause", () => {
       3,
       "Page took too long to respond"
     );
-  });
-
-  it("Browserless infrastructure failures emit a monitor-agnostic warning so affected monitors aggregate under one log pattern", async () => {
-    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
-      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
-
-    process.env.BROWSERLESS_TOKEN = "test-token";
-    const { BrowserlessUsageTracker } = await import("./browserlessTracker");
-    (BrowserlessUsageTracker.canUseBrowserless as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ allowed: true });
-    mockConnectOverCDP.mockRejectedValue(new Error("connectOverCDP failed: ECONNREFUSED"));
-
-    mockDbUpdate(1, true);
-    mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
-
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    try {
-      const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
-      await runWithTimers(monitor);
-
-      // Protect the dedup-aggregation intent: the canonical infra-outage
-      // message must stay monitor-agnostic so grep-based triage clusters
-      // across affected monitors. Per-monitor drill-down stays in the
-      // context object (see scraper.ts:1263 rationale comment).
-      const infraCalls = warnSpy.mock.calls.filter((c) =>
-        String(c[0]).includes("Browserless service unavailable"),
-      );
-      expect(infraCalls.length).toBeGreaterThanOrEqual(1);
-      for (const c of infraCalls) {
-        expect(String(c[0])).not.toContain("My Watch");
-        expect(c[1]).toEqual(
-          expect.objectContaining({
-            monitorId: 1,
-            monitorName: "My Watch",
-            classifiedReason: expect.stringContaining("connection refused"),
-          }),
-        );
-      }
-    } finally {
-      warnSpy.mockRestore();
-      delete process.env.BROWSERLESS_TOKEN;
-    }
   });
 });
 
@@ -2746,6 +2816,8 @@ describe("auto-heal selector recovery", () => {
     (BrowserlessUsageTracker.canUseBrowserless as ReturnType<typeof vi.fn>)
       .mockResolvedValue({ allowed: true });
 
+    const { ErrorLogger } = await import("./logger");
+
     // Build a page mock that returns matching suggestions for discoverSelectors
     const makeLocator = (count = 1) => ({
       count: vi.fn().mockResolvedValue(count),
@@ -2803,6 +2875,14 @@ describe("auto-heal selector recovery", () => {
     );
 
     // Should have logged an info message about auto-healing
+    expect(ErrorLogger.info).toHaveBeenCalledWith(
+      "scraper",
+      expect.stringContaining("auto-healed selector"),
+      expect.objectContaining({
+        oldSelector: ".old-price",
+        newSelector: ".new-price",
+      })
+    );
   });
 
   it("prefers single-match selectors when auto-healing", async () => {
@@ -3828,6 +3908,29 @@ describe("self-healing recovery", () => {
     expect(result.error).toBe("Selector not found (rendering service temporarily unavailable)");
   });
 
+  it("logs circuit-breaker-open warning for first-check monitors (no currentValue). See GitHub issue #449", async () => {
+    const emptyHtml = `<html><body><p>Loading...</p></body></html>`;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }))
+      .mockResolvedValueOnce(new Response(emptyHtml, { status: 200 }));
+
+    const cbMock = browserlessCircuitBreaker as unknown as { isAvailable: ReturnType<typeof vi.fn>; recordSuccess: ReturnType<typeof vi.fn>; recordInfraFailure: ReturnType<typeof vi.fn>; getState: ReturnType<typeof vi.fn> };
+    cbMock.isAvailable.mockReturnValue(false);
+
+    const monitor = makeMonitor({ selector: ".missing", currentValue: null });
+    await runWithTimers(monitor);
+
+    // Admin UI must see a circuit-open entry regardless of whether the monitor
+    // has a cached value (graceful degradation) or is first-check. The message
+    // is monitor-agnostic so affected monitors dedup into a single row via the
+    // partial unique index (#448).
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      "Browserless circuit breaker open — preserving last known values",
+      expect.objectContaining({ monitorId: 1 }),
+    );
+  });
+
   it("falls through to blocked when no currentValue, infra failure, and page is blocked", async () => {
     // Page has a captcha element (triggers block detection)
     const blockedHtml = `<html><body><div class="captcha-container">Please verify</div></body></html>`;
@@ -4263,6 +4366,8 @@ describe("checkMonitor outer catch resilience", () => {
     mockStorage.updateMonitor.mockRejectedValueOnce(new Error("connection terminated"));
     mockStorage.updateMonitor.mockRejectedValueOnce(new Error("connection terminated"));
 
+    const { ErrorLogger } = await import("./logger");
+
     const monitor = makeMonitor({ currentValue: "$39.99" });
     const result = await runWithTimers(monitor);
 
@@ -4271,6 +4376,36 @@ describe("checkMonitor outer catch resilience", () => {
     expect(result.changed).toBe(true);
     expect(result.error).toContain("server error prevented saving");
     // Transient DB errors are downgraded to warnings (will retry via accelerated retry)
+    expect(ErrorLogger.warning).toHaveBeenCalledWith(
+      "scraper",
+      expect.stringContaining("check succeeded but failed to save result"),
+      expect.objectContaining({
+        monitorId: 1,
+        extractedValue: "$49.99",
+        previousValue: "$39.99",
+        changed: true,
+        dbError: "connection terminated",
+        retryError: "connection terminated",
+      }),
+    );
+    expect(ErrorLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("returns result even when ErrorLogger.error rejects in outer catch", async () => {
+    // Force an error that reaches the outer catch by making fetch throw unexpectedly
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("getaddrinfo ENOTFOUND bad.example.com"));
+
+    // Make ErrorLogger.error reject
+    const { ErrorLogger } = await import("./logger");
+    (ErrorLogger.error as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("logging DB down"));
+
+    const monitor = makeMonitor();
+    const result = await runWithTimers(monitor);
+
+    // Should still return a valid result thanks to .catch(() => {})
+    expect(result).toBeDefined();
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("Could not resolve the target hostname");
   });
 
   it("returns classified error message from outer catch, not generic 'Failed to fetch page'", async () => {
@@ -5879,12 +6014,28 @@ describe("extractWithBrowserless error classification in logs", () => {
     delete process.env.BROWSERLESS_TOKEN;
   });
 
+  it("does not log to ErrorLogger (caller handles logging)", async () => {
+    mockConnectOverCDP.mockRejectedValue(new Error("Navigation timeout of 30000ms exceeded"));
+
+    await expect(
+      extractWithBrowserless("https://example.com", ".price", 1, "My Monitor")
+    ).rejects.toThrow();
+
+    // extractWithBrowserless no longer logs — the caller (checkMonitor) logs
+    // with fuller context to avoid duplicate error entries.
+    expect(ErrorLogger.error).not.toHaveBeenCalled();
+    expect(ErrorLogger.warning).not.toHaveBeenCalled();
+  });
+
   it("re-throws ECONNREFUSED without logging", async () => {
     mockConnectOverCDP.mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:443"));
 
     await expect(
       extractWithBrowserless("https://example.com", ".price")
     ).rejects.toThrow();
+
+    expect(ErrorLogger.error).not.toHaveBeenCalled();
+    expect(ErrorLogger.warning).not.toHaveBeenCalled();
   });
 
   it("re-throws errors without logging even when monitor name provided", async () => {
@@ -5893,6 +6044,9 @@ describe("extractWithBrowserless error classification in logs", () => {
     await expect(
       extractWithBrowserless("https://example.com", ".price", 1, "Price Tracker")
     ).rejects.toThrow();
+
+    expect(ErrorLogger.error).not.toHaveBeenCalled();
+    expect(ErrorLogger.warning).not.toHaveBeenCalled();
   });
 });
 

--- a/server/services/scraper.test.ts
+++ b/server/services/scraper.test.ts
@@ -30,7 +30,6 @@ vi.mock("./notification", () => ({
 vi.mock("./logger", () => ({
   ErrorLogger: {
     error: vi.fn().mockResolvedValue(undefined),
-    warning: vi.fn().mockResolvedValue(undefined),
     info: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -1957,24 +1956,28 @@ describe("failure tracking and auto-pause", () => {
     mockDbUpdate(1, true);
     mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
 
-    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
-    await runWithTimers(monitor);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+      await runWithTimers(monitor);
 
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scraper",
-      "Browserless service unavailable — preserving last known values",
-      expect.objectContaining({
-        monitorId: 1,
-        monitorName: "My Watch",
-        classifiedReason: expect.stringContaining("connection refused"),
-      }),
-    );
-    // Every infra-warning call must omit the monitor name so dedup aggregates across monitors.
-    const infraCalls = (ErrorLogger.warning as ReturnType<typeof vi.fn>).mock.calls
-      .filter((c) => c[0] === "scraper" && String(c[1]).includes("Browserless service unavailable"));
-    expect(infraCalls.length).toBeGreaterThanOrEqual(1);
-    for (const c of infraCalls) {
-      expect(c[1]).not.toContain("My Watch");
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scraper] Browserless service unavailable — preserving last known values",
+        expect.objectContaining({
+          monitorId: 1,
+          monitorName: "My Watch",
+          classifiedReason: expect.stringContaining("connection refused"),
+        }),
+      );
+      // Every infra-warning call must omit the monitor name so dedup-style aggregation works.
+      const infraCalls = consoleWarnSpy.mock.calls
+        .filter((c) => typeof c[0] === "string" && c[0].includes("Browserless service unavailable"));
+      expect(infraCalls.length).toBeGreaterThanOrEqual(1);
+      for (const c of infraCalls) {
+        expect(c[0]).not.toContain("My Watch");
+      }
+    } finally {
+      consoleWarnSpy.mockRestore();
     }
 
     delete process.env.BROWSERLESS_TOKEN;
@@ -1997,24 +2000,28 @@ describe("failure tracking and auto-pause", () => {
     mockDbUpdate(1, true);
     mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
 
-    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
-    // Non-infra failures retry once with BASE_RETRY_MS + jitter (up to ~3.5s).
-    // Bound to 10s so future refactors adding recursive setTimeout in this path
-    // produce a test timeout rather than an infinite loop.
-    const promise = checkMonitor(monitor);
-    await vi.advanceTimersByTimeAsync(10000);
-    await promise;
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+      // Non-infra failures retry once with BASE_RETRY_MS + jitter (up to ~3.5s).
+      // Bound to 10s so future refactors adding recursive setTimeout in this path
+      // produce a test timeout rather than an infinite loop.
+      const promise = checkMonitor(monitor);
+      await vi.advanceTimersByTimeAsync(10000);
+      await promise;
 
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scraper",
-      `"My Watch" — page timeout`,
-      expect.objectContaining({
-        monitorId: 1,
-        monitorName: "My Watch",
-        classifiedReason: "page timeout",
-        rawBrowserlessMsg: expect.stringContaining("Navigation timeout"),
-      }),
-    );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        `[scraper] "My Watch" — page timeout`,
+        expect.objectContaining({
+          monitorId: 1,
+          monitorName: "My Watch",
+          classifiedReason: "page timeout",
+          rawBrowserlessMsg: expect.stringContaining("Navigation timeout"),
+        }),
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
 
     delete process.env.BROWSERLESS_TOKEN;
   });
@@ -2031,18 +2038,22 @@ describe("failure tracking and auto-pause", () => {
     mockDbUpdate(1, true);
     mockStorage.getUser.mockResolvedValue({ id: "user1", tier: "free" });
 
-    const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
-    await runWithTimers(monitor);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const monitor = makeMonitor({ currentValue: "$99.99", name: "My Watch" });
+      await runWithTimers(monitor);
 
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scraper",
-      "Browserless circuit breaker open — preserving last known values",
-      expect.objectContaining({ monitorId: 1, monitorName: "My Watch" }),
-    );
-    const circuitCalls = (ErrorLogger.warning as ReturnType<typeof vi.fn>).mock.calls
-      .filter((c) => c[0] === "scraper" && String(c[1]).includes("circuit breaker open"));
-    for (const c of circuitCalls) {
-      expect(c[1]).not.toContain("My Watch");
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scraper] Browserless circuit breaker open — preserving last known values",
+        expect.objectContaining({ monitorId: 1, monitorName: "My Watch" }),
+      );
+      const circuitCalls = consoleWarnSpy.mock.calls
+        .filter((c) => typeof c[0] === "string" && c[0].includes("circuit breaker open"));
+      for (const c of circuitCalls) {
+        expect(c[0]).not.toContain("My Watch");
+      }
+    } finally {
+      consoleWarnSpy.mockRestore();
     }
 
     delete process.env.BROWSERLESS_TOKEN;
@@ -3917,18 +3928,22 @@ describe("self-healing recovery", () => {
     const cbMock = browserlessCircuitBreaker as unknown as { isAvailable: ReturnType<typeof vi.fn>; recordSuccess: ReturnType<typeof vi.fn>; recordInfraFailure: ReturnType<typeof vi.fn>; getState: ReturnType<typeof vi.fn> };
     cbMock.isAvailable.mockReturnValue(false);
 
-    const monitor = makeMonitor({ selector: ".missing", currentValue: null });
-    await runWithTimers(monitor);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const monitor = makeMonitor({ selector: ".missing", currentValue: null });
+      await runWithTimers(monitor);
 
-    // Admin UI must see a circuit-open entry regardless of whether the monitor
-    // has a cached value (graceful degradation) or is first-check. The message
-    // is monitor-agnostic so affected monitors dedup into a single row via the
-    // partial unique index (#448).
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scraper",
-      "Browserless circuit breaker open — preserving last known values",
-      expect.objectContaining({ monitorId: 1 }),
-    );
+      // Operator console must see a circuit-open entry regardless of whether the
+      // monitor has a cached value (graceful degradation) or is first-check. The
+      // message is monitor-agnostic so affected monitors aggregate into a single
+      // line in the logs.
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[scraper] Browserless circuit breaker open — preserving last known values",
+        expect.objectContaining({ monitorId: 1 }),
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("falls through to blocked when no currentValue, infra failure, and page is blocked", async () => {
@@ -4368,27 +4383,31 @@ describe("checkMonitor outer catch resilience", () => {
 
     const { ErrorLogger } = await import("./logger");
 
-    const monitor = makeMonitor({ currentValue: "$39.99" });
-    const result = await runWithTimers(monitor);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const monitor = makeMonitor({ currentValue: "$39.99" });
+      const result = await runWithTimers(monitor);
 
-    expect(result.status).toBe("ok");
-    expect(result.currentValue).toBe("$49.99");
-    expect(result.changed).toBe(true);
-    expect(result.error).toContain("server error prevented saving");
-    // Transient DB errors are downgraded to warnings (will retry via accelerated retry)
-    expect(ErrorLogger.warning).toHaveBeenCalledWith(
-      "scraper",
-      expect.stringContaining("check succeeded but failed to save result"),
-      expect.objectContaining({
-        monitorId: 1,
-        extractedValue: "$49.99",
-        previousValue: "$39.99",
-        changed: true,
-        dbError: "connection terminated",
-        retryError: "connection terminated",
-      }),
-    );
-    expect(ErrorLogger.error).not.toHaveBeenCalled();
+      expect(result.status).toBe("ok");
+      expect(result.currentValue).toBe("$49.99");
+      expect(result.changed).toBe(true);
+      expect(result.error).toContain("server error prevented saving");
+      // Transient DB errors are downgraded to console.warn (will retry via accelerated retry)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("check succeeded but failed to save result"),
+        expect.objectContaining({
+          monitorId: 1,
+          extractedValue: "$49.99",
+          previousValue: "$39.99",
+          changed: true,
+          dbError: "connection terminated",
+          retryError: "connection terminated",
+        }),
+      );
+      expect(ErrorLogger.error).not.toHaveBeenCalled();
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("returns result even when ErrorLogger.error rejects in outer catch", async () => {
@@ -6005,13 +6024,17 @@ describe("token redaction in Browserless connection errors", () => {
 // extractWithBrowserless error logging uses classifyBrowserlessError
 // ---------------------------------------------------------------------------
 describe("extractWithBrowserless error classification in logs", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.BROWSERLESS_TOKEN = "test-token";
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     delete process.env.BROWSERLESS_TOKEN;
+    consoleWarnSpy.mockRestore();
   });
 
   it("does not log to ErrorLogger (caller handles logging)", async () => {
@@ -6024,7 +6047,7 @@ describe("extractWithBrowserless error classification in logs", () => {
     // extractWithBrowserless no longer logs — the caller (checkMonitor) logs
     // with fuller context to avoid duplicate error entries.
     expect(ErrorLogger.error).not.toHaveBeenCalled();
-    expect(ErrorLogger.warning).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it("re-throws ECONNREFUSED without logging", async () => {
@@ -6035,7 +6058,7 @@ describe("extractWithBrowserless error classification in logs", () => {
     ).rejects.toThrow();
 
     expect(ErrorLogger.error).not.toHaveBeenCalled();
-    expect(ErrorLogger.warning).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it("re-throws errors without logging even when monitor name provided", async () => {
@@ -6046,7 +6069,7 @@ describe("extractWithBrowserless error classification in logs", () => {
     ).rejects.toThrow();
 
     expect(ErrorLogger.error).not.toHaveBeenCalled();
-    expect(ErrorLogger.warning).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -20,6 +20,29 @@ import { eq, sql } from "drizzle-orm";
  */
 export const monitorsNeedingRetry = new Set<number>();
 
+/**
+ * Per-process throttle for high-frequency infrastructure warnings. During a
+ * Browserless outage the scraper fires the same monitor-agnostic warning on
+ * every monitor check across every replica; without throttling that produces
+ * thousands of identical stdout lines per minute. Returns true if the caller
+ * should emit, false if suppressed.
+ *
+ * State is per-replica: under autoscale each replica throttles independently
+ * (acceptable tradeoff — infra-outage operational signal is coarse).
+ */
+const infraWarnLastEmit = new Map<string, number>();
+const INFRA_WARN_COOLDOWN_MS = 60_000;
+function shouldEmitInfraWarn(key: string): boolean {
+  const now = Date.now();
+  const last = infraWarnLastEmit.get(key) ?? 0;
+  if (now - last < INFRA_WARN_COOLDOWN_MS) return false;
+  infraWarnLastEmit.set(key, now);
+  return true;
+}
+export function _resetInfraWarnThrottleForTests(): void {
+  infraWarnLastEmit.clear();
+}
+
 /** Pool of modern User-Agent profiles to rotate per request, reducing fingerprint-based blocking. */
 const UA_PROFILES: Array<{ userAgent: string; secChUa?: string; secChUaPlatform?: string }> = [
   // Chrome 133 – Windows 10
@@ -1268,7 +1291,9 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             // most recent writer that supplied a non-null context, not an
             // aggregate across affected monitors. occurrenceCount is the only
             // signal of outage scope.
-            console.warn("[scraper] Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
+            if (shouldEmitInfraWarn("browserless-unavailable")) {
+              console.warn("[scraper] Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
+            }
           } else {
             // Site-specific failure: keep the monitor name because the site itself is the problem.
             // Emit via console.warn only (not ErrorLogger) so the Browserless infra-noise flood
@@ -1315,7 +1340,7 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     // when static extraction succeeded. The message is monitor-agnostic so
     // affected monitors dedup into a single row via the unresolved-dedup
     // index (#448). See GitHub issue #449.
-    if (skippedDueToOpenCircuit && newValue == null) {
+    if (skippedDueToOpenCircuit && newValue == null && shouldEmitInfraWarn("browserless-circuit-open")) {
       console.warn(
         "[scraper] Browserless circuit breaker open — preserving last known values",
         { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
@@ -1454,30 +1479,35 @@ export async function checkMonitor(monitor: Monitor): Promise<{
           const dbErrMsg = dbError instanceof Error ? dbError.message : String(dbError);
           const retryErrMsg = retryError instanceof Error ? retryError.message : String(retryError);
           const isTransientSave = isTransientDbError(retryError);
-          const saveContext = {
-            monitorId: monitor.id,
-            monitorName: monitor.name,
-            extractedValue: newValue?.substring(0, 200) ?? null,
-            previousValue: oldValue?.substring(0, 200) ?? null,
-            changed,
-            dbError: dbErrMsg,
-            retryError: retryErrMsg,
-          };
           if (isTransientSave) {
+            // Transient path goes to stdout only (console.warn bypasses ErrorLogger
+            // sanitization), so drop extractedValue/previousValue — they contain
+            // user-scraped page content that may include API tokens or PII.
             try {
               console.warn(
                 `[scraper] "${monitor.name}" check succeeded but failed to save result (will retry)`,
-                saveContext,
+                { monitorId: monitor.id, monitorName: monitor.name, changed, dbError: dbErrMsg, retryError: retryErrMsg },
               );
             } catch {
               // ignore
             }
           } else {
+            // Non-transient path goes through ErrorLogger.error which sanitizes
+            // context via SENSITIVE_VALUE_PATTERNS regex — safe to include
+            // truncated values for triage.
             await ErrorLogger.error(
               "scraper",
               `"${monitor.name}" check succeeded but failed to save result`,
               retryError instanceof Error ? retryError : null,
-              saveContext,
+              {
+                monitorId: monitor.id,
+                monitorName: monitor.name,
+                extractedValue: newValue?.substring(0, 200) ?? null,
+                previousValue: oldValue?.substring(0, 200) ?? null,
+                changed,
+                dbError: dbErrMsg,
+                retryError: retryErrMsg,
+              },
             ).catch(() => {});
           }
 
@@ -1585,14 +1615,22 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     const errMsg = error instanceof Error ? error.message : "";
     const isPermanentNetworkError = /ENOTFOUND|certificate|ssl|tls/i.test(errMsg);
     const isTransient = (logContext === "network error" && !isPermanentNetworkError) || logContext === "database connection error";
-    const logMessage = `"${monitor.name}" check failed (${logContext}): ${error instanceof Error ? error.message : "Unknown error"}`;
     if (isTransient) {
+      // Transient path goes to stdout only (console.warn bypasses ErrorLogger
+      // sanitization). Avoid interpolating error.message because undici/fetch
+      // errors echo the full requested URL with any userinfo or query-string
+      // credentials (e.g. "request to https://user:pw@host failed"). The
+      // classified logContext is enough for triage.
       try {
-        console.warn(`[scraper] ${logMessage}`, { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector });
+        console.warn(`[scraper] "${monitor.name}" check failed (${logContext})`, { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector });
       } catch {
         // ignore
       }
     } else {
+      // Non-transient path: ErrorLogger.error sanitizes message + stack via
+      // SENSITIVE_VALUE_PATTERNS (DSN/Bearer/provider-key regex) before
+      // persisting, so the full error message can be logged.
+      const logMessage = `"${monitor.name}" check failed (${logContext}): ${error instanceof Error ? error.message : "Unknown error"}`;
       await ErrorLogger.error(
         "scraper",
         logMessage,

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -2,6 +2,7 @@ import * as cheerio from "cheerio";
 import { storage } from "../storage";
 import { sendNotificationEmail, sendAutoPauseEmail, sendHealthWarningEmail, sendRecoveryEmail } from "./email";
 import { processChangeNotification } from "./notification";
+import { ErrorLogger } from "./logger";
 import { BrowserlessUsageTracker } from "./browserlessTracker";
 import { browserlessCircuitBreaker } from "./browserlessCircuitBreaker";
 import { isTransientDbError } from "../utils/dbErrors";
@@ -1254,24 +1255,38 @@ export async function checkMonitor(monitor: Monitor): Promise<{
         if (lastBrowserlessErr) {
           const rawBrowserlessMsg = lastBrowserlessErr instanceof Error ? lastBrowserlessErr.message : "Unknown error";
           if (/SSRF blocked/i.test(rawBrowserlessMsg)) {
-            console.error(
-              `[scraper] "${monitor.name}" — rendered page extraction blocked by SSRF protection`,
-              lastBrowserlessErr instanceof Error ? lastBrowserlessErr.message : "",
-              { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector },
-            );
+            // SSRF blocks are security-relevant — keep at error level
+            await ErrorLogger.error(
+              "scraper",
+              `"${monitor.name}" — rendered page extraction blocked by SSRF protection`,
+              lastBrowserlessErr instanceof Error ? lastBrowserlessErr : null,
+              { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector },
+            ).catch(() => {});
           } else if (browserlessInfraFailure) {
-            // Monitor-agnostic message so grep-based triage aggregates infra
-            // outages across affected monitors into a single log pattern.
-            // Per-monitor drill-down details stay in the context object.
-            console.warn("[scraper] Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
+            // Infra-wide outage: monitor-agnostic message so every affected monitor
+            // dedups into a single row in the admin UI. Per-monitor details stay
+            // in context for drill-down. NOTE: context is last-writer-wins at the
+            // DB level — the ON CONFLICT upsert in ErrorLogger.log uses
+            // COALESCE(EXCLUDED.context, current.context), so during a mixed-mode
+            // outage monitorId/monitorName/url/classifiedReason reflect only the
+            // most recent writer that supplied a non-null context, not an
+            // aggregate across affected monitors. occurrenceCount is the only
+            // signal of outage scope.
+            await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
           } else {
+            // Site-specific failure: keep the monitor name because the site itself is the problem.
+            // Mirror the infra branch's drill-down fields (classifiedReason + truncated raw
+            // error) so the admin UI has enough detail when the catchall "extraction failed"
+            // string fires. Logger sanitization (server/services/logger.ts:29-53) strips
+            // secrets from the raw error before persistence.
             const classifiedReason = classifyBrowserlessError(rawBrowserlessMsg);
-            console.warn(
-              `[scraper] "${monitor.name}" — ${classifiedReason}`,
+            await ErrorLogger.warning(
+              "scraper",
+              `"${monitor.name}" — ${classifiedReason}`,
               {
                 monitorId: monitor.id,
                 monitorName: monitor.name,
-                hostname: safeHostname(monitor.url),
+                url: monitor.url,
                 selector: monitor.selector,
                 circuitState: browserlessCircuitBreaker.getState(),
                 classifiedReason,
@@ -1296,10 +1311,22 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     let finalStatus: "ok" | "blocked" | "selector_missing" | "error" = "ok";
     let finalError: string | null = null;
 
+    // When the circuit breaker was already OPEN before we even attempted
+    // extraction, the warning inside the `capCheck.allowed` block never fires
+    // (capCheck is forced to `{allowed:false}` above). Log one here so the
+    // admin UI has an entry for the degradation episode — regardless of
+    // whether the monitor has a cached value (graceful degradation) or is a
+    // first-check monitor that falls through to selector_missing. Gated on
+    // `newValue == null` (explicit null/undefined, not falsy) so a monitor
+    // whose selector legitimately resolves to an empty string isn't flagged
+    // when static extraction succeeded. The message is monitor-agnostic so
+    // affected monitors dedup into a single row via the unresolved-dedup
+    // index (#448). See GitHub issue #449.
     if (skippedDueToOpenCircuit && newValue == null) {
-      console.warn(
-        "[scraper] Browserless circuit breaker open — preserving last known values",
-        { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
+      await ErrorLogger.warning(
+        "scraper",
+        "Browserless circuit breaker open — preserving last known values",
+        { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
       );
     }
 
@@ -1376,8 +1403,9 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             finalStatus = "ok";
             finalError = null;
 
-            console.log(
-              `[scraper] "${monitor.name}" — auto-healed selector from "${monitor.selector}" to "${best.selector}". The page structure likely changed.`,
+            await ErrorLogger.info(
+              "scraper",
+              `"${monitor.name}" — auto-healed selector from "${monitor.selector}" to "${best.selector}". The page structure likely changed.`,
               { monitorId: monitor.id, monitorName: monitor.name, oldSelector: monitor.selector, newSelector: best.selector }
             );
           } else {
@@ -1444,16 +1472,18 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             retryError: retryErrMsg,
           };
           if (isTransientSave) {
-            console.warn(
-              `[scraper] "${monitor.name}" check succeeded but failed to save result (will retry)`,
+            await ErrorLogger.warning(
+              "scraper",
+              `"${monitor.name}" check succeeded but failed to save result (will retry)`,
               saveContext,
-            );
+            ).catch(() => {});
           } else {
-            console.error(
-              `[scraper] "${monitor.name}" check succeeded but failed to save result`,
-              retryError instanceof Error ? retryError.message : "",
+            await ErrorLogger.error(
+              "scraper",
+              `"${monitor.name}" check succeeded but failed to save result`,
+              retryError instanceof Error ? retryError : null,
               saveContext,
-            );
+            ).catch(() => {});
           }
 
           saveFailed = true;
@@ -1557,18 +1587,19 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     // Note: "database error" (schema/constraint issues) is NOT transient and stays at error level.
     // Note: ENOTFOUND, certificate/ssl/tls errors are permanent misconfigurations, not transient.
     // Note: EAI_AGAIN is transient (temporary DNS resolver failure), so it is NOT in this list.
-    const errMsg = error instanceof Error ? error.message : String(error);
+    const errMsg = error instanceof Error ? error.message : "";
     const isPermanentNetworkError = /ENOTFOUND|certificate|ssl|tls/i.test(errMsg);
     const isTransient = (logContext === "network error" && !isPermanentNetworkError) || logContext === "database connection error";
     const logMessage = `"${monitor.name}" check failed (${logContext}): ${error instanceof Error ? error.message : "Unknown error"}`;
     if (isTransient) {
-      console.warn(`[scraper] ${logMessage}`, { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector });
+      await ErrorLogger.warning("scraper", logMessage, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector }).catch(() => {});
     } else {
-      console.error(
-        `[scraper] ${logMessage}`,
-        error instanceof Error ? error.message : String(error),
-        { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector }
-      );
+      await ErrorLogger.error(
+        "scraper",
+        logMessage,
+        error instanceof Error ? error : null,
+        { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector }
+      ).catch(() => {});
     }
 
     let wasPaused = false;

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -1260,7 +1260,7 @@ export async function checkMonitor(monitor: Monitor): Promise<{
               "scraper",
               `"${monitor.name}" — rendered page extraction blocked by SSRF protection`,
               lastBrowserlessErr instanceof Error ? lastBrowserlessErr : null,
-              { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector },
+              { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector },
             ).catch(() => {});
           } else if (browserlessInfraFailure) {
             // Infra-wide outage: monitor-agnostic message so every affected monitor
@@ -1272,24 +1272,22 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             // most recent writer that supplied a non-null context, not an
             // aggregate across affected monitors. occurrenceCount is the only
             // signal of outage scope.
-            console.warn("[scraper] Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
+            console.warn("[scraper] Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
           } else {
             // Site-specific failure: keep the monitor name because the site itself is the problem.
-            // Mirror the infra branch's drill-down fields (classifiedReason + truncated raw
-            // error) so the admin UI has enough detail when the catchall "extraction failed"
-            // string fires. Logger sanitization (server/services/logger.ts:29-53) strips
-            // secrets from the raw error before persistence.
+            // Emit via console.warn only (not ErrorLogger) so the Browserless infra-noise flood
+            // stays out of the admin Event Log. classifiedReason gives enough triage detail
+            // without echoing the raw upstream error (which can contain the requested URL).
             const classifiedReason = classifyBrowserlessError(rawBrowserlessMsg);
             console.warn(
               `[scraper] "${monitor.name}" — ${classifiedReason}`,
               {
                 monitorId: monitor.id,
                 monitorName: monitor.name,
-                url: monitor.url,
+                hostname: safeHostname(monitor.url),
                 selector: monitor.selector,
                 circuitState: browserlessCircuitBreaker.getState(),
                 classifiedReason,
-                rawBrowserlessMsg: rawBrowserlessMsg.slice(0, 500),
               },
             );
           }
@@ -1324,7 +1322,7 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     if (skippedDueToOpenCircuit && newValue == null) {
       console.warn(
         "[scraper] Browserless circuit breaker open — preserving last known values",
-        { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
+        { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
       );
     }
 
@@ -1594,7 +1592,7 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     const logMessage = `"${monitor.name}" check failed (${logContext}): ${error instanceof Error ? error.message : "Unknown error"}`;
     if (isTransient) {
       try {
-        console.warn(`[scraper] ${logMessage}`, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector });
+        console.warn(`[scraper] ${logMessage}`, { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector });
       } catch {
         // ignore
       }
@@ -1603,7 +1601,7 @@ export async function checkMonitor(monitor: Monitor): Promise<{
         "scraper",
         logMessage,
         error instanceof Error ? error : null,
-        { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector }
+        { monitorId: monitor.id, monitorName: monitor.name, hostname: safeHostname(monitor.url), selector: monitor.selector }
       ).catch(() => {});
     }
 

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -6,6 +6,7 @@ import { ErrorLogger } from "./logger";
 import { BrowserlessUsageTracker } from "./browserlessTracker";
 import { browserlessCircuitBreaker } from "./browserlessCircuitBreaker";
 import { isTransientDbError } from "../utils/dbErrors";
+import { safeHostname } from "../utils/urlUtils";
 import { browserPool } from "./browserPool";
 import { validateUrlBeforeFetch, ssrfSafeFetch } from "../utils/ssrf";
 import { type Monitor, monitorMetrics, monitors } from "@shared/schema";
@@ -18,11 +19,6 @@ import { eq, sql } from "drizzle-orm";
  * Browserless infrastructure failures. Cleared on success or server restart.
  */
 export const monitorsNeedingRetry = new Set<number>();
-
-/** Extract hostname from a URL for safe logging (no query params or paths). */
-function safeHostname(urlString: string): string {
-  try { return new URL(urlString).hostname; } catch { return "unknown"; }
-}
 
 /** Pool of modern User-Agent profiles to rotate per request, reducing fingerprint-based blocking. */
 const UA_PROFILES: Array<{ userAgent: string; secChUa?: string; secChUaPlatform?: string }> = [

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -1272,7 +1272,7 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             // most recent writer that supplied a non-null context, not an
             // aggregate across affected monitors. occurrenceCount is the only
             // signal of outage scope.
-            await ErrorLogger.warning("scraper", "Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
+            console.warn("[scraper] Browserless service unavailable — preserving last known values", { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState(), classifiedReason: classifyBrowserlessError(rawBrowserlessMsg) });
           } else {
             // Site-specific failure: keep the monitor name because the site itself is the problem.
             // Mirror the infra branch's drill-down fields (classifiedReason + truncated raw
@@ -1280,9 +1280,8 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             // string fires. Logger sanitization (server/services/logger.ts:29-53) strips
             // secrets from the raw error before persistence.
             const classifiedReason = classifyBrowserlessError(rawBrowserlessMsg);
-            await ErrorLogger.warning(
-              "scraper",
-              `"${monitor.name}" — ${classifiedReason}`,
+            console.warn(
+              `[scraper] "${monitor.name}" — ${classifiedReason}`,
               {
                 monitorId: monitor.id,
                 monitorName: monitor.name,
@@ -1323,9 +1322,8 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     // affected monitors dedup into a single row via the unresolved-dedup
     // index (#448). See GitHub issue #449.
     if (skippedDueToOpenCircuit && newValue == null) {
-      await ErrorLogger.warning(
-        "scraper",
-        "Browserless circuit breaker open — preserving last known values",
+      console.warn(
+        "[scraper] Browserless circuit breaker open — preserving last known values",
         { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector, circuitState: browserlessCircuitBreaker.getState() }
       );
     }
@@ -1472,11 +1470,14 @@ export async function checkMonitor(monitor: Monitor): Promise<{
             retryError: retryErrMsg,
           };
           if (isTransientSave) {
-            await ErrorLogger.warning(
-              "scraper",
-              `"${monitor.name}" check succeeded but failed to save result (will retry)`,
-              saveContext,
-            ).catch(() => {});
+            try {
+              console.warn(
+                `[scraper] "${monitor.name}" check succeeded but failed to save result (will retry)`,
+                saveContext,
+              );
+            } catch {
+              // ignore
+            }
           } else {
             await ErrorLogger.error(
               "scraper",
@@ -1592,7 +1593,11 @@ export async function checkMonitor(monitor: Monitor): Promise<{
     const isTransient = (logContext === "network error" && !isPermanentNetworkError) || logContext === "database connection error";
     const logMessage = `"${monitor.name}" check failed (${logContext}): ${error instanceof Error ? error.message : "Unknown error"}`;
     if (isTransient) {
-      await ErrorLogger.warning("scraper", logMessage, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector }).catch(() => {});
+      try {
+        console.warn(`[scraper] ${logMessage}`, { monitorId: monitor.id, monitorName: monitor.name, url: monitor.url, selector: monitor.selector });
+      } catch {
+        // ignore
+      }
     } else {
       await ErrorLogger.error(
         "scraper",

--- a/server/utils/urlUtils.test.ts
+++ b/server/utils/urlUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { safeHostname } from "./urlUtils";
+
+describe("safeHostname", () => {
+  it("extracts the hostname from a well-formed URL", () => {
+    expect(safeHostname("https://example.com/path?q=1")).toBe("example.com");
+    expect(safeHostname("http://sub.example.co.uk:8080/")).toBe("sub.example.co.uk");
+  });
+
+  it("strips userinfo credentials from the returned hostname", () => {
+    expect(safeHostname("https://user:password@example.com/path")).toBe("example.com");
+  });
+
+  it("does not include query-string secrets in the result", () => {
+    const out = safeHostname("https://example.com/feed?api_key=SECRET123&token=TOK");
+    expect(out).toBe("example.com");
+    expect(out).not.toContain("SECRET123");
+    expect(out).not.toContain("TOK");
+  });
+
+  it("returns the <invalid-url> sentinel (not 'unknown') for parse failures", () => {
+    // Angle-bracketed sentinel can never be a real hostname, so it is
+    // distinguishable from a legitimate host named "unknown".
+    expect(safeHostname("not a url")).toBe("<invalid-url>");
+    expect(safeHostname("")).toBe("<invalid-url>");
+  });
+
+  it("preserves a literal 'unknown' hostname when parsing succeeds", () => {
+    // Guards the sentinel-collision fix: a real URL whose hostname is the
+    // word 'unknown' must not be confused with a parse failure.
+    expect(safeHostname("http://unknown/path")).toBe("unknown");
+  });
+});

--- a/server/utils/urlUtils.ts
+++ b/server/utils/urlUtils.ts
@@ -4,11 +4,15 @@
  * User-supplied URLs can carry credentials in userinfo (`https://user:pw@host`)
  * or query-string (`?api_key=…`). Logging the hostname alone keeps enough
  * triage signal without leaking those secrets to Replit logs or error_logs.context.
+ *
+ * Parse failures return `<invalid-url>` (with angle brackets) rather than a
+ * plain word, so triage can distinguish a malformed URL from a real host whose
+ * name happens to be a common English word (e.g. `http://unknown/path`).
  */
 export function safeHostname(urlString: string): string {
   try {
     return new URL(urlString).hostname;
   } catch {
-    return "unknown";
+    return "<invalid-url>";
   }
 }

--- a/server/utils/urlUtils.ts
+++ b/server/utils/urlUtils.ts
@@ -1,0 +1,14 @@
+/**
+ * Safely extract hostname from a URL string for logging.
+ *
+ * User-supplied URLs can carry credentials in userinfo (`https://user:pw@host`)
+ * or query-string (`?api_key=…`). Logging the hostname alone keeps enough
+ * triage signal without leaking those secrets to Replit logs or error_logs.context.
+ */
+export function safeHostname(urlString: string): string {
+  try {
+    return new URL(urlString).hostname;
+  } catch {
+    return "unknown";
+  }
+}

--- a/server/webhookHandlers.test.ts
+++ b/server/webhookHandlers.test.ts
@@ -18,6 +18,12 @@ vi.mock("./replit_integrations/auth/storage", () => ({
   },
 }));
 
+vi.mock("./services/logger", () => ({
+  ErrorLogger: {
+    error: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("./storage", () => ({
   storage: {
     downgradeHourlyMonitors: vi.fn().mockResolvedValue({ count: 0, monitorNames: [] }),

--- a/server/webhookHandlers.ts
+++ b/server/webhookHandlers.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { getStripeSync, getUncachableStripeClient, getWebhookSecret } from './stripeClient';
 import { authStorage } from './replit_integrations/auth/storage';
 import { storage } from './storage';
+import { ErrorLogger } from './services/logger';
 import { type UserTier, TIER_LIMITS, FREQUENCY_TIERS } from '@shared/models/auth';
 import { sendTierDowngradeEmail } from './services/email';
 
@@ -107,7 +108,7 @@ export class WebhookHandlers {
             console.error(`[Stripe] Failed to send downgrade email for user ${user.id}:`, err));
         }
       } catch (error) {
-        console.error(`[stripe] Failed to downgrade hourly monitors for user ${user.id}`, error instanceof Error ? error.message : String(error), { userId: user.id });
+        await ErrorLogger.error("stripe", `Failed to downgrade hourly monitors for user ${user.id}`, error instanceof Error ? error : null, { userId: user.id });
       }
       // Deactivate automation subscriptions (Power-only feature)
       try {
@@ -116,7 +117,7 @@ export class WebhookHandlers {
           console.log(`[Stripe] Deactivated ${deactivated} automation subscription(s) for user ${user.id}`);
         }
       } catch (error) {
-        console.error(`[stripe] Failed to deactivate automation subscriptions for user ${user.id}`, error instanceof Error ? error.message : String(error), { userId: user.id });
+        await ErrorLogger.error("stripe", `Failed to deactivate automation subscriptions for user ${user.id}`, error instanceof Error ? error : null, { userId: user.id });
       }
       console.log(`[Stripe] User ${user.id} subscription inactive, set to free tier`);
       return;
@@ -140,7 +141,7 @@ export class WebhookHandlers {
       const product = price.product as any;
       newTier = determineTierFromProduct(product);
     } catch (error: any) {
-      console.error(`[stripe] Error retrieving price ${priceId}`, error instanceof Error ? error.message : String(error), { customerId, priceId, subscriptionId: subscription.id });
+      await ErrorLogger.error("stripe", `Error retrieving price ${priceId}`, error instanceof Error ? error : null, { customerId, priceId, subscriptionId: subscription.id });
       await authStorage.updateUser(user.id, {
         stripeSubscriptionId: subscription.id,
       });
@@ -162,7 +163,7 @@ export class WebhookHandlers {
             console.error(`[Stripe] Failed to send downgrade email for user ${user.id}:`, err));
         }
       } catch (error) {
-        console.error(`[stripe] Failed to downgrade hourly monitors for user ${user.id}`, error instanceof Error ? error.message : String(error), { userId: user.id, newTier });
+        await ErrorLogger.error("stripe", `Failed to downgrade hourly monitors for user ${user.id}`, error instanceof Error ? error : null, { userId: user.id, newTier });
       }
     }
 
@@ -174,7 +175,7 @@ export class WebhookHandlers {
           console.log(`[Stripe] Deactivated ${deactivated} automation subscription(s) for user ${user.id}`);
         }
       } catch (error) {
-        console.error(`[stripe] Failed to deactivate automation subscriptions for user ${user.id}`, error instanceof Error ? error.message : String(error), { userId: user.id, newTier });
+        await ErrorLogger.error("stripe", `Failed to deactivate automation subscriptions for user ${user.id}`, error instanceof Error ? error : null, { userId: user.id, newTier });
       }
     }
 
@@ -202,7 +203,7 @@ export class WebhookHandlers {
           console.error(`[Stripe] Failed to send downgrade email for user ${user.id}:`, err));
       }
     } catch (error) {
-      console.error(`[stripe] Failed to downgrade hourly monitors for user ${user.id}`, error instanceof Error ? error.message : String(error), { userId: user.id });
+      await ErrorLogger.error("stripe", `Failed to downgrade hourly monitors for user ${user.id}`, error instanceof Error ? error : null, { userId: user.id });
     }
     // Deactivate automation subscriptions (Power-only feature)
     try {
@@ -211,7 +212,7 @@ export class WebhookHandlers {
         console.log(`[Stripe] Deactivated ${deactivated} automation subscription(s) for user ${user.id}`);
       }
     } catch (error) {
-      console.error(`[stripe] Failed to deactivate automation subscriptions for user ${user.id}`, error instanceof Error ? error.message : String(error), { userId: user.id });
+      await ErrorLogger.error("stripe", `Failed to deactivate automation subscriptions for user ${user.id}`, error instanceof Error ? error : null, { userId: user.id });
     }
 
     console.log(`[Stripe] User ${user.id} downgraded to free tier`);

--- a/shared/routes.test.ts
+++ b/shared/routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { api, buildUrl, notificationPreferencesInputSchema } from "./routes";
+import { api, buildUrl, notificationPreferencesInputSchema, ERROR_LOG_SOURCES, errorLogSourceSchema } from "./routes";
 
 describe("buildUrl", () => {
   it("replaces a single :param placeholder", () => {
@@ -326,6 +326,19 @@ describe("notificationPreferencesInputSchema", () => {
   });
 });
 
+describe("ERROR_LOG_SOURCES", () => {
+  it("includes browserless as a valid source", () => {
+    expect(ERROR_LOG_SOURCES).toContain("browserless");
+  });
+
+  it("validates browserless via errorLogSourceSchema", () => {
+    expect(errorLogSourceSchema.safeParse("browserless").success).toBe(true);
+  });
+
+  it("rejects unknown source values", () => {
+    expect(errorLogSourceSchema.safeParse("unknown").success).toBe(false);
+  });
+});
 
 describe("slack status response schema", () => {
   const schema = api.integrations.slack.status.responses[200];

--- a/shared/routes.ts
+++ b/shared/routes.ts
@@ -17,6 +17,18 @@ export const errorSchemas = {
   }),
 };
 
+export const ERROR_LOG_SOURCES = [
+  "scraper",
+  "email",
+  "scheduler",
+  "api",
+  "stripe",
+  "resend",
+  "browserless",
+] as const;
+
+export const errorLogSourceSchema = z.enum(ERROR_LOG_SOURCES);
+
 export const contactFormSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
   category: z.enum(["bug", "feature", "billing", "general"], {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -87,6 +87,37 @@ export const monitorMetricsRelations = relations(monitorMetrics, ({ one }) => ({
 
 export type MonitorMetric = typeof monitorMetrics.$inferSelect;
 
+export const errorLogs = pgTable("error_logs", {
+  id: serial("id").primaryKey(),
+  timestamp: timestamp("timestamp").defaultNow().notNull(), // last occurrence
+  level: text("level").notNull(), // 'error' | 'warning' | 'info'
+  source: text("source").notNull(), // see ERROR_LOG_SOURCES in shared/routes.ts
+  errorType: text("error_type"),
+  message: text("message").notNull(),
+  stackTrace: text("stack_trace"),
+  context: jsonb("context"),
+  resolved: boolean("resolved").default(false).notNull(),
+  resolvedAt: timestamp("resolved_at"),
+  resolvedBy: text("resolved_by"),
+  firstOccurrence: timestamp("first_occurrence").defaultNow().notNull(),
+  occurrenceCount: integer("occurrence_count").default(1).notNull(),
+  deletedAt: timestamp("deleted_at"),
+}, (table) => ({
+  levelIdx: index("error_logs_level_idx").on(table.level),
+  sourceIdx: index("error_logs_source_idx").on(table.source),
+  timestampIdx: index("error_logs_timestamp_idx").on(table.timestamp),
+  // Partial unique index collapses the SELECT-then-INSERT dedup race in
+  // ErrorLogger.log: concurrent writers with the same (level, source, message)
+  // while resolved=false deterministically upsert into a single row instead
+  // of racing past a preceding SELECT miss and inserting duplicates. See
+  // GitHub issue #448.
+  unresolvedDedupIdx: uniqueIndex("error_logs_unresolved_dedup_idx")
+    .on(table.level, table.source, table.message)
+    .where(sql`resolved = false`),
+}));
+
+export type ErrorLog = typeof errorLogs.$inferSelect;
+
 export const browserlessUsage = pgTable("browserless_usage", {
   id: serial("id").primaryKey(),
   userId: text("user_id").notNull().references(() => users.id),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -90,7 +90,7 @@ export type MonitorMetric = typeof monitorMetrics.$inferSelect;
 export const errorLogs = pgTable("error_logs", {
   id: serial("id").primaryKey(),
   timestamp: timestamp("timestamp").defaultNow().notNull(), // last occurrence
-  level: text("level").notNull(), // 'error' | 'warning' | 'info'
+  level: text("level").notNull(), // 'error' | 'info' (new writes); 'warning' may appear in historical rows from pre-deprecation writes
   source: text("source").notNull(), // see ERROR_LOG_SOURCES in shared/routes.ts
   errorType: text("error_type"),
   message: text("message").notNull(),


### PR DESCRIPTION
## Summary

Reverts #461 to bring back the admin **Event Log** feature (the "admin panel menu entry" that disappeared), then removes `ErrorLogger.warning()` entirely so the Browserless infra-noise that motivated #461 never reaches the Event Log in the first place. Former warning call sites now emit via `console.warn` (stdout only), while error- and info-level entries continue to flow through `ErrorLogger` into the admin UI.

The revert replays #461's CodeRabbit URL-redaction hardening on top, consolidates `safeHostname` into `server/utils/urlUtils.ts`, and picks up additional hardening identified during the review pipeline (stdout throttling, admin badge/filter parity, console-bypass redaction).

## Changes

### Event Log restored (revert of #461 — `b36aecf`)
- `/admin/errors` page, `/api/admin/error-logs*` endpoints (count / list / batch-delete / restore / finalize)
- `DashboardNav` badge for Power tier showing unresolved error+info count
- `ErrorLogger` service, `error_logs` table, `ensureErrorLogColumns` bootstrap, partial unique dedup index
- "Admin event log" bullet restored in `Pricing.tsx` and `UpgradeDialog.tsx`

### Warning-level removed (`3541155`, `c7bb327`)
- `ErrorLogger.warning()` method deleted; `LogLevel = "error" | "info"`
- Every prior call site converted to `console.warn(`[source] message`, context)` — stdout only, no DB write
- Regression guards in `logger.test.ts` assert `ErrorLogger.warning` is undefined and `info` routes to `console.log`
- 12 dead `warning: vi.fn()` mocks removed from route test files

### Security hardening (`9491536`, `efcd314`)
- `url: monitor.url` → `hostname: safeHostname(monitor.url)` at every log site on this branch (scraper / scheduler / email). Monitor URLs can carry `https://user:pw@host` or `?api_key=…` secrets that the DSN/Bearer/provider-key regex list does not catch.
- Dropped `rawBrowserlessMsg` from the site-specific Browserless console.warn (upstream errors can echo back the requested URL)
- Narrowed API `level` allowlist + batch-delete Zod enum to `["error", "info"]`; removed the "Warnings" dropdown option in `AdminErrors.tsx`
- `resendTracker` direct `level: "warning"` inserts converted to `ErrorLogger.info` (preserves admin visibility + dedup upsert)
- `safeHostname` consolidated into `server/utils/urlUtils.ts`; `scraper.ts`, `scheduler.ts`, `email.ts`, `routes.ts`, `routes/extension.ts`, `routes/v1.ts` all import from the shared helper

### Skeptic-phase fixes (`e48eb4a`, `2b757b6`)
- `browserlessTracker.ts:111` direct insert → `ErrorLogger.info` (would otherwise throw `duplicate key` on partial index after 6h cooldown, silently swallowing threshold alerts)
- Transient-save `console.warn` no longer includes `extractedValue` / `previousValue` (user-scraped page content — can carry API tokens, PII, internal URLs). Non-transient `ErrorLogger.error` path keeps them because it runs `sanitizeContext`.
- Outer-catch transient `console.warn` no longer interpolates raw `error.message` (undici/fetch errors echo full URL with credentials)
- Count endpoint (`/api/admin/error-logs/count`) narrowed to `inArray(level, ["error","info"])` so the badge matches what the filter dropdown can show
- Module-level 60s throttle around Browserless-unavailable and circuit-breaker-open `console.warn` sites to prevent stdout flood during infra outages
- `safeHostname` parse-failure fallback changed from literal `"unknown"` → `"<invalid-url>"` so triage can distinguish a malformed URL from a real host named `unknown`

## How to test

1. **Admin Event Log visibility**: Sign in as a Power-tier user. Confirm the nav shows **Campaigns + Event Log** (with unresolved-count badge). Navigate to `/admin/errors` — the filter dropdown should offer `All levels / Errors / Info` only (no "Warnings" option).
2. **Warning silencing**: Trigger a Browserless infrastructure outage (mock: set `BROWSERLESS_TOKEN=bad` and run a monitor check). Observe stdout: expect `[scraper] Browserless service unavailable …` lines but *at most one per 60s per replica*. Confirm no new rows land in `error_logs` under `source='scraper', level='warning'`.
3. **URL redaction**: Create a monitor with `url = "https://example.com?api_key=SECRET123"`. Force a scheduled-check failure. Confirm `error_logs.context` shows `hostname: "example.com"` (not the raw URL) and that `SECRET123` does not appear in Replit logs or in the Event Log UI.
4. **Resend threshold alerts**: Mock Resend usage at 95%. Confirm a single `level='info', source='resend', message='resend_alert_95'` row lands in `error_logs` (not `level='warning'`); subsequent checks within 6h don't duplicate it.
5. **Admin batch-delete undo**: Batch-delete a handful of error rows, click Undo within 5s. Confirm the rows are restored. Repeat without clicking Undo and confirm they're finalized after 5s.
6. **Regression tests**: `npm run check && npm run test` — expect 2475 passing across 100 files.

## Deploy runbook

Legacy `level='warning'` rows from pre-deprecation writes (especially `source='resend', message='resend_alert_*'`) remain in the DB and render under the "All levels" filter with a yellow icon. They coexist with new `level='info'` rows for the same alert key (different partial-index dedup buckets). Optional one-shot cleanup to avoid apparent duplicate rows in the admin UI:

```sql
UPDATE error_logs SET resolved = true, resolved_at = NOW(), resolved_by = 'deploy-cleanup'
WHERE level = 'warning' AND resolved = false AND source IN ('resend', 'browserless');
```

## Out-of-scope follow-ups

Filed during Phase 6 bug triage — not required for this PR:
- #463 top-level error handler logs unsanitized err
- #464 log-message forgery via unsanitized monitor.name
- #465 admin endpoints 500-row JS filter + no rate limit
- #466 errorLogs.level no DB CHECK constraint
- #467 ErrorLogger console output bypasses sanitization
- #468 restore/finalize `asc(id).limit(500)` global scan can skip caller's rows

## Pipeline

`/magicwand` executed clean: 1 critical + 3 high + 3 medium + 2 low findings fixed in-branch (15 resolved issues across phases 2/3/4/5); 6 pre-existing issues filed as GitHub Issues. All 2475 tests pass; `npm run check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7kLVbbVmiJqqTqeynHFvC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Admin Error Logs page for power-tier users to view, filter, and manage application errors with batch actions and undo functionality.
  * Added Event Log navigation button displaying unresolved error count badge for power users.
  * Implemented comprehensive error logging system capturing and tracking application errors across the platform.

* **Updates**
  * Added "Admin event log" capability to the Power plan in pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->