### PR TITLE
fix: harden error-logging pipeline for #463-#468

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -360,25 +360,6 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
 
   startStripeInitWithRetry();
 
-  // Error Handler — route the unhandled error through ErrorLogger so its
-  // regex redaction (postgres DSNs, Bearer tokens, Resend/Stripe/GitHub keys)
-  // applies to the message + stack before they hit the Replit log stream.
-  // A raw `console.error(err)` here leaks any secret embedded in the stack
-  // or SDK-attached fields (e.g. a Resend HTTP response body echoed in
-  // `err.message`). See #463.
-  const { ErrorLogger: TopLevelErrorLogger } = await import("./services/logger");
-  app.use((err: any, req: any, res: any, next: any) => {
-    const status = err.status || err.statusCode || 500;
-    TopLevelErrorLogger.error(
-      "api",
-      "Unhandled error in request handler",
-      err instanceof Error ? err : new Error(String(err?.message ?? err)),
-      { path: req?.path, method: req?.method, status },
-    ).catch(() => { /* ErrorLogger already logs its own DB failures */ });
-    if (res.headersSent) return next(err);
-    return res.status(status).json({ message: "Internal Server Error" });
-  });
-
   // Setup Vite or Static Files
   if (process.env.NODE_ENV === "development") {
     const { setupVite } = await import("./vite");
@@ -386,6 +367,26 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
   } else {
     serveStatic(app);
   }
+
+  // Error Handler — must be registered AFTER all other middleware/routes so
+  // errors propagated via next(err) from route handlers, Vite's SSR
+  // middleware, and serveStatic all flow through ErrorLogger's redaction
+  // (postgres DSNs, Bearer tokens, Resend/Stripe/GitHub keys). A raw
+  // `console.error(err)` here leaks any secret embedded in the stack or
+  // SDK-attached fields (e.g. a Resend HTTP response body echoed in
+  // `err.message`). See #463. Reuses the ErrorLogger binding imported at
+  // line 313 rather than re-importing.
+  app.use((err: any, req: any, res: any, next: any) => {
+    const status = err.status || err.statusCode || 500;
+    ErrorLogger.error(
+      "api",
+      "Unhandled error in request handler",
+      err instanceof Error ? err : new Error(String(err?.message ?? err)),
+      { path: req?.path, method: req?.method, status },
+    ).catch(() => { /* ErrorLogger already logs its own DB failures */ });
+    if (res.headersSent) return next(err);
+    return res.status(status).json({ message: "Internal Server Error", code: "INTERNAL_ERROR" });
+  });
 
   // Start Server — kill any stale process on the port first (Replit restarts
   // can leave zombies when the previous process didn't exit cleanly).

--- a/server/index.ts
+++ b/server/index.ts
@@ -360,10 +360,21 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = '/nix/store';
 
   startStripeInitWithRetry();
 
-  // Error Handler
-  app.use((err: any, _req: any, res: any, next: any) => {
+  // Error Handler — route the unhandled error through ErrorLogger so its
+  // regex redaction (postgres DSNs, Bearer tokens, Resend/Stripe/GitHub keys)
+  // applies to the message + stack before they hit the Replit log stream.
+  // A raw `console.error(err)` here leaks any secret embedded in the stack
+  // or SDK-attached fields (e.g. a Resend HTTP response body echoed in
+  // `err.message`). See #463.
+  const { ErrorLogger: TopLevelErrorLogger } = await import("./services/logger");
+  app.use((err: any, req: any, res: any, next: any) => {
     const status = err.status || err.statusCode || 500;
-    console.error("Internal Server Error:", err);
+    TopLevelErrorLogger.error(
+      "api",
+      "Unhandled error in request handler",
+      err instanceof Error ? err : new Error(String(err?.message ?? err)),
+      { path: req?.path, method: req?.method, status },
+    ).catch(() => { /* ErrorLogger already logs its own DB failures */ });
     if (res.headersSent) return next(err);
     return res.status(status).json({ message: "Internal Server Error" });
   });

--- a/server/middleware/rateLimiter.ts
+++ b/server/middleware/rateLimiter.ts
@@ -119,6 +119,18 @@ export const emailUpdateRateLimiter = createTieredRateLimiter("emailUpdate", {
   message: "Too many email update attempts. Please try again later."
 });
 
+// Caps per-user request volume on the admin error-log endpoints. Each call
+// runs a 500-row SELECT + JS ownership filter (see #465); without a bucket a
+// single Power-tier account with N browser tabs amplifies the badge poller
+// into N concurrent scans every 30s. 60/min easily covers legitimate manual
+// use (multiple tabs + mutation invalidations) while keeping DB load bounded.
+export const adminErrorLogsRateLimiter = createTieredRateLimiter("adminErrorLogs", {
+  free: { max: 60, windowMs: 60 * 1000 },
+  pro: { max: 60, windowMs: 60 * 1000 },
+  power: { max: 60, windowMs: 60 * 1000 },
+  message: "Too many admin error-log requests. Please slow down."
+});
+
 export const contactFormRateLimiter = createTieredRateLimiter("contactForm", {
   free: { max: 3, windowMs: 60 * 60 * 1000 },
   pro: { max: 5, windowMs: 60 * 60 * 1000 },

--- a/server/routes.bugfixes.test.ts
+++ b/server/routes.bugfixes.test.ts
@@ -140,6 +140,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/notificationReady", () => ({

--- a/server/routes.campaignDashboard.test.ts
+++ b/server/routes.campaignDashboard.test.ts
@@ -111,6 +111,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.campaignRecover.test.ts
+++ b/server/routes.campaignRecover.test.ts
@@ -113,6 +113,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.campaignSendTest.test.ts
+++ b/server/routes.campaignSendTest.test.ts
@@ -132,6 +132,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.conditions.test.ts
+++ b/server/routes.conditions.test.ts
@@ -133,6 +133,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.deleteErrorLog.test.ts
+++ b/server/routes.deleteErrorLog.test.ts
@@ -125,6 +125,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.deleteFailedCampaign.test.ts
+++ b/server/routes.deleteFailedCampaign.test.ts
@@ -135,6 +135,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/notificationReady", () => ({

--- a/server/routes.errorLogCount.test.ts
+++ b/server/routes.errorLogCount.test.ts
@@ -109,6 +109,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.migration.test.ts
+++ b/server/routes.migration.test.ts
@@ -121,6 +121,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({
@@ -414,8 +415,9 @@ describe("error_logs dedup column migration at startup", () => {
     vi.clearAllMocks();
     const channelError = new Error("permission denied for schema public");
     // monitor health ALTERs succeed (2), pending_retry_at (1), error_logs
-    // migration succeeds (3 ALTERs + 1 pg_indexes check + 4 in-tx + 1 CREATE
-    // INDEX CONCURRENTLY = 9), api_keys succeed (2), then channel tables fail
+    // migration succeeds (3 ALTERs + 1 DO block level CHECK + 1 pg_indexes
+    // check + 4 in-tx + 1 CREATE INDEX CONCURRENTLY = 10), api_keys succeed
+    // (2), then channel tables fail
     mockDbExecute
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors health_alert_sent_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors last_healthy_at
@@ -423,6 +425,7 @@ describe("error_logs dedup column migration at startup", () => {
       .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs first_occurrence
       .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs occurrence_count
       .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs deleted_at
+      .mockResolvedValueOnce({ rows: [] }) // DO block level CHECK
       .mockResolvedValueOnce({ rows: [] }) // pg_indexes check (no existing idx)
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL lock_timeout
       .mockResolvedValueOnce({ rows: [] }) // pg_advisory_xact_lock
@@ -462,8 +465,9 @@ describe("error_logs dedup column migration at startup", () => {
     vi.clearAllMocks();
     const channelError = new Error("connection timeout");
     // monitor health ALTERs succeed (2), pending_retry_at (1), error_logs
-    // migration succeeds (3 ALTERs + 1 pg_indexes check + 4 in-tx + 1 CREATE
-    // INDEX CONCURRENTLY = 9), api_keys succeed (2), channel tables fail
+    // migration succeeds (3 ALTERs + 1 DO block level CHECK + 1 pg_indexes
+    // check + 4 in-tx + 1 CREATE INDEX CONCURRENTLY = 10), api_keys succeed
+    // (2), channel tables fail
     mockDbExecute
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors health_alert_sent_at
       .mockResolvedValueOnce({ rows: [] }) // ALTER monitors last_healthy_at
@@ -471,6 +475,7 @@ describe("error_logs dedup column migration at startup", () => {
       .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs first_occurrence
       .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs occurrence_count
       .mockResolvedValueOnce({ rows: [] }) // ALTER error_logs deleted_at
+      .mockResolvedValueOnce({ rows: [] }) // DO block level CHECK
       .mockResolvedValueOnce({ rows: [] }) // pg_indexes check (no existing idx)
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL lock_timeout
       .mockResolvedValueOnce({ rows: [] }) // pg_advisory_xact_lock

--- a/server/routes.notificationChannels.test.ts
+++ b/server/routes.notificationChannels.test.ts
@@ -136,6 +136,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.notificationPreferences.test.ts
+++ b/server/routes.notificationPreferences.test.ts
@@ -97,6 +97,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.tags.test.ts
+++ b/server/routes.tags.test.ts
@@ -131,6 +131,7 @@ vi.mock("./middleware/rateLimiter", () => ({
   emailUpdateRateLimiter: (_req: any, _res: any, next: any) => next(),
   contactFormRateLimiter: (_req: any, _res: any, next: any) => next(),
   unauthenticatedRateLimiter: (_req: any, _res: any, next: any) => next(),
+  adminErrorLogsRateLimiter: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock("./services/scheduler", () => ({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1686,7 +1686,11 @@ export async function registerRoutes(
           conditions.push(notInArray(errorLogs.id, excludeList));
         }
 
-        const entries = await db.select().from(errorLogs).where(and(...conditions)).orderBy(asc(errorLogs.id)).limit(500);
+        // Newest-first matches the list view (`GET /api/admin/error-logs`
+        // orderBy `desc(timestamp)`) and the restore/finalize endpoints so
+        // "delete filtered" drains the rows the admin is actually looking at
+        // instead of starving on the oldest 500 matching rows.
+        const entries = await db.select().from(errorLogs).where(and(...conditions)).orderBy(desc(errorLogs.timestamp), desc(errorLogs.id)).limit(500);
 
         const authorized = entries.filter((log: any) => {
           const ctx = log.context as Record<string, unknown> | null;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -28,7 +28,8 @@ import {
   suggestSelectorsRateLimiter,
   emailUpdateRateLimiter,
   contactFormRateLimiter,
-  unauthenticatedRateLimiter
+  unauthenticatedRateLimiter,
+  adminErrorLogsRateLimiter
 } from "./middleware/rateLimiter";
 import { generateWebhookSecret, redactSecret } from "./services/webhookDelivery";
 import { listChannels as listSlackChannels } from "./services/slackDelivery";
@@ -1482,7 +1483,7 @@ export async function registerRoutes(
   // Lightweight count endpoint for notification badge.
   // Returns { count: 0 } instead of { message, code } on auth errors so the
   // client badge can consume every response shape uniformly without error handling.
-  app.get("/api/admin/error-logs/count", isAuthenticated, async (req: any, res) => {
+  app.get("/api/admin/error-logs/count", isAuthenticated, adminErrorLogsRateLimiter, async (req: any, res) => {
     try {
       const userId = req.user?.claims?.sub;
       if (!userId) {
@@ -1525,7 +1526,7 @@ export async function registerRoutes(
     }
   });
 
-  app.get("/api/admin/error-logs", isAuthenticated, async (req: any, res) => {
+  app.get("/api/admin/error-logs", isAuthenticated, adminErrorLogsRateLimiter, async (req: any, res) => {
     try {
       const userId = req.user?.claims?.sub;
       if (!userId) {
@@ -1614,7 +1615,7 @@ export async function registerRoutes(
   });
 
   // Batch soft-delete error log entries
-  app.post("/api/admin/error-logs/batch-delete", isAuthenticated, async (req: any, res) => {
+  app.post("/api/admin/error-logs/batch-delete", isAuthenticated, adminErrorLogsRateLimiter, async (req: any, res) => {
     try {
       const userId = req.user?.claims?.sub;
       if (!userId) {
@@ -1708,7 +1709,7 @@ export async function registerRoutes(
   });
 
   // Restore soft-deleted error log entries (undo)
-  app.post("/api/admin/error-logs/restore", isAuthenticated, async (req: any, res) => {
+  app.post("/api/admin/error-logs/restore", isAuthenticated, adminErrorLogsRateLimiter, async (req: any, res) => {
     try {
       const userId = req.user?.claims?.sub;
       if (!userId) {
@@ -1724,7 +1725,13 @@ export async function registerRoutes(
         (await storage.getMonitors(userId)).map((m: any) => m.id)
       );
 
-      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).orderBy(asc(errorLogs.id)).limit(500);
+      // Order by most-recently-soft-deleted so the user's just-deleted rows
+      // (which they're trying to undo) fall inside the 500-row window even
+      // when the table has accumulated older soft-deletes from another admin
+      // between the 60s safety-net cleanup cycles. The old `asc(id)` scan
+      // picked oldest rows first and silently returned count=0 to the user
+      // when their own rows lived past the window. See #468.
+      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).orderBy(desc(errorLogs.deletedAt), desc(errorLogs.id)).limit(500);
 
       const authorized = softDeleted.filter((log: any) => {
         const ctx = log.context as Record<string, unknown> | null;
@@ -1746,7 +1753,7 @@ export async function registerRoutes(
   });
 
   // Finalize soft-deleted error log entries (hard-delete)
-  app.post("/api/admin/error-logs/finalize", isAuthenticated, async (req: any, res) => {
+  app.post("/api/admin/error-logs/finalize", isAuthenticated, adminErrorLogsRateLimiter, async (req: any, res) => {
     try {
       const userId = req.user?.claims?.sub;
       if (!userId) {
@@ -1762,7 +1769,11 @@ export async function registerRoutes(
         (await storage.getMonitors(userId)).map((m: any) => m.id)
       );
 
-      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).orderBy(asc(errorLogs.id)).limit(500);
+      // Most-recently-soft-deleted first — symmetric with the restore endpoint
+      // above so the user's count reflects their just-deleted rows instead of
+      // returning 0 because older soft-deletes from another admin dominate
+      // the 500-row window. See #468.
+      const softDeleted = await db.select().from(errorLogs).where(isNotNull(errorLogs.deletedAt)).orderBy(desc(errorLogs.deletedAt), desc(errorLogs.id)).limit(500);
 
       const authorized = softDeleted.filter((log: any) => {
         const ctx = log.context as Record<string, unknown> | null;

--- a/server/services/ensureTables.test.ts
+++ b/server/services/ensureTables.test.ts
@@ -77,14 +77,16 @@ describe("ensureErrorLogColumns", () => {
     // Default empty rows → no existing valid index, proceed to dedup + create.
     mockExecute.mockResolvedValue({ rows: [] });
     await ensureErrorLogColumns();
-    // 3 ALTER TABLE + 1 pg_indexes check + 4 in-tx (SET LOCAL, advisory
-    // lock, UPDATE, DELETE) + 1 CREATE UNIQUE INDEX CONCURRENTLY = 9
-    expect(mockExecute).toHaveBeenCalledTimes(9);
+    // 3 ALTER TABLE + 1 DO block (level CHECK) + 1 pg_indexes check + 4 in-tx
+    // (SET LOCAL, advisory lock, UPDATE, DELETE) + 1 CREATE UNIQUE INDEX
+    // CONCURRENTLY = 10
+    expect(mockExecute).toHaveBeenCalledTimes(10);
     const stmts = mockExecute.mock.calls.map(([arg]: any) => {
       try { return JSON.stringify(arg); } catch { return String(arg); }
     });
     expect(stmts.some((s: string) => s.includes("first_occurrence"))).toBe(true);
     expect(stmts.some((s: string) => s.includes("occurrence_count"))).toBe(true);
+    expect(stmts.some((s: string) => s.includes("error_logs_level_chk"))).toBe(true);
     expect(stmts.some((s: string) => s.includes("pg_indexes"))).toBe(true);
     expect(stmts.some((s: string) => s.includes("pg_advisory_xact_lock"))).toBe(true);
     expect(stmts.some((s: string) => s.includes("CREATE UNIQUE INDEX") && s.includes("CONCURRENTLY") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);
@@ -98,13 +100,14 @@ describe("ensureErrorLogColumns", () => {
       .mockResolvedValueOnce({ rows: [] }) // ALTER first_occurrence
       .mockResolvedValueOnce({ rows: [] }) // ALTER occurrence_count
       .mockResolvedValueOnce({ rows: [] }) // ALTER deleted_at
+      .mockResolvedValueOnce({ rows: [] }) // DO block level CHECK
       .mockResolvedValueOnce({ rows: [{
         indisvalid: true,
         indisunique: true,
         indexdef: "CREATE UNIQUE INDEX error_logs_unresolved_dedup_idx ON public.error_logs USING btree (level, source, message) WHERE (resolved = false)",
       }] });
     await ensureErrorLogColumns();
-    expect(mockExecute).toHaveBeenCalledTimes(4); // ALTERs + pg_indexes only
+    expect(mockExecute).toHaveBeenCalledTimes(5); // ALTERs + CHECK DO block + pg_indexes only
   });
 
   it("drops and rebuilds when existing index is INVALID", async () => {
@@ -113,6 +116,7 @@ describe("ensureErrorLogColumns", () => {
       .mockResolvedValueOnce({ rows: [] }) // ALTER first_occurrence
       .mockResolvedValueOnce({ rows: [] }) // ALTER occurrence_count
       .mockResolvedValueOnce({ rows: [] }) // ALTER deleted_at
+      .mockResolvedValueOnce({ rows: [] }) // DO block level CHECK
       .mockResolvedValueOnce({ rows: [{
         indisvalid: false,
         indisunique: true,
@@ -135,6 +139,7 @@ describe("ensureErrorLogColumns", () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] }) // DO block level CHECK
       .mockResolvedValueOnce({ rows: [{
         indisvalid: true,
         indisunique: false, // ← the drift we're guarding against
@@ -155,6 +160,7 @@ describe("ensureErrorLogColumns", () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] }) // DO block level CHECK
       .mockResolvedValueOnce({ rows: [{
         indisvalid: true,
         indisunique: true,

--- a/server/services/ensureTables.test.ts
+++ b/server/services/ensureTables.test.ts
@@ -86,7 +86,14 @@ describe("ensureErrorLogColumns", () => {
     });
     expect(stmts.some((s: string) => s.includes("first_occurrence"))).toBe(true);
     expect(stmts.some((s: string) => s.includes("occurrence_count"))).toBe(true);
-    expect(stmts.some((s: string) => s.includes("error_logs_level_chk"))).toBe(true);
+    // Lock in the exact allowed-values tuple so an accidental widening or
+    // narrowing of the level set is caught at CI rather than at runtime.
+    expect(stmts.some((s: string) =>
+      s.includes("error_logs_level_chk") &&
+      s.includes("'error'") &&
+      s.includes("'info'") &&
+      s.includes("'warning'")
+    )).toBe(true);
     expect(stmts.some((s: string) => s.includes("pg_indexes"))).toBe(true);
     expect(stmts.some((s: string) => s.includes("pg_advisory_xact_lock"))).toBe(true);
     expect(stmts.some((s: string) => s.includes("CREATE UNIQUE INDEX") && s.includes("CONCURRENTLY") && s.includes("error_logs_unresolved_dedup_idx"))).toBe(true);

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -33,6 +33,33 @@ export async function ensureErrorLogColumns(): Promise<void> {
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS occurrence_count INTEGER NOT NULL DEFAULT 1`);
     await db.execute(sql`ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP`);
 
+    // Enforce the level enum at the DB layer so a direct SQL INSERT or a
+    // caller that bypasses the TypeScript union (e.g. `db.execute(sql\`INSERT
+    // INTO error_logs (level, …) VALUES ('Error', …)\`)`) cannot land a
+    // misspelled/miscased level in the table. The admin UI's levelConfig
+    // (`client/src/pages/AdminErrors.tsx`) only indexes `error|warning|info`,
+    // so an unknown level silently falls back to the info badge. Keep
+    // `'warning'` allowed until the historical warning rows are purged — new
+    // writes only use `error|info`. See #466.
+    await db.execute(sql`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'error_logs_level_chk'
+            AND conrelid = 'error_logs'::regclass
+        ) THEN
+          BEGIN
+            ALTER TABLE error_logs
+              ADD CONSTRAINT error_logs_level_chk
+              CHECK (level IN ('error', 'info', 'warning'));
+          EXCEPTION WHEN check_violation THEN
+            RAISE WARNING 'error_logs_level_chk not added: existing rows have levels outside (error, info, warning)';
+          END;
+        END IF;
+      END$$;
+    `);
+
     // Check if a VALID, UNIQUE, correctly-shaped index already exists — skip
     // DDL entirely if so. Validates four invariants simultaneously:
     //   1. `indisvalid` — not a leftover INVALID build

--- a/server/services/ensureTables.ts
+++ b/server/services/ensureTables.ts
@@ -41,6 +41,11 @@ export async function ensureErrorLogColumns(): Promise<void> {
     // so an unknown level silently falls back to the info badge. Keep
     // `'warning'` allowed until the historical warning rows are purged — new
     // writes only use `error|info`. See #466.
+    //
+    // Catches `duplicate_object` too so concurrent boots in a rolling deploy
+    // don't race past the `IF NOT EXISTS` probe and abort the function with
+    // SQLSTATE 42710 — if another instance wins the ALTER we treat it as a
+    // no-op and fall through to the index-build steps below.
     await db.execute(sql`
       DO $$
       BEGIN
@@ -53,8 +58,11 @@ export async function ensureErrorLogColumns(): Promise<void> {
             ALTER TABLE error_logs
               ADD CONSTRAINT error_logs_level_chk
               CHECK (level IN ('error', 'info', 'warning'));
-          EXCEPTION WHEN check_violation THEN
-            RAISE WARNING 'error_logs_level_chk not added: existing rows have levels outside (error, info, warning)';
+          EXCEPTION
+            WHEN check_violation THEN
+              RAISE WARNING 'error_logs_level_chk not added: existing rows have levels outside (error, info, warning)';
+            WHEN duplicate_object THEN
+              NULL;
           END;
         END IF;
       END$$;

--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -26,13 +26,21 @@ const SENSITIVE_VALUE_PATTERNS = [
   /\b[A-Za-z0-9+/]{40,}={0,2}\b/g,
 ];
 
-// Strip C0 controls (except \t which we normalize to a space) and C1 controls
-// so an attacker who embeds `\n[ERROR][scheduler]` in a user-controlled field
-// like `monitor.name` cannot forge fake log rows or poison the
-// (level, source, message) dedup bucket by splitting the line. See #464.
+// Strip C0/C1 controls, Unicode line/paragraph separators (U+2028/U+2029),
+// and BiDi overrides (U+202A-U+202E, U+2066-U+2069). The line-separator and
+// BiDi points are not line terminators to Node's `console` but DO split lines
+// in most terminal emulators (including Replit's) and downstream log
+// aggregators, so an attacker who embeds `\n[ERROR][scheduler]` or U+2028 in
+// a user-controlled field like `monitor.name` cannot forge fake log rows or
+// poison the (level, source, message) dedup bucket. Tabs are normalized to a
+// space separately. See #464.
 function stripControlChars(str: string): string {
   // eslint-disable-next-line no-control-regex
-  return str.replace(/[\x00-\x08\x0A-\x1F\x7F-\x9F]/g, " ").replace(/\t/g, " ");
+  return str
+    .replace(/[\x00-\x08\x0A-\x1F\x7F-\x9F]/g, " ")
+    .replace(/[\u2028\u2029]/g, " ")
+    .replace(/[\u202A-\u202E\u2066-\u2069]/g, "")
+    .replace(/\t/g, " ");
 }
 
 function sanitizeString(str: string): string {
@@ -74,7 +82,9 @@ export class ErrorLogger {
     // Sanitize before any console output so secrets embedded in the message
     // or the raw SDK error.message (e.g. `Authorization: Bearer re_…` echoed
     // in a Resend/Stripe HTTP response body) do not leak to the Replit log
-    // stream. Matches the DB-write sanitization below. See #467.
+    // stream. Matches the DB-write sanitization below. `sanitizedStack` is
+    // intentionally NOT emitted to the console — stacks pollute Replit logs
+    // and the DB copy is enough for admin triage. See #467.
     const sanitizedMessage = sanitizeString(message);
     const sanitizedStack = error?.stack ? sanitizeString(error.stack) : null;
     const sanitizedContext = context ? sanitizeContext(context) : null;
@@ -82,7 +92,11 @@ export class ErrorLogger {
     const logMsg = `${prefix} ${sanitizedMessage}`;
 
     if (level === "error") {
-      console.error(logMsg, sanitizeString(error?.message || ""));
+      if (error?.message) {
+        console.error(logMsg, sanitizeString(error.message));
+      } else {
+        console.error(logMsg);
+      }
     } else {
       console.log(logMsg);
     }

--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -26,8 +26,17 @@ const SENSITIVE_VALUE_PATTERNS = [
   /\b[A-Za-z0-9+/]{40,}={0,2}\b/g,
 ];
 
+// Strip C0 controls (except \t which we normalize to a space) and C1 controls
+// so an attacker who embeds `\n[ERROR][scheduler]` in a user-controlled field
+// like `monitor.name` cannot forge fake log rows or poison the
+// (level, source, message) dedup bucket by splitting the line. See #464.
+function stripControlChars(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/[\x00-\x08\x0A-\x1F\x7F-\x9F]/g, " ").replace(/\t/g, " ");
+}
+
 function sanitizeString(str: string): string {
-  let result = str;
+  let result = stripControlChars(str);
   for (const pattern of SENSITIVE_VALUE_PATTERNS) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, "[REDACTED]");
@@ -61,18 +70,22 @@ export class ErrorLogger {
     context?: Record<string, any> | null
   ): Promise<void> {
     const prefix = `[${level.toUpperCase()}][${source}]`;
-    const logMsg = `${prefix} ${message}`;
 
-    if (level === "error") {
-      console.error(logMsg, error?.message || "");
-    } else {
-      console.log(logMsg);
-    }
-
+    // Sanitize before any console output so secrets embedded in the message
+    // or the raw SDK error.message (e.g. `Authorization: Bearer re_…` echoed
+    // in a Resend/Stripe HTTP response body) do not leak to the Replit log
+    // stream. Matches the DB-write sanitization below. See #467.
     const sanitizedMessage = sanitizeString(message);
     const sanitizedStack = error?.stack ? sanitizeString(error.stack) : null;
     const sanitizedContext = context ? sanitizeContext(context) : null;
     const errorType = error?.constructor?.name || null;
+    const logMsg = `${prefix} ${sanitizedMessage}`;
+
+    if (level === "error") {
+      console.error(logMsg, sanitizeString(error?.message || ""));
+    } else {
+      console.log(logMsg);
+    }
 
     try {
       // Atomic upsert against the partial unique index


### PR DESCRIPTION
## Summary

Closes six open bugs clustered around the admin error-logging subsystem (#463, #464, #465, #466, #467, #468). The changes redact secrets before they reach Replit logs, prevent attacker-controlled log-row forgery, enforce the `level` enum at the DB layer, fix the restore/finalize window-starvation bug, and cap per-user request volume on admin error-log endpoints.

## Changes

**Secret redaction (`server/services/logger.ts`, `server/index.ts`)**
- `ErrorLogger.log` now sanitizes `message` and `error.message` **before** writing to `console.error`/`console.log`, matching what was already done for the DB write. Fixes #467.
- `sanitizeString` additionally strips C0/C1 control characters so an attacker-controlled field like `monitor.name` cannot embed `\n[ERROR][scheduler] …` lines and poison the `(level, source, message)` dedup bucket. Fixes #464.
- The top-level Express error handler now routes through `ErrorLogger.error("api", …)` instead of raw `console.error(err)`, so postgres DSNs, `Bearer …` tokens, Resend/Stripe/GitHub keys and long base64 blobs in stack traces or SDK-attached fields are redacted before hitting the Replit log stream. Fixes #463.

**DB-level `level` enum (`server/services/ensureTables.ts` + test)**
- Adds an idempotent `error_logs_level_chk` CHECK constraint (`level IN ('error','info','warning')`) inside `ensureErrorLogColumns` so a direct SQL insert (`INSERT … VALUES ('Error', …)`) can no longer land a miscased/typoed level. Historical `'warning'` rows remain valid. Fixes #466.
- Constraint add is wrapped in `DO … EXCEPTION WHEN check_violation` so a database with pre-existing out-of-range rows logs a `WARNING` instead of crashing boot.

**Restore/finalize ordering (`server/routes.ts`)**
- `POST /api/admin/error-logs/restore` and `POST /api/admin/error-logs/finalize` now `ORDER BY deleted_at DESC, id DESC` so the caller's just-soft-deleted rows fall inside the 500-row window. The old `ORDER BY id ASC` starved the user when another admin's older soft-deletes dominated the window, returning `count: 0` and letting the 5-minute safety-net cleanup hard-delete them silently. Fixes #468.

**Per-user rate limiter (`server/middleware/rateLimiter.ts`, `server/routes.ts`)**
- Adds `adminErrorLogsRateLimiter` (60 req/min across all tiers) and applies it to the five admin error-log endpoints (`count`, list, `batch-delete`, `restore`, `finalize`). Caps the amplification when a Power-tier account opens multiple dashboard tabs — the badge poller no longer fans out into N concurrent 500-row scans every 30 s. This is the short-term option called out in #465.

**Test updates**
- Added `adminErrorLogsRateLimiter: (_req, _res, next) => next()` to every test that mocks `./middleware/rateLimiter` (11 files).
- Bumped `ensureErrorLogColumns` execute-count assertions from 9 → 10 and 4 → 5 to account for the new `DO` block; inserted the extra `mockResolvedValueOnce({ rows: [] })` in the fast-path + drift-detection tests and in `routes.migration.test.ts` fallback sequences.

## How to test

- `npm run check` — type checks clean (tsc, no errors).
- `npm run test` — all 2480 tests pass (101 files).
- `npm run build` — production bundle succeeds (pre-existing `import.meta` warnings unchanged).

Manual:
1. Trigger a Resend or Stripe SDK failure whose raw `error.message` contains `Authorization: Bearer re_…`. Confirm the Replit log line shows `[REDACTED]` and the `error_logs` row stores the same redacted string (#467).
2. Create a monitor named `"Real\n[ERROR][scheduler] fake"` and force a scheduler failure for it. Confirm the stored `message` contains a space where the newline was (dedup bucket is not forged) (#464).
3. In psql, run `INSERT INTO error_logs (level, source, message) VALUES ('Error', 'scraper', 'test');` — the CHECK constraint should reject it (#466).
4. As admin A, batch-delete 600 rows; as admin B, batch-delete 200 rows; click Undo within 5 s as B. Confirm B's rows are restored (they are the most-recently-deleted, so `ORDER BY deleted_at DESC` finds them) (#468).
5. Open `/admin-errors` in 10 tabs simultaneously as a Power user. Confirm the 11th poll in a 60 s window returns 429 (#465).
6. Force an unhandled exception in any route (e.g. temporarily throw `new Error(\"postgres://user:pw@host/db\")` from a handler). Confirm the Replit log line shows `[REDACTED]` rather than the DSN (#463).

https://claude.ai/code/session_017VHC5MqCX5EtZnGC4Mqn5U

---
_Generated by [Claude Code](https://claude.ai/code/session_017VHC5MqCX5EtZnGC4Mqn5U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting implemented on admin error-log management endpoints to prevent excessive usage
  * Soft-deleted error logs now display in reverse chronological order, showing most recent deletions first

* **Improvements**
  * Error messages now sanitized for console output to eliminate control character artifacts
  * Database-level validation constraints applied to error log fields for improved data consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->